### PR TITLE
Restore 'Subscribe to our newsletter' link

### DIFF
--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -5,6 +5,7 @@ module.exports = {
     "The largest and most diverse European gathering of scholars and practitioners on security issues.",
   url: "https://eiss-europa.com",
   contactEmail: "contact@eiss-europa.com",
+  newsletterUrl: "https://eepurl.com/h40Gkr",
   social: {
     youtube: "https://www.youtube.com/channel/UCfdVczE8X2iDPsIaadtP57Q",
     twitter: "https://twitter.com/APB_Laudrain",

--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -37,6 +37,7 @@
           <li><a href="/initiative.html">The Initiative</a></li>
           <li><a href="/board.html">The People</a></li>
           <li><a href="/membership.html">Membership</a></li>
+          <li><a href="{{ site.newsletterUrl }}" target="_blank" rel="noopener">Newsletter</a></li>
           <li><a href="mailto:{{ site.contactEmail }}">Contact</a></li>
         </ul>
       </div>

--- a/src/index.njk
+++ b/src/index.njk
@@ -25,6 +25,8 @@ navKey: home
       <a class="btn btn-ghost" href="/initiative.html">About the initiative</a>
     </div>
     <p class="reveal reveal-delay-3" style="margin-top: var(--space-6); font-size: var(--fs-sm); color: hsl(0 0% 100% / 0.85);">
+      <a href="{{ site.newsletterUrl }}" target="_blank" rel="noopener" style="color: inherit;">Subscribe to our newsletter</a>
+      <span aria-hidden="true">&nbsp;·&nbsp;</span>
       <a href="{{ site.social.youtube }}" target="_blank" rel="noopener" style="color: inherit;">Follow our YouTube channel</a>
       <span aria-hidden="true">&nbsp;·&nbsp;</span>
       <a href="mailto:{{ site.contactEmail }}" style="color: inherit;">Contact us</a>


### PR DESCRIPTION
## Summary

Bug fix — the migration dropped the newsletter signup link that used to live on the homepage.

**Before (original Mobirise homepage):** prominent "Subscribe to our newsletter" button next to Contact, pointing at https://eepurl.com/h40Gkr (the EISS Mailchimp signup).

**After this PR:**

- **Hero "stay in touch" row** on `/` — gains a leading "Subscribe to our newsletter" link, before the existing YouTube + Contact entries.
- **Footer About column** — gains a "Newsletter" item between Membership and Contact, so the link is reachable from every page.

Plus `src/_data/site.js` gains a `newsletterUrl` field so the URL is defined once and reused.

## Test plan

- [x] Local build → 2 mentions in `_site/index.html` (hero + footer), 1 mention in every other page (footer)
- [x] URL is HTTPS (the original Mobirise export was HTTP)