### PR TITLE
Handle directory open failure in DirectoryIterator

### DIFF
--- a/edit/index.php
+++ b/edit/index.php
@@ -189,6 +189,8 @@ class Directory extends Dirent {
 }
 }
 namespace SiteEditor\Fs {
+use SiteEditor\Exception\ServerException;
+
 class DirectoryIterator implements \Iterator {
 
     private $stack = array();
@@ -207,7 +209,11 @@ class DirectoryIterator implements \Iterator {
     public function rewind() {
         if (!$this->path) return;
         $this->index = $this->cursor = 0;
-        $this->stack = array(@dir($this->path));
+        $dir = @dir($this->path);
+        if ($dir === false) {
+            throw new ServerException(sprintf('Failed to open directory: %s', $this->path));
+        }
+        $this->stack = array($dir);
         $this->next();
     }
 


### PR DESCRIPTION
## Summary
- Validate DirectoryIterator::rewind opens directories successfully and throw ServerException on failure

## Testing
- `php -l edit/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6894eb653c9883218d360fe4ab6e9024