### PR TITLE
Icons (1/N): add Lucide icon macro + apply to homepage — please review visually before merging

### DIFF
--- a/src/_includes/icons.njk
+++ b/src/_includes/icons.njk
@@ -1,0 +1,104 @@
+{#
+  Inline-SVG icon macro. Source: Lucide (https://lucide.dev, ISC licence).
+  Icons are 24×24 stroke-based, rendered inline at 1em (the surrounding
+  font-size) so they line up naturally with text.
+
+  USAGE
+    {% from "icons.njk" import icon %}
+    {{ icon("globe") }}                  → 1em globe
+    {{ icon("calendar", "icon-lg") }}    → 1.5em calendar
+    {{ icon("mail", "icon-inline") }}    → 1em + 0.25em right margin
+
+  SIZE CLASSES (defined in src/assets/css/site.css)
+    .icon         → 1em × 1em (default)
+    .icon-sm      → 0.875em
+    .icon-lg      → 1.5em
+    .icon-xl      → 2em
+    .icon-inline  → adds margin-right and vertical-align for inline use
+
+  SEMANTIC MAPPING
+    Concept                    → icon name
+    ─────────────────────────────────────
+    conference / international → "globe"
+    date / when                → "calendar"
+    location / venue / where   → "map-pin"
+    people / network           → "users"
+    one person                 → "user"
+    research / publication     → "book-open"
+    document / PDF / paper     → "file-text"
+    external link / outbound   → "external-link"
+    email                      → "mail"
+    YouTube                    → "youtube"
+    Twitter / X                → "twitter"
+    LinkedIn                   → "linkedin"
+    Newsletter / subscribe     → "bell"
+    Become a member            → "user-plus"
+    Manage / settings          → "settings"
+    Forward / CTA              → "arrow-right"
+    Download                   → "download"
+    Initiative / about         → "lightbulb"
+    Security / mission         → "shield"
+
+  HOW TO ADD A NEW ICON
+    1. Visit https://lucide.dev, search the name, click "Copy SVG".
+    2. Add a new {% elif name == "your-name" %} branch below.
+    3. Strip the <svg> wrapper from the copied SVG and paste only the
+       inner paths/circles — the wrapper is added by the macro so every
+       icon shares the same attributes and class.
+    4. Document the mapping above.
+#}
+
+{% macro icon(name, classes="icon") %}
+{%- set svgAttrs -%}
+class="{{ classes }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"
+{%- endset -%}
+{%- if name == "globe" -%}
+<svg {{ svgAttrs | safe }}><circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/></svg>
+{%- elif name == "calendar" -%}
+<svg {{ svgAttrs | safe }}><path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/></svg>
+{%- elif name == "map-pin" -%}
+<svg {{ svgAttrs | safe }}><path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"/><circle cx="12" cy="10" r="3"/></svg>
+{%- elif name == "users" -%}
+<svg {{ svgAttrs | safe }}><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+{%- elif name == "user" -%}
+<svg {{ svgAttrs | safe }}><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+{%- elif name == "user-plus" -%}
+<svg {{ svgAttrs | safe }}><path d="M2 21a8 8 0 0 1 13.292-6"/><circle cx="10" cy="8" r="5"/><path d="M19 16v6"/><path d="M22 19h-6"/></svg>
+{%- elif name == "book-open" -%}
+<svg {{ svgAttrs | safe }}><path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/></svg>
+{%- elif name == "file-text" -%}
+<svg {{ svgAttrs | safe }}><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>
+{%- elif name == "external-link" -%}
+<svg {{ svgAttrs | safe }}><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
+{%- elif name == "mail" -%}
+<svg {{ svgAttrs | safe }}><rect width="20" height="16" x="2" y="4" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
+{%- elif name == "youtube" -%}
+<svg {{ svgAttrs | safe }}><path d="M2.5 17a24.12 24.12 0 0 1 0-10 2 2 0 0 1 1.4-1.4 49.56 49.56 0 0 1 16.2 0A2 2 0 0 1 21.5 7a24.12 24.12 0 0 1 0 10 2 2 0 0 1-1.4 1.4 49.55 49.55 0 0 1-16.2 0A2 2 0 0 1 2.5 17"/><path d="m10 15 5-3-5-3z"/></svg>
+{%- elif name == "twitter" -%}
+<svg {{ svgAttrs | safe }}><path d="M22 4s-.7 2.1-2 3.4c1.6 10-9.4 17.3-18 11.6 2.2.1 4.4-.6 6-2C3 15.5.5 9.6 3 5c2.2 2.6 5.6 4.1 9 4-.9-4.2 4-6.6 7-3.8 1.1 0 3-1.2 3-1.2z"/></svg>
+{%- elif name == "linkedin" -%}
+<svg {{ svgAttrs | safe }}><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect width="4" height="12" x="2" y="9"/><circle cx="4" cy="4" r="2"/></svg>
+{%- elif name == "bell" -%}
+<svg {{ svgAttrs | safe }}><path d="M10.268 21a2 2 0 0 0 3.464 0"/><path d="M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326"/></svg>
+{%- elif name == "settings" -%}
+<svg {{ svgAttrs | safe }}><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+{%- elif name == "arrow-right" -%}
+<svg {{ svgAttrs | safe }}><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+{%- elif name == "download" -%}
+<svg {{ svgAttrs | safe }}><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+{%- elif name == "lightbulb" -%}
+<svg {{ svgAttrs | safe }}><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/></svg>
+{%- elif name == "shield" -%}
+<svg {{ svgAttrs | safe }}><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/></svg>
+{%- elif name == "play-circle" -%}
+<svg {{ svgAttrs | safe }}><circle cx="12" cy="12" r="10"/><polygon points="10 8 16 12 10 16 10 8"/></svg>
+{%- elif name == "graduation-cap" -%}
+<svg {{ svgAttrs | safe }}><path d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z"/><path d="M22 10v6"/><path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5"/></svg>
+{%- elif name == "award" -%}
+<svg {{ svgAttrs | safe }}><path d="m15.477 12.89 1.515 8.526a.5.5 0 0 1-.81.47l-3.58-2.687a1 1 0 0 0-1.197 0l-3.586 2.686a.5.5 0 0 1-.81-.469l1.514-8.526"/><circle cx="12" cy="8" r="6"/></svg>
+{%- elif name == "users-round" -%}
+<svg {{ svgAttrs | safe }}><path d="M18 21a8 8 0 0 0-16 0"/><circle cx="10" cy="8" r="5"/><path d="M22 20c0-3.37-2-6.5-4-8a5 5 0 0 0-.45-8.3"/></svg>
+{%- else -%}
+<!-- icons.njk: unknown icon name {{ name | e }} — add it to src/_includes/icons.njk -->
+{%- endif -%}
+{% endmacro %}

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -241,6 +241,29 @@ h4 { font-size: var(--fs-lg); }
   color: var(--text);
 }
 
+/* ---------- inline icons (Lucide via src/_includes/icons.njk) ---------- */
+/* All icons render in the surrounding font colour via stroke="currentColor",
+   so they automatically work in light + dark themes and inherit link colours.
+   Sizes are em-relative so they scale with the surrounding text. */
+.icon {
+  width: 1em;
+  height: 1em;
+  vertical-align: -0.125em;
+  display: inline-block;
+  flex-shrink: 0;
+}
+.icon-sm { width: 0.875em; height: 0.875em; }
+.icon-lg { width: 1.5em; height: 1.5em; vertical-align: -0.3em; }
+.icon-xl { width: 2em; height: 2em; vertical-align: -0.4em; }
+.icon-inline {
+  width: 1em;
+  height: 1em;
+  vertical-align: -0.15em;
+  margin-right: 0.4em;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
 /* ---------- skip link ---------- */
 .skip-link {
   position: absolute;

--- a/src/index.njk
+++ b/src/index.njk
@@ -6,6 +6,7 @@ description: We are the largest and most diverse European gathering of scholars 
 metaImage: /assets/images/index-meta.jpg
 navKey: home
 ---
+{% from "icons.njk" import icon %}
 
 <section class="hero" aria-labelledby="hero-title">
   <div class="hero-bg" aria-hidden="true">
@@ -25,11 +26,11 @@ navKey: home
       <a class="btn btn-ghost" href="/initiative.html">About the initiative</a>
     </div>
     <p class="reveal reveal-delay-3" style="margin-top: var(--space-6); font-size: var(--fs-sm); color: hsl(0 0% 100% / 0.85);">
-      <a href="{{ site.newsletterUrl }}" target="_blank" rel="noopener" style="color: inherit;">Subscribe to our newsletter</a>
+      <a href="{{ site.newsletterUrl }}" target="_blank" rel="noopener" style="color: inherit;">{{ icon("bell", "icon-inline") }}Subscribe to our newsletter</a>
       <span aria-hidden="true">&nbsp;·&nbsp;</span>
-      <a href="{{ site.social.youtube }}" target="_blank" rel="noopener" style="color: inherit;">Follow our YouTube channel</a>
+      <a href="{{ site.social.youtube }}" target="_blank" rel="noopener" style="color: inherit;">{{ icon("youtube", "icon-inline") }}Follow our YouTube channel</a>
       <span aria-hidden="true">&nbsp;·&nbsp;</span>
-      <a href="mailto:{{ site.contactEmail }}" style="color: inherit;">Contact us</a>
+      <a href="mailto:{{ site.contactEmail }}" style="color: inherit;">{{ icon("mail", "icon-inline") }}Contact us</a>
     </p>
   </div>
 </section>
@@ -46,11 +47,11 @@ navKey: home
         </p>
         <div class="featured-meta">
           <div>
-            <strong>Dates</strong>
+            <strong>{{ icon("calendar", "icon-inline") }}Dates</strong>
             11 — 12 June 2026
           </div>
           <div>
-            <strong>Venue</strong>
+            <strong>{{ icon("map-pin", "icon-inline") }}Venue</strong>
             Stockholm University
           </div>
         </div>


### PR DESCRIPTION
## ⚠️ Visual review needed — do **not** auto-merge

Per our earlier discussion, this is the first preview cycle of the icon overhaul. Eyeball it on a real browser before merging, then we iterate.

## What I tried to do for you

I attempted to screenshot the rendered homepage with the preview MCP, but the tool is sandboxed to a stale worktree path I can't escape from inside this session. Two ways for you to preview:

- **Locally**: `git fetch && git checkout claude/icons-foundation && npm install && npx @11ty/eleventy --serve` then visit http://localhost:8080/
- **Deployed preview**: if GitHub Pages builds the branch, it'll appear under the Actions tab — otherwise merging into a `preview` branch would work.

(Apologies for the lack of screenshot — I'll figure out the preview-server CWD issue before the next icon PR.)

## Summary

Foundation only — establishes the icon system without re-icing every page.

### Files

- **`src/_includes/icons.njk`** *(new)* — Nunjucks `icon` macro emitting inline SVG. Built around [Lucide](https://lucide.dev) (ISC, 1400+ icons, 24×24 stroke-based). ~23 icons embedded so far; full list + semantic-concept mapping in the file's header docblock.

  Usage:
  ```njk
  {% raw %}{% from "icons.njk" import icon %}
  {{ icon("globe") }}                  → 1em globe
  {{ icon("mail", "icon-inline") }}    → 1em + right margin
  {{ icon("calendar", "icon-lg") }}    → 1.5em calendar{% endraw %}
  ```

- **`src/assets/css/site.css`** — adds `.icon`, `.icon-sm`, `.icon-lg`, `.icon-xl`, `.icon-inline` classes. Sizes in `em` units so icons scale with surrounding text; colour inherited via `stroke="currentColor"` (works in both light + dark themes).

- **`src/index.njk`** — homepage gets icons applied to:
  - Hero stay-in-touch row: 🔔 Newsletter / ▶ YouTube / ✉ Contact
  - Featured ESSC 2026 card: 📅 Dates / 📍 Venue
  
  (The emoji above are illustrative — actual output is consistent inline Lucide SVGs in `currentColor`.)

## What this PR deliberately *doesn't* do yet — needs your input

- **Conference page (2026.njk + archive years)** — single-letter venue badges (S/G/T/Ö/St for Stockholm neighbourhoods) need a design call before I touch them: replace with map-pin (loses neighbourhood differentiation) or keep the letters and add map-pin alongside?
- **Tile icons on other pages** (events, initiative, JPW*, membership, Ukraine, coercion) — same question, per page.
- **Buttons (`.btn`)** — icons inside buttons need their own micro-styling pass.
- **Footer social links** — would benefit from icons but bundled with a separate "social links in footer" PR.

Will pick these up in follow-up PRs once you've eyeballed the homepage choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)