### PR TITLE
Rewrite Privacy Policy to reflect what the site actually does

### DIFF
--- a/src/policy.njk
+++ b/src/policy.njk
@@ -2,7 +2,7 @@
 layout: base.njk
 permalink: /policy.html
 title: Privacy Policy
-description: How the European Initiative for Security Studies collects, uses, and protects personal data, in compliance with GDPR.
+description: How the European Initiative for Security Studies handles personal data on eiss-europa.com — what we collect, what we do not, third parties, and your GDPR rights.
 navKey: ""
 ---
 
@@ -11,8 +11,8 @@ navKey: ""
     <span class="eyebrow">Legal</span>
     <h1>Privacy Policy</h1>
     <p class="page-lead">
-      How the European Initiative for Security Studies (RNA: 751263001) collects, uses, and protects personal data,
-      in compliance with the GDPR and the French Data Protection Act.
+      How the European Initiative for Security Studies (RNA: 751263001) handles personal
+      data on this website, in compliance with the GDPR and the French Data Protection Act.
     </p>
   </div>
 </header>
@@ -20,102 +20,221 @@ navKey: ""
 <section class="section">
   <div class="container">
     <article class="prose">
-      <p>The European Initiative for Security Studies (hereinafter referred to as "EISS", "we", "us", or "our") is committed to protecting and respecting your privacy. This Privacy Policy outlines our practices regarding the collection, use, storage, and disclosure of personal data we receive from users (hereinafter referred to as "you" or "your") of our website, services, or any other interactions you may have with us.</p>
 
-      <p>This Privacy Policy is in compliance with the General Data Protection Regulation (EU) 2016/679 ("GDPR") and the French Data Protection Act (Loi Informatique et Libertés).</p>
+      <p>
+        The European Initiative for Security Studies (hereinafter <strong>"EISS"</strong>,
+        <strong>"we"</strong>, <strong>"us"</strong>, or <strong>"our"</strong>) is committed
+        to protecting and respecting your privacy. This Privacy Policy describes what personal
+        data we process when you visit
+        <a href="https://eiss-europa.com">eiss-europa.com</a>, what we do <em>not</em> do, and
+        what rights you have.
+      </p>
+      <p>
+        This policy is in compliance with the
+        <a href="https://eur-lex.europa.eu/eli/reg/2016/679/oj" target="_blank" rel="noopener">General Data Protection Regulation (EU) 2016/679</a>
+        (<strong>"GDPR"</strong>) and the French Data Protection Act
+        (<em>Loi Informatique et Libertés</em>).
+      </p>
 
-      <h2>1. Controller and Data Protection Officer</h2>
-
-      <p>The controller responsible for the processing of personal data under this Privacy Policy is:</p>
-
-      <p>The European Initiative for Security Studies (EISS)<br>
-        CERI-Sciences Po, 56 Rue Jacob<br>
-        75006 Paris<br>
-        France</p>
-
-      <p>If you have any questions, concerns, or requests regarding your personal data, you may contact our Data Protection Officer at <a href="mailto:contact@eiss-europa.com">contact@eiss-europa.com</a>.</p>
-
-      <h2>2. Collection of Personal Data</h2>
-
-      <p>We may collect the following personal data from you:</p>
-
-      <ul>
-        <li>Contact information, such as name, email address, and phone number.</li>
-        <li>Professional information, such as job title, organisation, and areas of interest.</li>
-        <li>Technical information, such as IP address, browser type, and operating system, when you interact with our website or services.</li>
-      </ul>
-
-      <h2>3. Purpose and Legal Basis for Processing</h2>
-
-      <p>We process your personal data for the following purposes and based on the following legal grounds:</p>
-
-      <ul>
-        <li>To provide you with information, services, or products you have requested, based on your consent (GDPR Article 6(1)(a)).</li>
-        <li>To comply with legal obligations, such as responding to valid requests from public authorities (GDPR Article 6(1)(c)).</li>
-        <li>To pursue our legitimate interests, such as improving our website and services, and conducting research and analysis (GDPR Article 6(1)(f)).</li>
-      </ul>
-
-      <h2>4. Recipients of Personal Data</h2>
-
-      <p>We may share your personal data with trusted third parties, such as service providers, for the purposes stated in this Privacy Policy. We ensure that these third parties adhere to GDPR and French data protection law requirements.</p>
-
-      <h2>5. International Transfers</h2>
-
-      <p>We may transfer your personal data to countries outside the European Economic Area (EEA). In such cases, we will implement appropriate safeguards, such as standard contractual clauses approved by the European Commission, to ensure the protection of your personal data.</p>
-
-      <h2>6. Retention of Personal Data</h2>
-
-      <p>We will retain your personal data only for as long as necessary to fulfill the purposes for which it was collected or as required by applicable laws or regulations.</p>
-
-      <h2>7. Your Rights</h2>
-
-      <p>Under GDPR and French data protection law, you have the following rights:</p>
-
-      <ul>
-        <li>The right to access your personal data.</li>
-        <li>The right to rectification of your personal data if it is inaccurate or incomplete.</li>
-        <li>The right to erasure of your personal data, subject to legal requirements.</li>
-        <li>The right to restrict the processing of your personal data.</li>
-        <li>The right to data portability, allowing you to receive your personal data in a structured, commonly used format.</li>
-        <li>The right to object to the processing of your personal data.</li>
-        <li>The right to withdraw your consent at any time, without affecting the lawfulness of processing based on consent before withdrawal.</li>
-        <li>The right to lodge a complaint with a supervisory authority.</li>
-      </ul>
-
-      <p>To exercise any of your rights or if you have any questions regarding this Privacy Policy, please contact our Data Protection Officer at <a href="mailto:contact@eiss-europa.com">contact@eiss-europa.com</a>.</p>
-
-      <h2>8. Changes to This Privacy Policy</h2>
-
-      <p>We reserve the right to update or modify this Privacy Policy at any time to reflect changes in our practices or applicable laws and regulations. We will post the updated Privacy Policy on our website and notify you of any material changes. We encourage you to periodically review this Privacy Policy to stay informed about our data protection practices.</p>
-
-      <h2>9. Security Measures</h2>
-
-      <p>We take appropriate technical and organisational measures to protect your personal data against unauthorised access, alteration, disclosure, or destruction. These measures may include, but are not limited to, access controls, encryption, secure storage, and regular security assessments.</p>
-
-      <h2>10. Links to Third-Party Websites</h2>
-
-      <p>Our website may contain links to external websites operated by third parties. This Privacy Policy does not apply to these external websites, and we are not responsible for their content or privacy practices. We encourage you to review the privacy policies of these third-party websites before disclosing any personal data.</p>
-
-      <h2>11. Cookies</h2>
-
-      <p>Our website uses cookies to enhance your browsing experience and collect information about your use of the website. Cookies are small text files that a website stores on your device. You may adjust your browser settings to block or delete cookies, but this may affect the functionality of our website.</p>
-
-      <h2>12. Children's Privacy</h2>
-
-      <p>Our services are not directed at individuals under the age of 16, and we do not knowingly collect personal data from children under 16. If we become aware that we have collected personal data from a child under the age of 16, we will take appropriate steps to delete such data.</p>
-
-      <h2>13. Contact Information</h2>
-
-      <p>If you have any questions, concerns, or requests regarding this Privacy Policy or your personal data, please contact our Data Protection Officer at:</p>
-
-      <p>Email: <a href="mailto:contact@eiss-europa.com">contact@eiss-europa.com</a><br>
-        Postal Address:<br>
+      <h2>1. Controller and Data Protection contact</h2>
+      <p>The controller responsible for any personal data processing under this policy is:</p>
+      <p>
         The European Initiative for Security Studies (EISS)<br>
-        CERI-Sciences Po, 56 Rue Jacob<br>
+        CERI-Sciences&nbsp;Po, 56 Rue Jacob<br>
         75006 Paris<br>
-        France</p>
+        France
+      </p>
+      <p>
+        For any question, request, or complaint regarding your personal data, contact
+        <a href="mailto:contact@eiss-europa.com">contact@eiss-europa.com</a>.
+      </p>
 
-      <p class="meta">Last Updated: 09/05/2023.</p>
+      <h2>2. What we do <em>not</em> do</h2>
+      <p>To save you reading: on this website we do <strong>not</strong> —</p>
+      <ul>
+        <li>set any cookies of our own;</li>
+        <li>use any web analytics, tracking pixels, fingerprinting, or visitor measurement service;</li>
+        <li>embed any social-media widgets that load before you click them;</li>
+        <li>run any advertising network or programmatic ads;</li>
+        <li>sell, rent, or share any data with marketers.</li>
+      </ul>
+      <p>
+        This site is a plain static website. It runs in your browser, fetches a small CSS
+        and JavaScript file, and that's it.
+      </p>
+
+      <h2>3. Data we may process</h2>
+      <p>
+        We minimise the personal data we process. The categories below are the only ones in
+        scope of this policy:
+      </p>
+      <ol>
+        <li>
+          <strong>Server access logs.</strong> The site is hosted on
+          <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener">GitHub Pages</a>.
+          When you load a page, GitHub records the request — IP address, user-agent string,
+          and the requested URL — for security, abuse-prevention, and operational reasons.
+          EISS does not have access to those raw logs. GitHub acts as our hosting processor and
+          is bound by its own privacy statement.
+        </li>
+        <li>
+          <strong>Contact correspondence.</strong> If you email us at
+          <code>contact@eiss-europa.com</code>, we keep that correspondence in order to answer
+          you, follow up, and manage our records.
+        </li>
+        <li>
+          <strong>Membership and conference registration.</strong> If you become an EISS member
+          or register for a conference, additional data is collected by the relevant third
+          parties (see §5). Those interactions are governed by the policies of those services
+          and by any explicit consent you give at the point of registration.
+        </li>
+      </ol>
+
+      <h2>4. Browser storage</h2>
+      <p>
+        The site uses one <strong>localStorage</strong> entry, <code>eiss-theme</code>, to
+        remember whether you have manually set the site to light or dark mode. It is written
+        to your browser only when you click the theme-toggle button in the header. It contains
+        the literal value <code>"light"</code> or <code>"dark"</code> and is never transmitted
+        to us or to anyone else. You can remove it by clearing your browser's site data for
+        <code>eiss-europa.com</code>.
+      </p>
+      <p>
+        This is not a cookie. It cannot be read by third-party scripts and does not follow you
+        across other sites.
+      </p>
+
+      <h2>5. Third-party services</h2>
+      <p>
+        These third parties may receive data — typically your IP address and user-agent — as
+        a technical side effect of loading or following content on this site:
+      </p>
+      <ul>
+        <li>
+          <strong>Google Fonts</strong> (<code>fonts.googleapis.com</code>,
+          <code>fonts.gstatic.com</code>). The site loads the Inter font stylesheet and font
+          files directly from Google's CDN. Per Google's
+          <a href="https://developers.google.com/fonts/faq/privacy" target="_blank" rel="noopener">Fonts privacy statement</a>,
+          requests are logged briefly and the data is not used for ad personalisation.
+        </li>
+        <li>
+          <strong>GitHub Pages</strong> (<code>github.io</code> infrastructure) — see §3.1 above.
+        </li>
+      </ul>
+      <p>
+        When you click an outbound link on this site — for example to
+        <strong>Stripe</strong> (membership management), <strong>Indico</strong>
+        (<a href="https://indico.eiss-europa.com/" target="_blank" rel="noopener">indico.eiss-europa.com</a>,
+        our events platform), <strong>YouTube</strong>, the
+        <strong>COST</strong> Association, or any partner institution — you leave this
+        website and become subject to that service's own privacy policy. None of those
+        services are embedded on the pages of this site; they only see you when you choose
+        to visit them.
+      </p>
+
+      <h2>6. Purpose and legal basis</h2>
+      <p>The (very limited) processing described above rests on:</p>
+      <ul>
+        <li>
+          <strong>Your consent</strong> (GDPR Article 6(1)(a)) when you write to us or sign
+          up for an EISS service;
+        </li>
+        <li>
+          <strong>Our legitimate interests</strong> (GDPR Article 6(1)(f)) in operating a
+          secure, functional website — for example, GitHub's access logs for abuse prevention,
+          and Google Fonts for displaying readable typography.
+        </li>
+        <li>
+          <strong>Legal obligations</strong> (GDPR Article 6(1)(c)) such as responding to
+          lawful requests from public authorities.
+        </li>
+      </ul>
+
+      <h2>7. Retention</h2>
+      <p>
+        We retain personal data only for as long as necessary to fulfil the purpose for which
+        it was collected, or as required by applicable law. Email correspondence is kept while
+        the matter is open and for a reasonable period afterwards for archival reasons. Server
+        access logs are retained by GitHub according to their own schedule, which is outside
+        our control.
+      </p>
+
+      <h2>8. International transfers</h2>
+      <p>
+        GitHub Pages is operated by GitHub Inc. in the United States. Google Fonts is operated
+        by Google Ireland Limited with US-affiliated infrastructure. Both transfers rely on
+        Standard Contractual Clauses approved by the European Commission and on the
+        EU–US Data Privacy Framework where applicable, as documented in each provider's
+        privacy statement.
+      </p>
+
+      <h2>9. Your rights</h2>
+      <p>Under the GDPR and French data protection law, you have the right to —</p>
+      <ul>
+        <li>access the personal data we hold about you;</li>
+        <li>rectify inaccurate or incomplete data;</li>
+        <li>request erasure, subject to legal requirements;</li>
+        <li>restrict or object to processing;</li>
+        <li>receive your data in a structured, commonly used format (portability);</li>
+        <li>withdraw any consent you have given, without affecting earlier lawful processing;</li>
+        <li>
+          lodge a complaint with a supervisory authority — in France, the
+          <a href="https://www.cnil.fr/en" target="_blank" rel="noopener">Commission Nationale de l'Informatique et des Libertés (CNIL)</a>.
+        </li>
+      </ul>
+      <p>
+        To exercise any of these rights, email
+        <a href="mailto:contact@eiss-europa.com">contact@eiss-europa.com</a>. We aim to answer
+        within one month.
+      </p>
+
+      <h2>10. Security</h2>
+      <p>
+        The site is served over HTTPS with HTTP Strict Transport Security. The source code is
+        public (<a href="https://github.com/EISSeuropa/EISSeuropa.github.io" target="_blank" rel="noopener">github.com/EISSeuropa/EISSeuropa.github.io</a>),
+        so any third party can inspect what runs in your browser. We take appropriate
+        technical and organisational measures to protect any personal data we hold against
+        unauthorised access, alteration, disclosure, or destruction.
+      </p>
+
+      <h2>11. Children's privacy</h2>
+      <p>
+        Our services are not directed at individuals under the age of 16, and we do not
+        knowingly collect personal data from children under 16. If you believe we have
+        received data from a child, please email us and we will delete it.
+      </p>
+
+      <h2>12. Links to third-party websites</h2>
+      <p>
+        This website contains links to external sites (see §5). This Privacy Policy does not
+        apply to those sites and we are not responsible for their content or privacy practices.
+        We encourage you to review their policies before disclosing any personal data.
+      </p>
+
+      <h2>13. Changes to this Policy</h2>
+      <p>
+        We may update this Privacy Policy from time to time to reflect changes in our
+        practices or in applicable law. The current version is always available at
+        <a href="https://eiss-europa.com/policy.html">eiss-europa.com/policy.html</a>, and the
+        full history is preserved in the public Git repository linked above. Material changes
+        will be flagged on the home page.
+      </p>
+
+      <h2>14. Contact</h2>
+      <p>
+        For any question, request, or complaint regarding your personal data or this Privacy
+        Policy:
+      </p>
+      <p>
+        Email: <a href="mailto:contact@eiss-europa.com">contact@eiss-europa.com</a><br>
+        Postal address:<br>
+        The European Initiative for Security Studies (EISS)<br>
+        CERI-Sciences&nbsp;Po, 56 Rue Jacob<br>
+        75006 Paris<br>
+        France
+      </p>
+
+      <p class="meta">Last updated: 15 May 2026.</p>
     </article>
   </div>
 </section>


### PR DESCRIPTION
## Summary

The previous Privacy Policy was inherited verbatim from the Mobirise export and made several claims that haven't been true since the migration. Rewrites it to match what the site actually does.

## The two biggest factual problems

1. **§11 claimed "Our website uses cookies"** — false. The modernised site sets zero cookies. The previous Mobirise build may have set some via its embedded framework, but that's gone.

2. **§2 listed "IP address, browser type, and operating system" as data we collect** — implying first-party processing / running analytics. We don't. Those are logged by GitHub Pages (our host) and by Google Fonts as a side effect of any web request, but EISS itself has no access to them.

## What the new policy says

Same structure approach as the accessibility statement — numbered, concrete, links to the documents it cites.

| § | Section | Notable changes |
| - | ------- | --------------- |
| 1 | Controller and Data Protection contact | Renamed from "Data Protection Officer" — a formally appointed DPO has specific GDPR meaning and EISS isn't required to have one |
| **2** | **What we do *not* do** | **New section, up front.** No cookies, no analytics, no tracking pixels, no fingerprinting, no auto-loaded social widgets, no ads, no data sales |
| 3 | Data we may process | Reduced to three honest categories: server access logs (held by GitHub, EISS doesn't see), email correspondence, third-party platforms (Stripe, Indico, etc.) — each clearly labelled |
| **4** | **Browser storage** | **New section.** Documents the one localStorage key `eiss-theme`, what it contains, what it doesn't do, how to clear it |
| **5** | **Third-party services** | **New section.** Lists only the two third parties that actually receive data per page-load: Google Fonts (`fonts.googleapis.com` + `fonts.gstatic.com`) and GitHub Pages. Plus a clear note that outbound links (Stripe, Indico, YouTube, COST, partner institutions) are not embedded — those services only see you on click |
| 6 | Purpose and legal basis | Tied to the actual processing in §3, with the GDPR articles |
| 7 | Retention | Acknowledges email retention is ours, server logs are GitHub's |
| 8 | International transfers | Names GitHub Inc. (US) and Google Ireland Ltd, references SCCs + EU-US Data Privacy Framework |
| 9 | Your rights | Adds CNIL as the French supervisory authority for complaints, with a link |
| 10 | Security | Notes HTTPS + HSTS in place; flags that source code is public on GitHub so anyone can verify what runs in browsers |
| 11 | Children's privacy | Unchanged in substance |
| 12 | Links to third-party websites | Tightened |
| 13 | Changes to this Policy | Points to the public Git repo for full version history |
| 14 | Contact | Unchanged |

**Last updated**: 15 May 2026 (was 09/05/2023).

## Disclaimer

I'm not a lawyer. This rewrite is an honest factual update — it removes inaccurate claims and adds detail about what the site actually does. Before merging, you may want to have a French data-protection professional cast an eye over it, particularly §6 (legal basis) and §8 (international transfers). Happy to adjust wording on your read.

## Test plan

- [x] CI build green
- [x] Read through `/policy.html` and flag wording you'd change
- [x] Confirm "Last updated: 15 May 2026" shows at the foot of the page
- [x] Confirm the footer "Privacy Policy" link still works from every page

🤖 Generated with [Claude Code](https://claude.com/claude-code)