### PR TITLE
Drop stale src/legacy/ from .eleventyignore

### DIFF
--- a/.eleventyignore
+++ b/.eleventyignore
@@ -1,3 +1,2 @@
-src/legacy/
 src/assets/
 src/.well-known/


### PR DESCRIPTION
Trivial follow-up to #23 (which removed `src/legacy/`) and #24 (Mobirise binary). The directory is gone, so the ignore directive is dead config — harmless, but worth cleaning up while in flow.

Build verified locally: 46 HTML files, no change.