### PR TITLE
Phase 6 (partial): accessibility pass — WCAG AA across modernised pages

### DIFF
--- a/scripts/a11y_lint.py
+++ b/scripts/a11y_lint.py
@@ -1,0 +1,265 @@
+"""Static accessibility lint for the built site.
+
+Scans every HTML file in _site/ (only the modernised templates, not the
+passthrough legacy files which we accept as-is) and reports common a11y
+issues we can fix automatically:
+
+- Images missing alt attribute
+- <img>/<a>/<button> with empty content and no accessible name
+- Missing <html lang>
+- Missing <main> / <header> / <footer> / <nav> landmarks
+- Heading hierarchy gaps (h1 → h3, etc.)
+- Multiple <h1> on one page
+- Form inputs without labels
+- Links opening in new tab without rel="noopener"
+- Duplicate id attributes
+- <a href="#"> placeholders
+- Buttons styled as links / links styled as buttons (icon-only without aria-label)
+
+Usage: python3 scripts/a11y_lint.py
+"""
+
+import os
+import re
+import sys
+from html.parser import HTMLParser
+from collections import defaultdict, Counter
+
+
+# Modernised pages are those we generate from src/*.njk — they end up as
+# _site/*.html. Legacy passthroughs come from src/legacy/*.html (also at
+# _site/*.html). We discriminate by scanning the page for our new design
+# system marker class `.site-header`. Anything else is legacy and skipped.
+def is_modernised(html: str) -> bool:
+    return 'class="site-header"' in html or "class='site-header'" in html
+
+
+class A11yScan(HTMLParser):
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.issues = []
+        self.tag_stack = []
+        self.headings = []  # list of (level, text)
+        self._head_text_buf = ""
+        self._cur_heading = None
+        self.ids = []
+        self.has_main = False
+        self.has_header = False
+        self.has_footer = False
+        self.has_nav = False
+        self.html_lang = None
+        self._in_button = None  # current <button> open or None
+        self._button_text = ""
+        self._in_link = None
+        self._link_text = ""
+        self._link_attrs = None
+        self._line_no = 0
+        self.icon_anchor_count = 0
+        self.placeholder_anchors = []
+        self.images_no_alt = []
+        self.images_decorative_with_role = []
+        self.heading_gaps = []
+        self.h1_count = 0
+        self.empty_buttons = []
+        self.empty_links = []
+        self.new_tab_no_noopener = []
+        self.dup_ids = []
+        self.inputs_no_label = []  # id of input
+        self.labelled_input_ids = set()
+        self.form_inputs = []  # (id, type, has_aria_label_or_labelledby)
+
+    def handle_starttag(self, tag, attrs_list):
+        attrs = dict(attrs_list)
+        self.tag_stack.append(tag)
+
+        if tag == "html":
+            self.html_lang = attrs.get("lang")
+        elif tag == "main":
+            self.has_main = True
+        elif tag == "header" and attrs.get("class", "").find("site-header") >= 0:
+            self.has_header = True
+        elif tag == "footer":
+            self.has_footer = True
+        elif tag == "nav":
+            self.has_nav = True
+        elif tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+            level = int(tag[1])
+            self._cur_heading = (level, "")
+            if level == 1:
+                self.h1_count += 1
+        elif tag == "img":
+            alt = attrs.get("alt")
+            if alt is None:
+                self.images_no_alt.append(attrs.get("src", "?"))
+            elif alt == "" and attrs.get("role"):
+                # alt="" is fine; flag if also has role that doesn't match decorative
+                pass
+        elif tag == "a":
+            self._in_link = tag
+            self._link_text = ""
+            self._link_attrs = attrs
+            href = attrs.get("href", "")
+            if href == "#":
+                self.placeholder_anchors.append(href)
+            if attrs.get("target") == "_blank":
+                rel = attrs.get("rel", "")
+                if "noopener" not in rel:
+                    self.new_tab_no_noopener.append(href)
+        elif tag == "button":
+            self._in_button = tag
+            self._button_text = ""
+            self._button_attrs = attrs
+        elif tag == "input":
+            input_id = attrs.get("id")
+            t = attrs.get("type", "text")
+            if t in {"hidden", "submit", "button", "reset"}:
+                pass
+            else:
+                has_aria = bool(attrs.get("aria-label") or attrs.get("aria-labelledby"))
+                self.form_inputs.append((input_id, t, has_aria))
+        elif tag == "label":
+            for_id = attrs.get("for")
+            if for_id:
+                self.labelled_input_ids.add(for_id)
+
+        # IDs
+        if "id" in attrs:
+            self.ids.append(attrs["id"])
+
+    def handle_endtag(self, tag):
+        # heading text capture
+        if tag in {"h1", "h2", "h3", "h4", "h5", "h6"} and self._cur_heading:
+            self.headings.append(self._cur_heading)
+            self._cur_heading = None
+        elif tag == "button" and self._in_button:
+            text = self._button_text.strip()
+            attrs = self._button_attrs
+            if not text and not (attrs.get("aria-label") or attrs.get("aria-labelledby") or attrs.get("title")):
+                self.empty_buttons.append(attrs)
+            self._in_button = None
+        elif tag == "a" and self._in_link:
+            text = self._link_text.strip()
+            attrs = self._link_attrs
+            if not text:
+                if not (attrs.get("aria-label") or attrs.get("aria-labelledby") or attrs.get("title")):
+                    self.empty_links.append(attrs.get("href", "?"))
+            self._in_link = None
+        if self.tag_stack:
+            self.tag_stack.pop()
+
+    def handle_data(self, data):
+        if self._cur_heading:
+            self._cur_heading = (self._cur_heading[0], self._cur_heading[1] + data)
+        if self._in_button:
+            self._button_text += data
+        if self._in_link:
+            self._link_text += data
+
+    def finalize(self):
+        # heading gaps
+        last_level = 0
+        for lvl, _txt in self.headings:
+            if last_level and lvl > last_level + 1:
+                self.heading_gaps.append((last_level, lvl))
+            last_level = lvl
+
+        # duplicate ids
+        c = Counter(self.ids)
+        self.dup_ids = [i for i, n in c.items() if n > 1]
+
+        # inputs without labels
+        for inp_id, t, has_aria in self.form_inputs:
+            if has_aria:
+                continue
+            if inp_id and inp_id in self.labelled_input_ids:
+                continue
+            self.inputs_no_label.append((inp_id, t))
+
+
+def main():
+    site_dir = "_site"
+    total = 0
+    modernised = 0
+    bucketed = defaultdict(list)
+    pages_with_issues = 0
+
+    for fn in sorted(os.listdir(site_dir)):
+        if not fn.endswith(".html"):
+            continue
+        path = os.path.join(site_dir, fn)
+        html = open(path, "r", encoding="utf-8", errors="ignore").read()
+        total += 1
+        if not is_modernised(html):
+            bucketed["legacy_skipped"].append(fn)
+            continue
+        modernised += 1
+
+        scanner = A11yScan()
+        try:
+            scanner.feed(html)
+            scanner.finalize()
+        except Exception as e:
+            bucketed["parse_error"].append((fn, str(e)))
+            continue
+
+        page_issues = []
+
+        if scanner.html_lang is None:
+            page_issues.append("missing-html-lang")
+        if not scanner.has_main:
+            page_issues.append("missing-main-landmark")
+        if not scanner.has_header:
+            page_issues.append("missing-site-header")
+        if not scanner.has_footer:
+            page_issues.append("missing-footer")
+        if not scanner.has_nav:
+            page_issues.append("missing-nav")
+        if scanner.h1_count == 0:
+            page_issues.append("missing-h1")
+        elif scanner.h1_count > 1:
+            page_issues.append(f"multiple-h1 ({scanner.h1_count})")
+        if scanner.heading_gaps:
+            for prev, cur in scanner.heading_gaps:
+                page_issues.append(f"heading-gap h{prev}->h{cur}")
+        if scanner.images_no_alt:
+            page_issues.append(f"img-no-alt x{len(scanner.images_no_alt)}: {scanner.images_no_alt[:3]}")
+        if scanner.placeholder_anchors:
+            page_issues.append(f"href=# x{len(scanner.placeholder_anchors)}")
+        if scanner.empty_buttons:
+            page_issues.append(f"button-no-accessible-name x{len(scanner.empty_buttons)}")
+        if scanner.empty_links:
+            page_issues.append(f"link-no-accessible-name x{len(scanner.empty_links)}: {scanner.empty_links[:3]}")
+        if scanner.new_tab_no_noopener:
+            page_issues.append(f"target=_blank-no-rel-noopener x{len(scanner.new_tab_no_noopener)}: {scanner.new_tab_no_noopener[:3]}")
+        if scanner.dup_ids:
+            page_issues.append(f"duplicate-ids: {scanner.dup_ids[:3]}")
+        if scanner.inputs_no_label:
+            page_issues.append(f"input-no-label x{len(scanner.inputs_no_label)}: {scanner.inputs_no_label[:3]}")
+
+        if page_issues:
+            bucketed["issues"].append((fn, page_issues))
+            pages_with_issues += 1
+        else:
+            bucketed["clean"].append(fn)
+
+    print(f"\n=== Lint summary ===")
+    print(f"  Total HTML files:       {total}")
+    print(f"  Modernised (scanned):   {modernised}")
+    print(f"  Legacy (skipped):       {len(bucketed['legacy_skipped'])}")
+    print(f"  Pages with issues:      {pages_with_issues}")
+    print(f"  Pages clean:            {len(bucketed['clean'])}")
+
+    if bucketed["issues"]:
+        print(f"\n=== Issues by page ===")
+        for fn, issues in bucketed["issues"]:
+            print(f"\n  {fn}")
+            for i in issues:
+                print(f"    - {i}")
+    if bucketed["legacy_skipped"]:
+        print(f"\nLegacy passthroughs skipped:")
+        for f in bucketed["legacy_skipped"]:
+            print(f"  - {f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -12,7 +12,7 @@
       </div>
 
       <div>
-        <h3>Conferences</h3>
+        <h2>Conferences</h2>
         <ul class="footer-list">
           <li><a href="/2026.html">2026 — Stockholm</a></li>
           <li><a href="/2025.html">2025 — Thessaloniki</a></li>
@@ -22,7 +22,7 @@
       </div>
 
       <div>
-        <h3>Programmes</h3>
+        <h2>Programmes</h2>
         <ul class="footer-list">
           <li><a href="/NetSecSchool.html">NetSec Summer School</a></li>
           <li><a href="/euroswamos.html">Euro-SWAMOS</a></li>
@@ -32,7 +32,7 @@
       </div>
 
       <div>
-        <h3>About</h3>
+        <h2>About</h2>
         <ul class="footer-list">
           <li><a href="/initiative.html">The Initiative</a></li>
           <li><a href="/board.html">The People</a></li>

--- a/src/_includes/nav.njk
+++ b/src/_includes/nav.njk
@@ -1,5 +1,5 @@
-<header class="site-header" role="banner">
-  <div class="container nav">
+<header class="site-header">
+  <nav class="container nav" aria-label="Primary">
     <a class="nav-brand" href="/" aria-label="{{ site.fullName }} — home">
       <span class="nav-brand-mark" aria-hidden="true">E</span>
       <span>EISS</span>
@@ -35,5 +35,5 @@
         </svg>
       </button>
     </div>
-  </div>
+  </nav>
 </header>

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -69,8 +69,8 @@
   --border-strong: hsl(220 14% 82%);
   --border-glass: hsl(220 30% 100% / 0.6);
   --text: hsl(222 28% 12%);
-  --text-muted: hsl(222 14% 38%);
-  --text-subtle: hsl(222 10% 52%);
+  --text-muted: hsl(222 16% 34%);
+  --text-subtle: hsl(222 13% 40%);
   --accent: hsl(216 88% 50%);
   --accent-hover: hsl(216 88% 44%);
   --accent-soft: hsl(216 88% 50% / 0.1);
@@ -838,13 +838,15 @@ h4 { font-size: var(--fs-lg); }
   gap: var(--space-3);
 }
 
-.footer h3 {
+.footer h2 {
   font-size: var(--fs-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--text-subtle);
   margin-bottom: var(--space-3);
+  line-height: var(--lh-snug);
+  letter-spacing: 0.08em;
 }
 
 .footer-list {
@@ -1021,9 +1023,12 @@ h4 { font-size: var(--fs-lg); }
   font-weight: 700;
 }
 
+.tile h2,
 .tile h3 {
   font-size: var(--fs-lg);
   margin-bottom: var(--space-2);
+  line-height: var(--lh-snug);
+  letter-spacing: var(--tracking-tight);
 }
 
 .tile p {

--- a/src/events.njk
+++ b/src/events.njk
@@ -22,7 +22,7 @@ navKey: ""
     <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));">
       <article class="tile">
         <div class="tile-icon" aria-hidden="true">R</div>
-        <h3>Roundtables &amp; Conferences</h3>
+        <h2>Roundtables &amp; Conferences</h2>
         <p>
           Online and hybrid events organised by EISS members with guests from academia and/or
           the policy world to talk about critical issues in international security. EISS members
@@ -33,7 +33,7 @@ navKey: ""
 
       <article class="tile">
         <div class="tile-icon" aria-hidden="true">E</div>
-        <h3>Early Career Seminars</h3>
+        <h2>Early Career Seminars</h2>
         <p>
           Online and hybrid seminars organised by PhD students or early career academics to share
           their research and exchange ideas with the broader EISS community. PhD students or
@@ -44,7 +44,7 @@ navKey: ""
 
       <article class="tile">
         <div class="tile-icon" aria-hidden="true">D</div>
-        <h3>Doctoral Training Workshops</h3>
+        <h2>Doctoral Training Workshops</h2>
         <p>
           Online and hybrid workshops organised by members of EISS, intended and tailored for
           PhD students and early career academics. These online training workshops can revolve

--- a/src/initiative.njk
+++ b/src/initiative.njk
@@ -26,7 +26,7 @@ navKey: initiative
     <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr)); margin-block: var(--space-7);">
       <article class="tile">
         <div class="tile-icon" aria-hidden="true">N</div>
-        <h3>Creating a Network</h3>
+        <h2>Creating a Network</h2>
         <p>
           To develop and sustain a Europe-wide network in the field of security studies. This gives
           visibility to the range of individual and collective research projects that are currently
@@ -35,7 +35,7 @@ navKey: initiative
       </article>
       <article class="tile">
         <div class="tile-icon" aria-hidden="true">P</div>
-        <h3>Creating a Platform</h3>
+        <h2>Creating a Platform</h2>
         <p>
           To establish a forum for the exchange of ideas in order to foster new joint research
           projects and develop international research partnerships.

--- a/src/policy.njk
+++ b/src/policy.njk
@@ -24,7 +24,7 @@ navKey: ""
 
       <p>This Privacy Policy is in compliance with the General Data Protection Regulation (EU) 2016/679 ("GDPR") and the French Data Protection Act (Loi Informatique et Libertés).</p>
 
-      <h3>1. Controller and Data Protection Officer</h3>
+      <h2>1. Controller and Data Protection Officer</h2>
 
       <p>The controller responsible for the processing of personal data under this Privacy Policy is:</p>
 
@@ -35,7 +35,7 @@ navKey: ""
 
       <p>If you have any questions, concerns, or requests regarding your personal data, you may contact our Data Protection Officer at <a href="mailto:contact@eiss-europa.com">contact@eiss-europa.com</a>.</p>
 
-      <h3>2. Collection of Personal Data</h3>
+      <h2>2. Collection of Personal Data</h2>
 
       <p>We may collect the following personal data from you:</p>
 
@@ -45,7 +45,7 @@ navKey: ""
         <li>Technical information, such as IP address, browser type, and operating system, when you interact with our website or services.</li>
       </ul>
 
-      <h3>3. Purpose and Legal Basis for Processing</h3>
+      <h2>3. Purpose and Legal Basis for Processing</h2>
 
       <p>We process your personal data for the following purposes and based on the following legal grounds:</p>
 
@@ -55,19 +55,19 @@ navKey: ""
         <li>To pursue our legitimate interests, such as improving our website and services, and conducting research and analysis (GDPR Article 6(1)(f)).</li>
       </ul>
 
-      <h3>4. Recipients of Personal Data</h3>
+      <h2>4. Recipients of Personal Data</h2>
 
       <p>We may share your personal data with trusted third parties, such as service providers, for the purposes stated in this Privacy Policy. We ensure that these third parties adhere to GDPR and French data protection law requirements.</p>
 
-      <h3>5. International Transfers</h3>
+      <h2>5. International Transfers</h2>
 
       <p>We may transfer your personal data to countries outside the European Economic Area (EEA). In such cases, we will implement appropriate safeguards, such as standard contractual clauses approved by the European Commission, to ensure the protection of your personal data.</p>
 
-      <h3>6. Retention of Personal Data</h3>
+      <h2>6. Retention of Personal Data</h2>
 
       <p>We will retain your personal data only for as long as necessary to fulfill the purposes for which it was collected or as required by applicable laws or regulations.</p>
 
-      <h3>7. Your Rights</h3>
+      <h2>7. Your Rights</h2>
 
       <p>Under GDPR and French data protection law, you have the following rights:</p>
 
@@ -84,27 +84,27 @@ navKey: ""
 
       <p>To exercise any of your rights or if you have any questions regarding this Privacy Policy, please contact our Data Protection Officer at <a href="mailto:contact@eiss-europa.com">contact@eiss-europa.com</a>.</p>
 
-      <h3>8. Changes to This Privacy Policy</h3>
+      <h2>8. Changes to This Privacy Policy</h2>
 
       <p>We reserve the right to update or modify this Privacy Policy at any time to reflect changes in our practices or applicable laws and regulations. We will post the updated Privacy Policy on our website and notify you of any material changes. We encourage you to periodically review this Privacy Policy to stay informed about our data protection practices.</p>
 
-      <h3>9. Security Measures</h3>
+      <h2>9. Security Measures</h2>
 
       <p>We take appropriate technical and organisational measures to protect your personal data against unauthorised access, alteration, disclosure, or destruction. These measures may include, but are not limited to, access controls, encryption, secure storage, and regular security assessments.</p>
 
-      <h3>10. Links to Third-Party Websites</h3>
+      <h2>10. Links to Third-Party Websites</h2>
 
       <p>Our website may contain links to external websites operated by third parties. This Privacy Policy does not apply to these external websites, and we are not responsible for their content or privacy practices. We encourage you to review the privacy policies of these third-party websites before disclosing any personal data.</p>
 
-      <h3>11. Cookies</h3>
+      <h2>11. Cookies</h2>
 
       <p>Our website uses cookies to enhance your browsing experience and collect information about your use of the website. Cookies are small text files that a website stores on your device. You may adjust your browser settings to block or delete cookies, but this may affect the functionality of our website.</p>
 
-      <h3>12. Children's Privacy</h3>
+      <h2>12. Children's Privacy</h2>
 
       <p>Our services are not directed at individuals under the age of 16, and we do not knowingly collect personal data from children under 16. If we become aware that we have collected personal data from a child under the age of 16, we will take appropriate steps to delete such data.</p>
 
-      <h3>13. Contact Information</h3>
+      <h2>13. Contact Information</h2>
 
       <p>If you have any questions, concerns, or requests regarding this Privacy Policy or your personal data, please contact our Data Protection Officer at:</p>
 

--- a/src/programmes.njk
+++ b/src/programmes.njk
@@ -24,7 +24,7 @@ navKey: programmes
 
       <article class="tile">
         <div class="featured-eyebrow" style="margin-bottom: var(--space-3);">COST Action · 2025 — 2029</div>
-        <h3>NetSec — Networking European Security Knowledge</h3>
+        <h2>NetSec — Networking European Security Knowledge</h2>
         <p>
           A four-year COST Action that EISS launched together with a dozen institutions across
           Europe to address the fragmentation of the continent’s intellectual and analytical base
@@ -39,7 +39,7 @@ navKey: programmes
 
       <article class="tile">
         <div class="featured-eyebrow" style="margin-bottom: var(--space-3);">Annual summer school</div>
-        <h3>NetSec Early-Career Scholars Summer School</h3>
+        <h2>NetSec Early-Career Scholars Summer School</h2>
         <p>
           A residential summer school for PhD students and early-career researchers working at the
           intersection of security studies, strategic studies, and international relations.
@@ -51,7 +51,7 @@ navKey: programmes
 
       <article class="tile">
         <div class="featured-eyebrow" style="margin-bottom: var(--space-3);">Multidisciplinary programme</div>
-        <h3>Coercive Statecraft</h3>
+        <h2>Coercive Statecraft</h2>
         <p>
           A research programme on the use of coercive instruments — sanctions, threats, hybrid
           measures — in contemporary statecraft, gathering scholars and practitioners.
@@ -63,7 +63,7 @@ navKey: programmes
 
       <article class="tile">
         <div class="featured-eyebrow" style="margin-bottom: var(--space-3);">Joint summer school</div>
-        <h3>Euro-SWAMOS</h3>
+        <h2>Euro-SWAMOS</h2>
         <p>
           The European Summer Workshop on the Analysis of Military Operations and Strategy — a
           partnership programme bringing together advanced students of strategy.
@@ -75,7 +75,7 @@ navKey: programmes
 
       <article class="tile">
         <div class="featured-eyebrow" style="margin-bottom: var(--space-3);">Survey · Results</div>
-        <h3>Global Risks to the EU</h3>
+        <h2>Global Risks to the EU</h2>
         <p>
           A periodic expert survey on the global risks European security analysts consider most
           consequential for the EU — and the responses they recommend.


### PR DESCRIPTION
## Summary

Two automated audits drove this pass:

1. **Static a11y lint** — new [scripts/a11y_lint.py](scripts/a11y_lint.py) walks every built HTML file and checks for missing landmarks, alt-less images, heading-hierarchy gaps, duplicate IDs, accessible-name absence on buttons/links, `target=_blank` without `rel=noopener`, and a few other common WCAG issues. The 5 legacy `ticket-*` pages are intentionally skipped (still on passthrough).
2. **axe-core 4.10.2** running in the preview browser against 7 representative pages × 2 colour modes = 14 scans: home, `/2026.html`, `/board.html`, `/NetSecSchool.html`, `/policy.html`, `/page9.html`, `/membership.html` in both light and dark.

### Before

- Static lint: **19 pages with issues** out of 39 modernised
- axe-core: **8 contrast violations per page**, ratio 3.96:1

### After

- Static lint: **0 pages with issues**, 39 clean
- axe-core: **0 violations** across all 14 scans

## What changed

### 1. Nav landmark

The primary nav was a styled `<div class="nav">` inside `<header role="banner">` — the `<nav>` element itself was missing, so every modernised page failed the WCAG "navigation landmark" check.

Replaced with `<nav class="container nav" aria-label="Primary">`. Dropped the now-redundant `role="banner"` since `<header>` children of `<body>` get the banner role implicitly.

### 2. Heading hierarchy — three patterns, three fixes

| Pattern | Where | Fix |
| ------- | ----- | --- |
| Footer column titles were `<h3>` | `_includes/footer.njk` "Conferences / Programmes / About" | Promote to `<h2>`; CSS that was on `.footer h3` is now on `.footer h2` |
| Tile-grid was first content block, with `.tile h3` immediately after `<h1>` | `events.njk`, `initiative.njk`, `programmes.njk` | Promote those tiles' `<h3>` to `<h2>`; added `.tile h2` to CSS to match existing `.tile h3` visual size |
| 13 numbered policy sections were `<h3>` | `policy.njk` "1. Controller", "2. Collection", … | Promote all 13 to `<h2>` — they are top-level sections of the policy |

### 3. Colour contrast

axe surfaced one issue firing in 8 places per page: `--text-subtle` was `hsl(222 10% 52%)` = `#788091`, giving 3.96:1 against the white footer background — just below the 4.5:1 AA threshold for normal text. Affected the footer description, the three column titles, the fine-print paragraphs (©, image credits, charity registration), and the NetSec figure caption on the home page.

| Token | Before | After | Δ |
| ----- | ------ | ----- | - |
| `--text-subtle` | `hsl(222 10% 52%)` (3.96:1) | `hsl(222 13% 40%)` (6.14:1) | ✅ |
| `--text-muted` | `hsl(222 14% 38%)` | `hsl(222 16% 34%)` | extra headroom on tinted backgrounds |

**Dark-mode tokens unchanged** — they already passed both audits.

## Visual

Footer screenshot post-change confirms the text now reads crisp without becoming jet-black — still a clean muted tone, just darker enough to clear AA.

## What's still left in phase 6 (deferred per your earlier instruction)

- Re-link the `*-meta.jpg` Open Graph cards from each page's frontmatter (orphaned, currently no preview image for shared links)
- Case-by-case decisions on the remaining ~115 unreferenced historical images
- Lighthouse score capture (CLS, LCP, perf)
- Bump GH Actions to v5 once Node-24 releases land
- Switch CI back to `npm ci` + cache now that `package-lock.json` exists
- README final pass
- Remove `project.mobirise.archived` (preserved in git history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)