### PR TITLE
Refactor /board page to data-driven loop (prep for Form sync)

### DIFF
--- a/src/_data/board.json
+++ b/src/_data/board.json
@@ -1,0 +1,182 @@
+{
+  "_documentation": "Data source for /board.html. The page template (src/board.njk) loops over `members` and `support`. New people, role changes, photo swaps — edit this file, not the template. A future workflow will overwrite this file from the linked Google Sheet (see docs/board-bios-setup.md once added).",
+
+  "members": [
+    {
+      "name": "Dr Hugo Meijer",
+      "role": "Founding Director",
+      "photo": "/assets/images/meijer-2-140x175.jpg",
+      "alt": "Dr Hugo MEIJER",
+      "affiliation": "CNRS Research Fellow — Sciences Po, Center for International Studies (CERI).",
+      "themes": "International Relations, Foreign Policy Analysis, Security Studies, Alliances."
+    },
+    {
+      "name": "Dr Marie Robin",
+      "role": "Treasurer",
+      "photo": "/assets/images/screenshot-2024-03-25-at-18.29.49-348x391.png",
+      "alt": "Dr Marie Robin",
+      "affiliation": "Assistant Professor of War Studies — Leiden University.",
+      "themes": "Revenge in international relations, Strategic use of emotions, Evolution of conflictuality, Ethics of war."
+    },
+    {
+      "name": "Prof. Moritz Weiss",
+      "role": "Secretary-General",
+      "photo": "/assets/images/moritzweiss-eiss2024-348x305.jpg",
+      "alt": "Prof. Moritz Weiss",
+      "affiliation": "Senior Lecturer and Principal Investigator — Ludwig Maximilian University of Munich.",
+      "themes": "International Relations, Theorizing (informal) institutions, European integration, Governance of international security."
+    },
+    {
+      "name": "Prof. Silvia D’Amato",
+      "role": "Board Member",
+      "photo": "/assets/images/1-2.jpeg",
+      "alt": "Prof. Silvia D’Amato",
+      "affiliation": "Associate Professor — James Madison University.",
+      "themes": "Terrorism, Political Violence and War, Peace and Justice."
+    },
+    {
+      "name": "Dr Julia Carver",
+      "role": "Board Member",
+      "photo": "/assets/images/julia20carver20headshot-253x169.jpeg",
+      "alt": "Dr Julia Carver",
+      "affiliation": "Assistant Professor — Leiden University.",
+      "themes": "Foreign policymaking, Strategic concepts, Emerging digital technologies."
+    },
+    {
+      "name": "Prof. Marco Wyss",
+      "role": "Board Member",
+      "photo": "/assets/images/wyss-1-403x564.jpg",
+      "alt": "Prof. Marco Wyss",
+      "affiliation": "Professor of International History and Security — Lancaster University; Research Fellow — Stellenbosch University; Senior Research Fellow — School of Advanced Study, University of London.",
+      "themes": "Cold War, African and European defence, Neutrality."
+    },
+    {
+      "name": "Dr Eliza Gheorghe",
+      "role": "Board Member",
+      "photo": "/assets/images/eliza-gheorghe.jpg",
+      "alt": "Dr Eliza Gheorghe",
+      "affiliation": "Assistant Professor — Department of International Relations, Bilkent University.",
+      "themes": "International Relations Theory, International Security, Nuclear Politics."
+    },
+    {
+      "name": "Prof. Marina Henke",
+      "role": "Board Member",
+      "photo": "/assets/images/henke-marina-3-347x521.jpg",
+      "alt": "Prof. Marina Henke",
+      "affiliation": "Professor of International Relations and Director of the Centre for International Security — Hertie School.",
+      "themes": "Intervention decision-making, Nuclear security, U.S. and European Grand Strategy."
+    },
+    {
+      "name": "Dr Sanne Verschuren",
+      "role": "Board Member",
+      "photo": "/assets/images/picture-sanne-verschuren-sanne-verschuren-348x348.jpg",
+      "alt": "Dr Sanne Verschuren",
+      "affiliation": "Assistant Professor of International Security — Boston University.",
+      "themes": "Domestic determinants of security policy, Role of ideas, norms, and institutions in national security decision-making."
+    },
+    {
+      "name": "Prof. Revecca Pedi",
+      "role": "Board Member",
+      "photo": "/assets/images/5731-revecca-pedi-1-2-253x253.jpg",
+      "alt": "Prof. Revecca Pedi",
+      "affiliation": "Associate Professor of International Relations — University of Macedonia.",
+      "themes": "International relations of small states, Theories of international relations, International relations and the European Union."
+    },
+    {
+      "name": "Dr Chiara Libiseller",
+      "role": "Board Member",
+      "photo": "/assets/images/chiara-l3303ibiseller.x2806b916.jpg.webp",
+      "alt": "Dr Chiara Libiseller",
+      "affiliation": "Lecturer in Strategic Studies — King’s College London.",
+      "themes": "Knowledge production on war, Changing character of war, Impact of technology on the theory and practice of war."
+    },
+    {
+      "name": "Alisa Kerschbaum",
+      "role": "Board Member",
+      "photo": "/assets/images/alisa-kerschbaum-uva-253x371.jpeg",
+      "alt": "Alisa Kerschbaum",
+      "affiliation": "Research Grant Advisor — University of Amsterdam.",
+      "themes": "Global affairs, International Peace &amp; Security, Environmental security."
+    },
+    {
+      "name": "Prof. Nicolas Blarel",
+      "role": "Board Member",
+      "photo": "/assets/images/d200x250-3.jpeg",
+      "alt": "Prof. Nicolas Blarel",
+      "affiliation": "Associate Professor of International Relations and Director of Studies — Leiden University.",
+      "themes": "Foreign Policy Analysis, Politics of migration governance, International politics of South Asia."
+    },
+    {
+      "name": "Prof. Antonio Calcara",
+      "role": "Board Member",
+      "photo": "/assets/images/r2sk57tg-400x400.jpg",
+      "alt": "Prof. Antonio Calcara",
+      "affiliation": "Professor — Vrije Universiteit Brussels.",
+      "themes": "European Security and Defence, Defence Industry, Political Economy."
+    },
+    {
+      "name": "Prof. Olivier Schmitt",
+      "role": "Board Member",
+      "photo": "/assets/images/schmitt-olivier-2-213x320.jpg",
+      "alt": "Prof. Olivier Schmitt",
+      "affiliation": "Head of Research — Institute for Military Operations at the Royal Danish Defence College.",
+      "themes": "Military Operations, Alliances, Transformation."
+    },
+    {
+      "name": "Prof. Chiara Ruffa",
+      "role": "Board Member",
+      "photo": "/assets/images/jritvrpl-400x400.jpg",
+      "alt": "Prof. Chiara Ruffa",
+      "affiliation": "Professor of Political Science — Sciences Po, Center for International Studies (CERI).",
+      "themes": "Multilateralism on the ground, Peacekeeping, Civil-military relations, Political sociology, Fieldwork."
+    },
+    {
+      "name": "Dr Tim Sweijs",
+      "role": "Board Member",
+      "photo": "/assets/images/1071-07280937-s001tim-003-1-705x705.png",
+      "alt": "Dr Tim Sweijs",
+      "affiliation": "Senior Research Fellow — Netherlands’ War Studies Research Centre; Director of Research — The Hague Centre for Strategic Studies.",
+      "themes": "Warfare (past, present, future), Strategy, Coercion, Deterrence, Emerging technologies."
+    },
+    {
+      "name": "Prof. Filip Ejdus",
+      "role": "Board Member",
+      "photo": "/assets/images/ejdus-photo-253x253.jpg",
+      "alt": "Prof. Filip Ejdus",
+      "affiliation": "Professor of Security Studies — Faculty of Political Science, University of Belgrade.",
+      "themes": "Identity, memory, and emotions, International interventions, Civil-military relations, Security sector reform."
+    },
+    {
+      "name": "Sarka Kolmasova",
+      "role": "Board Member",
+      "photo": "/assets/images/citations.jpeg",
+      "alt": "Sarka Kolmasova",
+      "affiliation": "Deputy Head &amp; Assistant Professor — Department of International Relations and European Studies, Metropolitan University Prague.",
+      "themes": "Norms, Military Interventions, Responsibility to Protect, Human Rights in International Politics."
+    }
+  ],
+
+  "support": [
+    {
+      "name": "Dr Arthur PB Laudrain",
+      "role": "Technology Coordinator",
+      "photo": "/assets/images/rsd25-cropped-348x332.jpg",
+      "alt": "Dr Arthur PB Laudrain",
+      "bio": "Arthur is responsible for most of the online logistics of the organisation. He is Team Lead and a Senior Researcher for Cyber Security at the Center for Security Studies at ETH Zurich. Arthur has been with us since 2017."
+    },
+    {
+      "name": "Dr John NT Helferich",
+      "role": "Events Coordinator",
+      "photo": "/assets/images/helferich-portrait-college-3.jpeg",
+      "alt": "Dr John NT Helferich",
+      "bio": "John is your first point of contact. He is in charge of our email communications, and ensures smooth coordination between chairs and panel members, among other things. He is a DPhil candidate in International Relations at St. Antony's College, Oxford. John joined the Initiative in 2018."
+    },
+    {
+      "name": "Eugenio Sanchez",
+      "role": "Communications Coordinator",
+      "photo": "/assets/images/1659415900816.jpeg",
+      "alt": "Eugenio Sanchez",
+      "bio": "Eugenio assists with the development of our communication strategy and the logistics of our events. He is a PhD candidate in International Relations at Sciences Po Paris. Eugenio joined the Initiative in 2023."
+    }
+  ]
+}

--- a/src/board.njk
+++ b/src/board.njk
@@ -21,195 +21,19 @@ navKey: ""
   <div class="container">
     <h2 style="margin-bottom: var(--space-5);">Board</h2>
     <div class="people-grid">
+      {%- for person in board.members %}
       <article class="person">
-        <img class="person-photo" src="/assets/images/meijer-2-140x175.jpg" alt="Dr Hugo MEIJER" loading="lazy">
+        <img class="person-photo" src="{{ person.photo }}" alt="{{ person.alt or person.name }}" loading="lazy">
         <div class="person-body">
-          <p class="person-role">Founding Director</p>
-          <p class="person-name">Dr Hugo Meijer</p>
-          <p class="person-affiliation">CNRS Research Fellow — Sciences Po, Center for International Studies (CERI).</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> International Relations, Foreign Policy Analysis, Security Studies, Alliances.</p>
+          <p class="person-role">{{ person.role }}</p>
+          <p class="person-name">{{ person.name }}</p>
+          <p class="person-affiliation">{{ person.affiliation | safe }}</p>
+          {%- if person.themes %}
+          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> {{ person.themes | safe }}</p>
+          {%- endif %}
         </div>
       </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/screenshot-2024-03-25-at-18.29.49-348x391.png" alt="Dr Marie Robin" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Treasurer</p>
-          <p class="person-name">Dr Marie Robin</p>
-          <p class="person-affiliation">Assistant Professor of War Studies — Leiden University.</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> Revenge in international relations, Strategic use of emotions, Evolution of conflictuality, Ethics of war.</p>
-        </div>
-      </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/moritzweiss-eiss2024-348x305.jpg" alt="Prof. Moritz Weiss" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Secretary-General</p>
-          <p class="person-name">Prof. Moritz Weiss</p>
-          <p class="person-affiliation">Senior Lecturer and Principal Investigator — Ludwig Maximilian University of Munich.</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> International Relations, Theorizing (informal) institutions, European integration, Governance of international security.</p>
-        </div>
-      </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/1-2.jpeg" alt="Prof. Silvia D’Amato" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Board Member</p>
-          <p class="person-name">Prof. Silvia D’Amato</p>
-          <p class="person-affiliation">Associate Professor — James Madison University.</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> Terrorism, Political Violence and War, Peace and Justice.</p>
-        </div>
-      </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/julia20carver20headshot-253x169.jpeg" alt="Dr Julia Carver" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Board Member</p>
-          <p class="person-name">Dr Julia Carver</p>
-          <p class="person-affiliation">Assistant Professor — Leiden University.</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> Foreign policymaking, Strategic concepts, Emerging digital technologies.</p>
-        </div>
-      </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/wyss-1-403x564.jpg" alt="Prof. Marco Wyss" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Board Member</p>
-          <p class="person-name">Prof. Marco Wyss</p>
-          <p class="person-affiliation">Professor of International History and Security — Lancaster University; Research Fellow — Stellenbosch University; Senior Research Fellow — School of Advanced Study, University of London.</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> Cold War, African and European defence, Neutrality.</p>
-        </div>
-      </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/eliza-gheorghe.jpg" alt="Dr Eliza Gheorghe" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Board Member</p>
-          <p class="person-name">Dr Eliza Gheorghe</p>
-          <p class="person-affiliation">Assistant Professor — Department of International Relations, Bilkent University.</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> International Relations Theory, International Security, Nuclear Politics.</p>
-        </div>
-      </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/henke-marina-3-347x521.jpg" alt="Prof. Marina Henke" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Board Member</p>
-          <p class="person-name">Prof. Marina Henke</p>
-          <p class="person-affiliation">Professor of International Relations and Director of the Centre for International Security — Hertie School.</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> Intervention decision-making, Nuclear security, U.S. and European Grand Strategy.</p>
-        </div>
-      </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/picture-sanne-verschuren-sanne-verschuren-348x348.jpg" alt="Dr Sanne Verschuren" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Board Member</p>
-          <p class="person-name">Dr Sanne Verschuren</p>
-          <p class="person-affiliation">Assistant Professor of International Security — Boston University.</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> Domestic determinants of security policy, Role of ideas, norms, and institutions in national security decision-making.</p>
-        </div>
-      </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/5731-revecca-pedi-1-2-253x253.jpg" alt="Prof. Revecca Pedi" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Board Member</p>
-          <p class="person-name">Prof. Revecca Pedi</p>
-          <p class="person-affiliation">Associate Professor of International Relations — University of Macedonia.</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> International relations of small states, Theories of international relations, International relations and the European Union.</p>
-        </div>
-      </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/chiara-l3303ibiseller.x2806b916.jpg.webp" alt="Dr Chiara Libiseller" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Board Member</p>
-          <p class="person-name">Dr Chiara Libiseller</p>
-          <p class="person-affiliation">Lecturer in Strategic Studies — King’s College London.</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> Knowledge production on war, Changing character of war, Impact of technology on the theory and practice of war.</p>
-        </div>
-      </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/alisa-kerschbaum-uva-253x371.jpeg" alt="Alisa Kerschbaum" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Board Member</p>
-          <p class="person-name">Alisa Kerschbaum</p>
-          <p class="person-affiliation">Research Grant Advisor — University of Amsterdam.</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> Global affairs, International Peace &amp; Security, Environmental security.</p>
-        </div>
-      </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/d200x250-3.jpeg" alt="Prof. Nicolas Blarel" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Board Member</p>
-          <p class="person-name">Prof. Nicolas Blarel</p>
-          <p class="person-affiliation">Associate Professor of International Relations and Director of Studies — Leiden University.</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> Foreign Policy Analysis, Politics of migration governance, International politics of South Asia.</p>
-        </div>
-      </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/r2sk57tg-400x400.jpg" alt="Prof. Antonio Calcara" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Board Member</p>
-          <p class="person-name">Prof. Antonio Calcara</p>
-          <p class="person-affiliation">Professor — Vrije Universiteit Brussels.</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> European Security and Defence, Defence Industry, Political Economy.</p>
-        </div>
-      </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/schmitt-olivier-2-213x320.jpg" alt="Prof. Olivier Schmitt" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Board Member</p>
-          <p class="person-name">Prof. Olivier Schmitt</p>
-          <p class="person-affiliation">Head of Research — Institute for Military Operations at the Royal Danish Defence College.</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> Military Operations, Alliances, Transformation.</p>
-        </div>
-      </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/jritvrpl-400x400.jpg" alt="Prof. Chiara Ruffa" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Board Member</p>
-          <p class="person-name">Prof. Chiara Ruffa</p>
-          <p class="person-affiliation">Professor of Political Science — Sciences Po, Center for International Studies (CERI).</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> Multilateralism on the ground, Peacekeeping, Civil-military relations, Political sociology, Fieldwork.</p>
-        </div>
-      </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/1071-07280937-s001tim-003-1-705x705.png" alt="Dr Tim Sweijs" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Board Member</p>
-          <p class="person-name">Dr Tim Sweijs</p>
-          <p class="person-affiliation">Senior Research Fellow — Netherlands’ War Studies Research Centre; Director of Research — The Hague Centre for Strategic Studies.</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> Warfare (past, present, future), Strategy, Coercion, Deterrence, Emerging technologies.</p>
-        </div>
-      </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/ejdus-photo-253x253.jpg" alt="Prof. Filip Ejdus" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Board Member</p>
-          <p class="person-name">Prof. Filip Ejdus</p>
-          <p class="person-affiliation">Professor of Security Studies — Faculty of Political Science, University of Belgrade.</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> Identity, memory, and emotions, International interventions, Civil-military relations, Security sector reform.</p>
-        </div>
-      </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/citations.jpeg" alt="Sarka Kolmasova" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Board Member</p>
-          <p class="person-name">Sarka Kolmasova</p>
-          <p class="person-affiliation">Deputy Head &amp; Assistant Professor — Department of International Relations and European Studies, Metropolitan University Prague.</p>
-          <p class="person-affiliation muted" style="margin-top: var(--space-2); font-size: var(--fs-xs); border-top: 1px solid var(--border); padding-top: var(--space-2);"><strong>Research themes:</strong> Norms, Military Interventions, Responsibility to Protect, Human Rights in International Politics.</p>
-        </div>
-      </article>
+      {%- endfor %}
     </div>
   </div>
 </section>
@@ -218,32 +42,16 @@ navKey: ""
   <div class="container">
     <h2 style="margin-bottom: var(--space-5);">Support Team</h2>
     <div class="people-grid">
+      {%- for person in board.support %}
       <article class="person">
-        <img class="person-photo" src="/assets/images/rsd25-cropped-348x332.jpg" alt="Dr Arthur PB Laudrain" loading="lazy">
+        <img class="person-photo" src="{{ person.photo }}" alt="{{ person.alt or person.name }}" loading="lazy">
         <div class="person-body">
-          <p class="person-role">Technology Coordinator</p>
-          <p class="person-name">Dr Arthur PB Laudrain</p>
-          <p class="person-affiliation">Arthur is responsible for most of the online logistics of the organisation. He is Team Lead and a Senior Researcher for Cyber Security at the Center for Security Studies at ETH Zurich. Arthur has been with us since 2017.</p>
+          <p class="person-role">{{ person.role }}</p>
+          <p class="person-name">{{ person.name }}</p>
+          <p class="person-affiliation">{{ person.bio | safe }}</p>
         </div>
       </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/helferich-portrait-college-3.jpeg" alt="Dr John NT Helferich" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Events Coordinator</p>
-          <p class="person-name">Dr John NT Helferich</p>
-          <p class="person-affiliation">John is your first point of contact. He is in charge of our email communications, and ensures smooth coordination between chairs and panel members, among other things. He is a DPhil candidate in International Relations at St. Antony's College, Oxford. John joined the Initiative in 2018.</p>
-        </div>
-      </article>
-
-      <article class="person">
-        <img class="person-photo" src="/assets/images/1659415900816.jpeg" alt="Eugenio Sanchez" loading="lazy">
-        <div class="person-body">
-          <p class="person-role">Communications Coordinator</p>
-          <p class="person-name">Eugenio Sanchez</p>
-          <p class="person-affiliation">Eugenio assists with the development of our communication strategy and the logistics of our events. He is a PhD candidate in International Relations at Sciences Po Paris. Eugenio joined the Initiative in 2023.</p>
-        </div>
-      </article>
+      {%- endfor %}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary

Replaces the 22 hand-edited `<article class="person">` blocks in `src/board.njk` with a single template that loops over a new `src/_data/board.json` file.

**No behaviour change.** The built `_site/board.html` is content-identical to before (verified with `diff -B` — only inter-article blank-line whitespace differs).

This is **Step 1 of 2** for replicating the NetSec member-bio Google Form pipeline on the EISS site, but for board members only:

- **This PR**: refactor only, so future work writes JSON, not Nunjucks.
- **Next PR**: Google Form → linked Sheet → `workflow_dispatch`-triggered sync script → opens a PR on `board-sync/auto` updating this same `board.json`. Roles (`Founding Director`, `Treasurer`, …) will be maintained in a small in-repo overlay so members can't change their own title.

### Why this is a useful refactor on its own

- The typo we just fixed (Filip Edjus → Ejdus) would now be a one-line JSON change instead of editing Nunjucks.
- The 207-line markup reduction makes future edits less error-prone (no more grepping for the right `<article>` block by image filename).
- `_data/board.json` is the same shape the Form sync will produce, so the next PR's review surface is small.

## Files

- **`src/_data/board.json`** *(new)* — 19 board members + 3 support team members, schema designed to match what the future sync script will output.
- **`src/board.njk`** *(modified, −207 / +15 lines net)* — the markup for one `<article>` block, looped twice (once for `board.members`, once for `board.support`).

## Test plan

- [ ] `npm install && npx @11ty/eleventy` builds cleanly
- [ ] `_site/board.html` renders all 22 people in the same order
- [ ] Visual spot-check on the deployed Pages preview: Founding Director / Treasurer / Secretary-General appear first; Filip Ejdus appears correctly spelt; support team has 3 entries with bio text (not research-themes block)
- [ ] No regressions on other pages (only `board.html` is rebuilt from changed inputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)