### PR TITLE
Icons rollout: replace remaining letter tiles with semantic Lucide icons

### DIFF
--- a/src/2026.njk
+++ b/src/2026.njk
@@ -6,6 +6,7 @@ description: European Security Studies Conference, 11 — 12 June 2026 at Stockh
 metaImage: /assets/images/2026-meta.jpg
 navKey: conferences
 ---
+{% from "icons.njk" import icon %}
 
 <section class="hero" aria-labelledby="hero-title-2026">
   <div class="hero-bg" aria-hidden="true">
@@ -128,7 +129,7 @@ navKey: conferences
       </p>
       <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(min(16rem, 100%), 1fr)); margin-block: var(--space-5) var(--space-6);">
         <article class="tile">
-          <div class="tile-icon" aria-hidden="true">S</div>
+          <div class="tile-icon" aria-hidden="true">{{ icon("map-pin") }}</div>
           <h3>Södermalm</h3>
           <p>
             Metros <strong>Hornstull</strong>, <strong>Zinkensdamm</strong>,
@@ -137,22 +138,22 @@ navKey: conferences
           </p>
         </article>
         <article class="tile">
-          <div class="tile-icon" aria-hidden="true">G</div>
+          <div class="tile-icon" aria-hidden="true">{{ icon("map-pin") }}</div>
           <h3>Gamla stan</h3>
           <p>The Old Town — Stockholm’s historic centre on its own small island.</p>
         </article>
         <article class="tile">
-          <div class="tile-icon" aria-hidden="true">T</div>
+          <div class="tile-icon" aria-hidden="true">{{ icon("map-pin") }}</div>
           <h3>T-centralen</h3>
           <p>Stockholm City station — the central transport hub.</p>
         </article>
         <article class="tile">
-          <div class="tile-icon" aria-hidden="true">Ö</div>
+          <div class="tile-icon" aria-hidden="true">{{ icon("map-pin") }}</div>
           <h3>Östermalmstorg</h3>
           <p>An elegant central district to the north-east.</p>
         </article>
         <article class="tile">
-          <div class="tile-icon" aria-hidden="true">St</div>
+          <div class="tile-icon" aria-hidden="true">{{ icon("map-pin") }}</div>
           <h3>Stadion</h3>
           <p>Near Stockholm’s 1912 Olympic Stadium — a short hop from the venue.</p>
         </article>

--- a/src/JPW2022.njk
+++ b/src/JPW2022.njk
@@ -5,6 +5,7 @@ title: Joint Policy Workshop 2022
 description: 2022 Joint Policy Workshop on Military Alliances and Challenges to the Use of Military Force — 9 November 2022, VUB Brussels School of Governance.
 navKey: ""
 ---
+{% from "icons.njk" import icon %}
 
 <header class="page-header">
   <div class="container">
@@ -45,7 +46,7 @@ navKey: ""
     <h2 style="margin-bottom: var(--space-5);">Format</h2>
     <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(min(20rem, 100%), 1fr));">
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">A</div>
+        <div class="tile-icon" aria-hidden="true">{{ icon("book-open") }}</div>
         <h3>An Academic Perspective</h3>
         <p>
           Selected scholars (4–6) presented their papers which were discussed by EU/NATO
@@ -53,7 +54,7 @@ navKey: ""
         </p>
       </article>
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">P</div>
+        <div class="tile-icon" aria-hidden="true">{{ icon("shield") }}</div>
         <h3>A Policymakers' Perspective</h3>
         <p>
           Four policymakers provided a ten-minute pitch each, and their presentations were then

--- a/src/JPW23.njk
+++ b/src/JPW23.njk
@@ -5,6 +5,7 @@ title: Joint Policy Workshop 2023
 description: 2023 Joint Policy Workshop — EISS, NATO Defence College, and the Centre for Security, Diplomacy and Strategy at the Brussels School of Governance.
 navKey: ""
 ---
+{% from "icons.njk" import icon %}
 
 <header class="page-header">
   <div class="container">
@@ -35,7 +36,7 @@ navKey: ""
   <div class="container">
     <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(min(20rem, 100%), 1fr));">
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">A</div>
+        <div class="tile-icon" aria-hidden="true">{{ icon("book-open") }}</div>
         <h3>An Academic Perspective</h3>
         <p>
           Selected scholars (4–6) presented their papers which were discussed by EU/NATO
@@ -43,7 +44,7 @@ navKey: ""
         </p>
       </article>
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">P</div>
+        <div class="tile-icon" aria-hidden="true">{{ icon("shield") }}</div>
         <h3>A Policymakers' Perspective</h3>
         <p>
           Four policymakers provided a ten-minute pitch each, and their presentations were then

--- a/src/Ukraine.njk
+++ b/src/Ukraine.njk
@@ -6,6 +6,7 @@ description: Joint Conference on the War in Ukraine — Lessons Learned and the 
 metaImage: /assets/images/Ukraine-meta.jpg
 navKey: ""
 ---
+{% from "icons.njk" import icon %}
 
 <header class="page-header">
   <div class="container">
@@ -47,7 +48,7 @@ navKey: ""
     <h2 style="margin-bottom: var(--space-5);">Format — two roundtables</h2>
     <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(min(20rem, 100%), 1fr));">
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">1</div>
+        <div class="tile-icon" aria-hidden="true">{{ icon("shield") }}</div>
         <h3>Military lessons learned</h3>
         <p>
           The first roundtable focused on the key military lessons learned from the analysis of
@@ -56,7 +57,7 @@ navKey: ""
         </p>
       </article>
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">2</div>
+        <div class="tile-icon" aria-hidden="true">{{ icon("users-round") }}</div>
         <h3>Future political settlement</h3>
         <p>
           The second roundtable examined the prospects for a future political settlement between

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -1225,11 +1225,20 @@ h4 { font-size: var(--fs-lg); }
   background: var(--accent-soft);
   display: grid;
   place-items: center;
-  /* Use the darker accent for the icon text so a small badge meets 4.5:1
-     against the very pale accent-soft background. */
+  /* Use the darker accent for the icon text/glyph so a small badge meets
+     4.5:1 against the very pale accent-soft background. SVG icons inherit
+     this via stroke="currentColor". */
   color: var(--accent-hover);
   margin-bottom: var(--space-3);
   font-weight: 700;
+}
+
+/* Inline-SVG icons rendered inside a .tile-icon badge override the em-
+   relative .icon sizing — they should fill the badge consistently
+   regardless of the surrounding font-size. */
+.tile-icon svg {
+  width: 22px;
+  height: 22px;
 }
 
 .tile h2,

--- a/src/coercion.njk
+++ b/src/coercion.njk
@@ -6,6 +6,7 @@ description: A multiannual and multidisciplinary programme on the conditions for
 metaImage: /assets/images/coercion-meta.jpg
 navKey: programmes
 ---
+{% from "icons.njk" import icon %}
 
 <header class="page-header">
   <div class="container">
@@ -83,12 +84,12 @@ navKey: programmes
 
     <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(min(20rem, 100%), 1fr)); margin-block: var(--space-6);">
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">G</div>
+        <div class="tile-icon" aria-hidden="true">{{ icon("shield") }}</div>
         <h3>From Gunboat Diplomacy to Digital Control</h3>
         <p>Coercion has evolved, adapting to opportunities and limitations afforded by the Age.</p>
       </article>
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">R</div>
+        <div class="tile-icon" aria-hidden="true">{{ icon("globe") }}</div>
         <h3>Regional Variation and Multidomain Tactics</h3>
         <p>
           Interstate coercion has been on the uptick since the 2010s, yet with remarkable

--- a/src/events.njk
+++ b/src/events.njk
@@ -5,6 +5,7 @@ title: Members' Events
 description: Online and hybrid events organised by EISS members — roundtables, early-career seminars, and doctoral training workshops.
 navKey: ""
 ---
+{% from "icons.njk" import icon %}
 
 <header class="page-header">
   <div class="container">
@@ -21,7 +22,7 @@ navKey: ""
   <div class="container">
     <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));">
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">R</div>
+        <div class="tile-icon" aria-hidden="true">{{ icon("users-round") }}</div>
         <h2>Roundtables &amp; Conferences</h2>
         <p>
           Online and hybrid events organised by EISS members with guests from academia and/or
@@ -32,7 +33,7 @@ navKey: ""
       </article>
 
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">E</div>
+        <div class="tile-icon" aria-hidden="true">{{ icon("graduation-cap") }}</div>
         <h2>Early Career Seminars</h2>
         <p>
           Online and hybrid seminars organised by PhD students or early career academics to share
@@ -43,7 +44,7 @@ navKey: ""
       </article>
 
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">D</div>
+        <div class="tile-icon" aria-hidden="true">{{ icon("book-open") }}</div>
         <h2>Doctoral Training Workshops</h2>
         <p>
           Online and hybrid workshops organised by members of EISS, intended and tailored for

--- a/src/initiative.njk
+++ b/src/initiative.njk
@@ -5,6 +5,7 @@ title: The Initiative
 description: The European Initiative for Security Studies (EISS) is a Europe-wide multidisciplinary network of scholars consolidating security studies in Europe.
 navKey: initiative
 ---
+{% from "icons.njk" import icon %}
 
 <header class="page-header">
   <div class="container">
@@ -25,7 +26,7 @@ navKey: initiative
 
     <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr)); margin-block: var(--space-7);">
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">N</div>
+        <div class="tile-icon" aria-hidden="true">{{ icon("users-round") }}</div>
         <h2>Creating a Network</h2>
         <p>
           To develop and sustain a Europe-wide network in the field of security studies. This gives
@@ -34,7 +35,7 @@ navKey: initiative
         </p>
       </article>
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">P</div>
+        <div class="tile-icon" aria-hidden="true">{{ icon("globe") }}</div>
         <h2>Creating a Platform</h2>
         <p>
           To establish a forum for the exchange of ideas in order to foster new joint research

--- a/src/membership.njk
+++ b/src/membership.njk
@@ -6,6 +6,7 @@ description: Join the EISS community and get exclusive access to our online and 
 navKey: membership
 metaImage: /assets/images/membership-meta.jpg
 ---
+{% from "icons.njk" import icon %}
 
 <header class="page-header">
   <div class="container">
@@ -27,7 +28,7 @@ metaImage: /assets/images/membership-meta.jpg
 
     <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr)); margin-block: var(--space-6);">
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">∀</div>
+        <div class="tile-icon" aria-hidden="true">{{ icon("users-round") }}</div>
         <h3>Open to all</h3>
         <p>
           Early-career scholars, members of the armed forces, of diplomatic services, as well as
@@ -35,12 +36,12 @@ metaImage: /assets/images/membership-meta.jpg
         </p>
       </article>
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">M</div>
+        <div class="tile-icon" aria-hidden="true">{{ icon("lightbulb") }}</div>
         <h3>Multidisciplinary</h3>
         <p>History, political science, law, philosophy, economics, psychology, sociology, etc.</p>
       </article>
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">G</div>
+        <div class="tile-icon" aria-hidden="true">{{ icon("globe") }}</div>
         <h3>Geographically inclusive</h3>
         <p>
           Each year, the Annual Conference is organised on a rotational basis in a different


### PR DESCRIPTION
## Summary

Follow-up to #28 (foundation) and #29 (sizing fix). Replaces every single-letter tile badge across the site with a semantic Lucide icon. The letter mnemonics gave no shared visual vocabulary — 'G' meant Geographic in one place and Gunboat in another; 'P' meant Platform here and Policymaker there. Now each concept maps to the same icon everywhere it appears.

## Semantic mapping

| Concept | Icon | Pages using it |
|---|---|---|
| Location / venue | `map-pin` | 2026.njk (5×) |
| Network / community | `users-round` | events, initiative, Ukraine, membership |
| International / global | `globe` | initiative, coercion, membership |
| Academic / scholarship | `book-open` | events, JPW2022, JPW23 |
| Early career | `graduation-cap` | events |
| Security / policy | `shield` | JPW2022, JPW23, Ukraine, coercion |
| Multidisciplinary | `lightbulb` | membership |

## Per page

| Page | Before | After |
|---|---|---|
| `2026.njk` | S / G / T / Ö / St (5 Stockholm venues) | 5× `map-pin` (uniform per your direction) |
| `events.njk` | R / E / D | `users-round` / `graduation-cap` / `book-open` |
| `initiative.njk` | N / P | `users-round` / `globe` |
| `JPW2022.njk` | A / P | `book-open` / `shield` |
| `JPW23.njk` | A / P | `book-open` / `shield` |
| `Ukraine.njk` | 1 / 2 | `shield` / `users-round` |
| `coercion.njk` | G / R | `shield` / `globe` |
| `membership.njk` | ∀ / M / G | `users-round` / `lightbulb` / `globe` |

## CSS

- `src/assets/css/site.css` adds `.tile-icon svg { width: 22px; height: 22px; }` so the icon fills the 40×40 badge consistently regardless of surrounding font-size (the em-relative `.icon` class would otherwise shrink it).

## Verified locally with the preview MCP

Confirmed visually on `/2026.html`, `/membership.html`, `/initiative.html`, `/events.html` at 1280px viewport, light + dark modes. Icons render at 22px inside the existing accent-soft badge with proper WCAG contrast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)