### PR TITLE
Add /accessibility.html statement page + footer link + WCAG 2.1 AA badge

### DIFF
--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -59,7 +59,8 @@
       </p>
       <p>
         <a href="/refund.html">Terms and Conditions</a> ·
-        <a href="/policy.html">Privacy Policy</a>
+        <a href="/policy.html">Privacy Policy</a> ·
+        <a href="/accessibility.html">Accessibility</a>
       </p>
     </div>
   </div>

--- a/src/accessibility.njk
+++ b/src/accessibility.njk
@@ -1,0 +1,173 @@
+---
+layout: base.njk
+permalink: /accessibility.html
+title: Accessibility statement
+description: How eiss-europa.com targets accessibility — standard, testing methods, known limitations, and how to report barriers.
+navKey: ""
+---
+
+<header class="page-header">
+  <div class="container">
+    <span class="eyebrow">Accessibility</span>
+    <h1>Accessibility statement</h1>
+    <p class="page-lead">
+      The European Initiative for Security Studies is committed to making
+      <a href="{{ site.url }}">eiss-europa.com</a> usable to as wide an audience as
+      possible, including people with disabilities.
+    </p>
+  </div>
+</header>
+
+<section class="section">
+  <div class="container">
+    <article class="prose">
+      <h2>Standard we target</h2>
+      <p>
+        The modernised pages of this site are designed and tested to meet the
+        <a href="https://www.w3.org/TR/WCAG21/" target="_blank" rel="noopener">Web Content
+        Accessibility Guidelines (WCAG) 2.1</a> at <strong>Level&nbsp;AA</strong>.
+      </p>
+      <p>
+        Our goal is full conformance. We don't claim to have reached every individual success
+        criterion — see "Known limitations" below for areas we're still working on.
+      </p>
+
+      <h2>How we test</h2>
+      <p>
+        Every commit to the site runs through an automated build and is verified with:
+      </p>
+      <ul>
+        <li>
+          <a href="https://github.com/dequelabs/axe-core" target="_blank" rel="noopener">axe-core</a> —
+          run in both light and dark mode against the home page and a representative sample of
+          inner pages.
+        </li>
+        <li>
+          <a href="https://developer.chrome.com/docs/lighthouse/" target="_blank" rel="noopener">Lighthouse</a>
+          accessibility, best-practices, and SEO audits. Modernised pages currently score
+          <strong>100&nbsp;/&nbsp;100</strong> on the accessibility category.
+        </li>
+        <li>
+          A short in-house static linter
+          (<a href="https://github.com/EISSeuropa/EISSeuropa.github.io/blob/master/scripts/a11y_lint.py" target="_blank" rel="noopener">scripts/a11y_lint.py</a>)
+          that walks every built HTML file checking landmarks, heading hierarchy, alt text,
+          accessible-name presence, duplicate IDs, and a few other WCAG-adjacent issues.
+        </li>
+      </ul>
+      <p>
+        Beyond automated checks we periodically test keyboard navigation, screen-reader output,
+        zoom to 200 %, and dark-mode contrast. Automated tools surface roughly a third of
+        accessibility issues; the remaining criteria need human review, which we treat as an
+        ongoing task rather than a one-off audit.
+      </p>
+
+      <h2>What we currently support</h2>
+      <ul>
+        <li>
+          <strong>Semantic landmarks</strong> on every modernised page: header, nav, main,
+          footer, with a skip-to-content link as the first focusable element.
+        </li>
+        <li>
+          <strong>Keyboard navigation</strong> for every interactive control. Focus rings are
+          visible via <code>:focus-visible</code>; the theme toggle and mobile menu work without
+          a pointing device.
+        </li>
+        <li>
+          <strong>Light and dark colour schemes</strong>, both meeting WCAG&nbsp;AA contrast
+          ratios for body text, links, and UI controls. The site honours your operating
+          system's preference automatically and remembers a manual override.
+        </li>
+        <li>
+          <strong>Reduced motion.</strong> All animations are gated on
+          <code>prefers-reduced-motion</code>; with that setting on, transitions and reveal
+          animations are disabled.
+        </li>
+        <li>
+          <strong>Resizable text.</strong> No fixed pixel sizes on body copy; the site reflows
+          cleanly at 200 % zoom and at narrow viewports down to 320&nbsp;px.
+        </li>
+        <li>
+          <strong>Alt text</strong> on every meaningful image; decorative images carry
+          <code>alt=""</code> to be skipped by assistive technologies.
+        </li>
+        <li>
+          <strong>Descriptive link text.</strong> Links indicate their destination on their own,
+          without relying on surrounding context.
+        </li>
+      </ul>
+
+      <h2>Known limitations</h2>
+      <ul>
+        <li>
+          <strong>Legacy ticket pages.</strong> The five
+          <code>ticket-*.html</code> URLs are still served as the original
+          <a href="https://amp.dev/" target="_blank" rel="noopener">AMP HTML</a> exports from
+          our previous site builder and have not been retro-fitted to the new design
+          system. They remain accessible but may not match the contrast and keyboard guarantees
+          described above. We may migrate or retire these pages in a future update.
+        </li>
+        <li>
+          <strong>Older conference photos</strong> in the archive (2019–2024 pages) sometimes
+          carry generic alt text inherited from the original publication. We're improving this
+          as we revisit each page.
+        </li>
+        <li>
+          <strong>Embedded PDFs</strong> — for example the 2026 conference programme — are
+          presented inline with a fallback download link, but the document content itself is
+          only as accessible as the source PDF. We provide a plain-text download alongside
+          every embed.
+        </li>
+      </ul>
+
+      <h2>Compatibility</h2>
+      <p>
+        The site is designed to work with current versions of the major browsers
+        (Safari, Chrome, Firefox, Edge) on desktop, tablet, and mobile, and with current
+        versions of the major screen readers (VoiceOver, NVDA, JAWS, TalkBack).
+      </p>
+      <p>
+        JavaScript is used only for the theme toggle and mobile menu. The site is fully
+        readable and navigable without JavaScript enabled.
+      </p>
+
+      <h2>Reporting a barrier</h2>
+      <p>
+        If you encounter any accessibility barrier on this site — a confusing layout, a missing
+        label, a contrast issue, a focus you can't see, anything at all — please tell us. We
+        treat accessibility issues as bugs and fix them as quickly as we can.
+      </p>
+      <p>
+        <a class="btn btn-primary"
+           href="mailto:{{ site.contactEmail }}?subject=Accessibility%20feedback%20on%20eiss-europa.com">
+          Email accessibility feedback
+        </a>
+      </p>
+
+      <h2 id="conformance">Conformance status</h2>
+      <p>
+        <strong>Partial conformance:</strong> the modernised templates (everything other than
+        the five legacy ticket pages listed above) are designed to meet WCAG&nbsp;2.1 at
+        Level&nbsp;AA. Automated audits report no current issues. Manual review of the
+        remaining success criteria is ongoing.
+      </p>
+      <p>
+        <a class="wcag-badge"
+           href="https://www.w3.org/TR/WCAG21/#level-aa-conformance"
+           target="_blank" rel="noopener"
+           aria-label="WCAG 2.1 Level AA — Web Content Accessibility Guidelines, see the W3C reference">
+          <span class="wcag-badge-wcag" aria-hidden="true">WCAG</span>
+          <span class="wcag-badge-vert" aria-hidden="true">
+            <span class="wcag-badge-version">2.1</span>
+            <span class="wcag-badge-level">AA</span>
+          </span>
+        </a>
+      </p>
+      <p class="meta">
+        Last reviewed: 14 May 2026 ·
+        <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/issues" target="_blank" rel="noopener">
+          source code &amp; issue tracker
+        </a>
+      </p>
+    </article>
+  </div>
+</section>

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -880,6 +880,63 @@ h4 { font-size: var(--fs-lg); }
 
 .footer-fineprint p { margin-bottom: var(--space-3); }
 
+/* ---------- WCAG conformance badge ---------- */
+.wcag-badge {
+  display: inline-flex;
+  align-items: stretch;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  text-decoration: none;
+  box-shadow: var(--shadow-1);
+  border: 1px solid var(--border);
+  font-family: var(--font-display);
+  font-weight: 800;
+  line-height: 1;
+  transition: transform var(--motion-fast) var(--ease-out),
+              box-shadow var(--motion-fast) var(--ease-out);
+  margin-block: var(--space-3);
+}
+
+.wcag-badge:hover,
+.wcag-badge:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-2);
+  text-decoration: none;
+}
+
+.wcag-badge-wcag {
+  display: grid;
+  place-items: center;
+  padding: var(--space-3) var(--space-4);
+  background: var(--text);
+  color: var(--bg-elev);
+  font-size: var(--fs-base);
+  letter-spacing: 0.08em;
+}
+
+.wcag-badge-vert {
+  display: grid;
+  grid-template-rows: auto auto;
+  align-content: center;
+  gap: 2px;
+  padding: var(--space-2) var(--space-4);
+  background: var(--bg-elev);
+  text-align: center;
+}
+
+.wcag-badge-version {
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+.wcag-badge-level {
+  font-size: var(--fs-lg);
+  color: var(--accent);
+  letter-spacing: 0.02em;
+}
+
 /* ---------- pdf document card (Apple Files style) ---------- */
 .pdf-doc {
   margin-block: var(--space-6);


### PR DESCRIPTION
## Summary

Adds a proper accessibility statement at `/accessibility.html` plus an "Accessibility" link in the footer alongside Terms & Privacy. The page carries a custom-styled "WCAG 2.1 AA" conformance badge linking to the W3C Level AA reference.

## Why a statement, not a global-footer badge

A self-graded "we score 100/100" badge in the global footer would look like greenwashing. A proper statement page covers what serious accessibility statements cover, gives users a way to report issues, and is the practice the European Accessibility Act expects of organisations that take this seriously. W3C also dropped its official conformance logos with WCAG 2.1 — recommending text-based claims linked to a published statement — so this approach is now the actual best practice.

## What the page says

- **Standard targeted:** WCAG 2.1 Level AA, with an honest "partial conformance" caveat for the 5 legacy `ticket-*.html` AMP pages still on passthrough.
- **How we test:** axe-core (light + dark across representative pages), Lighthouse (accessibility category at 100/100 across modernised pages), the in-repo `scripts/a11y_lint.py`, plus periodic manual keyboard / screen-reader / 200%-zoom / contrast checks.
- **What we support today:** semantic landmarks + skip-link, full keyboard navigation with `:focus-visible` rings, auto + manual dark mode both meeting AA contrast, `prefers-reduced-motion` honoured, resizable text reflowing down to 320 px, alt text on meaningful images, descriptive link text.
- **Known limitations:** the legacy ticket pages, generic alt text on some archive conference photos, embedded PDFs only as accessible as their source.
- **Compatibility:** current major browsers + screen readers; site fully functions without JavaScript (theme toggle + mobile menu are progressive enhancement).
- **Reporting a barrier:** a primary CTA with a `mailto:` to `contact@eiss-europa.com` and a pre-filled subject line.
- **Conformance status:** partial conformance with the modernised templates, plus the WCAG 2.1 AA badge.
- **Last reviewed:** 14 May 2026, with a link to the public issue tracker.

## The badge

Custom `.wcag-badge` class — two-tone rounded pill, `WCAG` on a dark panel + `2.1 / AA` on a light panel with the level in the accent blue. Renders correctly in both light and dark modes. Sits **only on the accessibility statement page itself**, not in the global footer — putting it everywhere would defeat the point of a verifiable statement. The badge links to <https://www.w3.org/TR/WCAG21/#level-aa-conformance>.

## Files

- New: [src/accessibility.njk](src/accessibility.njk) — the statement page
- Modified: [src/_includes/footer.njk](src/_includes/footer.njk) — added "Accessibility" link
- Modified: [src/assets/css/site.css](src/assets/css/site.css) — `.wcag-badge` component (~50 lines)

## Verification

- ✅ Build clean
- ✅ `a11y_lint.py`: 40 modernised pages, 0 issues (was 39, +1 for accessibility.html)
- ✅ Badge renders cleanly in light + dark modes (screenshots in chat)

## Test plan

- [ ] CI build green
- [ ] After merge: visit `/accessibility.html` and read through; flag any wording you want to tweak
- [ ] Confirm the "Accessibility" footer link appears on every modernised page
- [ ] Click the WCAG badge — confirm it opens the W3C Level AA reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)