### PR TITLE
SEO + social-meta integration (og:url, twitter, JSON-LD, default share image, sitemap directive)

### DIFF
--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -6,9 +6,17 @@ module.exports = {
   url: "https://eiss-europa.com",
   contactEmail: "contact@eiss-europa.com",
   newsletterUrl: "https://eepurl.com/h40Gkr",
+
+  // Default Open Graph / Twitter Card image, used whenever a page
+  // doesn't set its own `metaImage` in front-matter. 1200×630, lives
+  // at src/assets/images/index-meta.jpg.
+  defaultMetaImage: "/assets/images/index-meta.jpg",
+
   social: {
     youtube: "https://www.youtube.com/channel/UCfdVczE8X2iDPsIaadtP57Q",
-    twitter: "https://twitter.com/APB_Laudrain",
+    twitter: "https://twitter.com/EISSnetwork",
+    twitterHandle: "@EISSnetwork",
+    linkedin: "https://www.linkedin.com/company/eiss-europa/",
   },
   nav: [
     { href: "/", text: "Home", key: "home" },

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -17,14 +17,42 @@
   {% endif %}
   <link rel="shortcut icon" href="/assets/images/logo-eiss-cmjn-2.jpeg" type="image/x-icon">
 
+  {# Open Graph (Facebook, LinkedIn, Mastodon, Bluesky preview cards) #}
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="{{ site.title }}">
   <meta property="og:title" content="{{ title or site.fullName }}">
   <meta property="og:description" content="{{ description or site.description }}">
-  {% if metaImage %}<meta property="og:image" content="{{ site.url }}{{ metaImage }}">{% endif %}
+  <meta property="og:url" content="{{ site.url }}{{ redirectTo or page.url }}">
+  <meta property="og:image" content="{{ site.url }}{{ metaImage or site.defaultMetaImage }}">
+  <meta property="og:image:alt" content="{{ title or site.fullName }}">
+
+  {# Twitter / X Card #}
   <meta name="twitter:card" content="summary_large_image">
-  {% if metaImage %}<meta name="twitter:image" content="{{ site.url }}{{ metaImage }}">{% endif %}
   <meta name="twitter:title" content="{{ title or site.fullName }}">
+  <meta name="twitter:description" content="{{ description or site.description }}">
+  <meta name="twitter:image" content="{{ site.url }}{{ metaImage or site.defaultMetaImage }}">
+  {% if site.social.twitterHandle %}<meta name="twitter:site" content="{{ site.social.twitterHandle }}">{% endif %}
+
+  {# JSON-LD Organization schema — helps Google Knowledge Panel attach
+     name, logo, and verified social profiles to the eiss-europa.com
+     domain. Emitted on every page; search engines deduplicate. #}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "{{ site.fullName }}",
+    "alternateName": "{{ site.title }}",
+    "url": "{{ site.url }}/",
+    "logo": "{{ site.url }}/assets/images/logo-eiss-cmjn-2.jpeg",
+    "description": "{{ site.description }}",
+    "email": "{{ site.contactEmail }}",
+    "sameAs": [
+      "{{ site.social.twitter }}",
+      "{{ site.social.linkedin }}",
+      "{{ site.social.youtube }}"
+    ]
+  }
+  </script>
 
   <script>
     (function(){

--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Disallow: /cgi-bin
+
+Sitemap: https://eiss-europa.com/sitemap.xml


### PR DESCRIPTION
## Summary

Closes the SEO gaps identified during the survey. No design changes — purely `<head>`-side improvements.

### Before / after when sharing pages

| | Before | After |
|---|---|---|
| Share `/2026.html` on LinkedIn | ✅ works, but no `og:url` so URL guessing possible | ✅ works + explicit `og:url`, `twitter:description`, JSON-LD context |
| Share `/board.html` anywhere | ❌ no preview image (no `metaImage`) | ✅ falls back to default `/assets/images/index-meta.jpg` |
| Share a redirect page (`/ticket-home.html`) | OG URL would point at the redirect | OG URL points at the canonical destination `/2026.html` |
| Google "EISS" → Knowledge Panel | Can't auto-attach socials to the domain | JSON-LD Organization with `sameAs: [Twitter, LinkedIn, YouTube]` |
| Crawler discovers the sitemap | Has to guess `/sitemap.xml` | `robots.txt` explicitly declares it |

### What changed

- `src/_data/site.js` — `defaultMetaImage`, switched `social.twitter` from `@APB_Laudrain` (personal) to `@EISSnetwork` (official), added `social.linkedin`.
- `src/_layouts/base.njk` — added `og:url`, `og:image:alt`, default-fallback `og:image` + `twitter:image`, `twitter:description`, `twitter:site`, full JSON-LD Organization block.
- `src/robots.txt` — added `Sitemap:` directive.

### What this PR deliberately doesn't touch

- **`apple-touch-icon`, `manifest.webmanifest`, real favicon**: requires generating 180×180 / 192×192 / 512×512 PNG variants. Better as its own focused PR with art-direction.
- **Per-page custom OG images for the 9 pages without one**: the fallback fixes the breakage; bespoke share cards are a nice-to-have later.

### Verified locally

- All four new meta tags present on every page
- `board.html` (no front-matter `metaImage`) → falls back to `/assets/images/index-meta.jpg`
- `ticket-home.html` (a redirect) → `og:url` points at `/2026.html`, not at itself
- JSON-LD parses as valid Schema.org Organization

🤖 Generated with [Claude Code](https://claude.com/claude-code)