### PR TITLE
Icons: tune sizing down (1em → 0.875em, stroke 2 → 1.75)

### DIFF
--- a/src/_includes/icons.njk
+++ b/src/_includes/icons.njk
@@ -50,7 +50,7 @@
 
 {% macro icon(name, classes="icon") %}
 {%- set svgAttrs -%}
-class="{{ classes }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"
+class="{{ classes }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"
 {%- endset -%}
 {%- if name == "globe" -%}
 <svg {{ svgAttrs | safe }}><circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/></svg>

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -244,22 +244,28 @@ h4 { font-size: var(--fs-lg); }
 /* ---------- inline icons (Lucide via src/_includes/icons.njk) ---------- */
 /* All icons render in the surrounding font colour via stroke="currentColor",
    so they automatically work in light + dark themes and inherit link colours.
-   Sizes are em-relative so they scale with the surrounding text. */
+   Sizes are em-relative so they scale with the surrounding text.
+
+   Why we size icons at 0.875em (not 1em): a 1em icon fills the whole line-box
+   (cap height + descender), which makes it look heavier than the lowercase
+   letters around it — those only occupy the x-height. 0.875em brings the
+   icon's visual mass closer to the surrounding text. */
 .icon {
-  width: 1em;
-  height: 1em;
-  vertical-align: -0.125em;
+  width: 0.875em;
+  height: 0.875em;
+  vertical-align: -0.1em;
   display: inline-block;
   flex-shrink: 0;
 }
-.icon-sm { width: 0.875em; height: 0.875em; }
-.icon-lg { width: 1.5em; height: 1.5em; vertical-align: -0.3em; }
-.icon-xl { width: 2em; height: 2em; vertical-align: -0.4em; }
+.icon-sm { width: 0.75em; height: 0.75em; vertical-align: -0.05em; }
+.icon-md { width: 1em; height: 1em; vertical-align: -0.15em; }
+.icon-lg { width: 1.25em; height: 1.25em; vertical-align: -0.2em; }
+.icon-xl { width: 1.75em; height: 1.75em; vertical-align: -0.3em; }
 .icon-inline {
-  width: 1em;
-  height: 1em;
-  vertical-align: -0.15em;
-  margin-right: 0.4em;
+  width: 0.875em;
+  height: 0.875em;
+  vertical-align: -0.1em;
+  margin-right: 0.35em;
   display: inline-block;
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary

Bug fix for #28 — you reported the icons looked 'way too big'. Two adjustments:

1. **Size down**: `.icon-inline` / `.icon` go from `1em` (full line-box, matching cap height + descender) to `0.875em` (closer to the visual mass of lowercase x-height). All size variants tuned proportionally; added a new `.icon-md` for the rare case we *want* a 1em icon.
2. **Lighter stroke**: SVG `stroke-width` `2` → `1.75`. Lucide's default 2 is calibrated for system fonts; against Inter's regular weight it read as bold. 1.75 sits in the right zone.

Tightened the `vertical-align` values to match the new sizes so icons sit cleanly on the text baseline at every size.

## Verified locally with the preview MCP

| | Before (#28) | After (this PR) |
|---|---|---|
| Hero stay-in-touch icons | 15×15 px | 13×13 px |
| Featured-card meta icons | 13×13 px | 11×11 px |
| Stroke weight | 2.0 | 1.75 |

Both light and dark mode rendered, icons no longer dominate text.

## Screenshot
Captured locally — happy to re-screenshot in any specific mode/viewport if you want to inspect before merging.