### PR TITLE
docs: clarify JWT source and changes

### DIFF
--- a/edit/index.php
+++ b/edit/index.php
@@ -523,7 +523,8 @@ class Token {
 
     protected $payload;
 
-    // source: https://github.com/firebase/php-jwt
+    // Adapted from firebase/php-jwt (BSD-3-Clause License). Modified for
+    // RS256-only verification and custom exception handling.
     public static function from($jwt) {
         if (!defined('JWT_PUBLIC_KEY')) {
             throw new ServerException('Invalid configuration');


### PR DESCRIPTION
## Summary
- document that JWT helper is adapted from firebase/php-jwt and note license and local modifications

## Testing
- `php -l edit/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6894f4ae42388321ba28f0046c52962a