### PR TITLE
v2.0.0 — Multilingual (FR + DE) plumbing + 3 PoC translated pages

### DIFF
--- a/.github/workflows/i18n-drift.yml
+++ b/.github/workflows/i18n-drift.yml
@@ -1,0 +1,37 @@
+# Translation-drift CI guard.
+#
+# Runs on every push and PR. Calls scripts/check-i18n-drift.py to verify
+# that every translation registered in data/i18n-state.json still matches
+# the SHA-1 of its English source. If a translation drifts (i.e. the
+# English source was edited without updating the translation), the job
+# fails — forcing either a re-translation or an explicit re-stamp via
+#   python3 scripts/check-i18n-drift.py --mark-fresh src/<page>.njk <lang>
+#
+# Per docs/i18n.md, re-stamping without translating is acceptable for
+# trivial source edits (typo fixes, link updates) — the maintainer just
+# accepts that the translation lags those minor changes until the next
+# real translation pass. Don't re-stamp on substantive content edits.
+
+name: i18n drift check
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    name: Verify translations match their English sources
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run drift checker
+        run: python3 scripts/check-i18n-drift.py

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -1,0 +1,47 @@
+{
+  "_documentation": "Translation drift state — tracks the SHA-1 of each English source .njk at the moment a translation was made. The CI workflow (.github/workflows/i18n-drift.yml) runs scripts/check-i18n-drift.py; if any recorded SHA does not match the current source SHA, the PR is blocked until either (a) the translation is updated and re-stamped, or (b) the source change is reverted. See docs/i18n.md for the full workflow.",
+  "translations": {
+    "src/index.njk": {
+      "fr": {
+        "file": "src/index.fr.njk",
+        "source_sha1": "97e55e16108e6fe23d4016b591168d5b14b937a9",
+        "translated_on": "2026-05-22",
+        "status": "beta"
+      },
+      "de": {
+        "file": "src/index.de.njk",
+        "source_sha1": "97e55e16108e6fe23d4016b591168d5b14b937a9",
+        "translated_on": "2026-05-22",
+        "status": "beta"
+      }
+    },
+    "src/initiative.njk": {
+      "fr": {
+        "file": "src/initiative.fr.njk",
+        "source_sha1": "95eb8ddd604bf975f4fe27d8c7b2f3a5de46bdd8",
+        "translated_on": "2026-05-22",
+        "status": "beta"
+      },
+      "de": {
+        "file": "src/initiative.de.njk",
+        "source_sha1": "95eb8ddd604bf975f4fe27d8c7b2f3a5de46bdd8",
+        "translated_on": "2026-05-22",
+        "status": "beta"
+      }
+    },
+    "src/membership.njk": {
+      "fr": {
+        "file": "src/membership.fr.njk",
+        "source_sha1": "5ddabe1b340a8c91409e3eca1752760fd1c62aa6",
+        "translated_on": "2026-05-22",
+        "status": "beta"
+      },
+      "de": {
+        "file": "src/membership.de.njk",
+        "source_sha1": "5ddabe1b340a8c91409e3eca1752760fd1c62aa6",
+        "translated_on": "2026-05-22",
+        "status": "beta"
+      }
+    }
+  }
+}

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,156 @@
+# EISS i18n — maintainer guide
+
+The EISS site ships three locale variants per translated page:
+
+| URL                              | Locale | Source                                         |
+|----------------------------------|--------|------------------------------------------------|
+| `/page.html`                     | EN     | `src/page.njk` — authoritative                 |
+| `/page.fr.html`                  | FR     | `src/page.fr.njk` — beta until reviewed        |
+| `/page.de.html`                  | DE     | `src/page.de.njk` — beta until reviewed        |
+
+This pattern is borrowed from [netsec-cost.eu](https://netsec-cost.eu) (`docs/i18n.md` upstream) and adapted to EISS's Eleventy/Nunjucks layout.
+
+## Quick reference
+
+| Task | Command / file |
+|---|---|
+| Check whether any translation has drifted | `python3 scripts/check-i18n-drift.py` |
+| Re-stamp a translation after re-translating | `python3 scripts/check-i18n-drift.py --mark-fresh src/<page>.njk <lang>` |
+| Translate chrome strings (nav, footer, buttons) | `src/_data/i18n.js` |
+| Translate a page's prose | duplicate `src/page.njk` → `src/page.fr.njk` (or `.de.njk`), translate, register in `data/i18n-state.json` |
+| Promote a beta translation to "reviewed" | flip `status` in `data/i18n-state.json` and drop `status: "beta"` from page front-matter |
+
+## How the system works
+
+### 1. Chrome strings — single catalog
+
+Nav labels, footer labels, buttons, theme-toggle aria text, beta-ribbon copy live in `src/_data/i18n.js`. The base layout sets `t = i18n[lang]` (where `lang` comes from page front-matter); every include reads `t.nav.home`, `t.footer.followUs`, etc.
+
+To add a chrome string: edit `src/_data/i18n.js`, add the key to **all three language objects** (`en`, `fr`, `de`), then use `{{ t.your.key }}` in the relevant template.
+
+### 2. Page prose — sibling `.njk` files
+
+For pages that need translation, the English source lives at `src/page.njk` and translated siblings at `src/page.fr.njk` / `src/page.de.njk`. Each sibling is a near-copy of the English file with the visible text translated and the front-matter adjusted:
+
+```yaml
+---
+layout: base.njk
+permalink: /page.fr.html
+title: <translated title>
+description: <translated description>
+metaImage: /assets/images/page-meta.jpg
+navKey: <same as EN>
+lang: fr
+status: beta
+alternates:
+  en: /page.html
+  fr: /page.fr.html
+  de: /page.de.html
+---
+```
+
+The `alternates` block on **all three** variants (EN, FR, DE) declares the URL of every locale's sibling. The base layout emits `<link rel="alternate" hreflang>` tags from this; the nav language switcher reads the same data to point at the right page when a user clicks FR / DE.
+
+### 3. Adding a new translation
+
+```
+# 1. Copy the English source
+cp src/membership.njk src/membership.fr.njk
+
+# 2. Edit src/membership.fr.njk:
+#    - change permalink to /membership.fr.html
+#    - change title + description to the translated values
+#    - add `lang: fr`, `status: beta`
+#    - add `alternates: { en: /…html, fr: /…fr.html, de: /…de.html }`
+#    - translate visible prose (DeepL Free is fine for the first pass)
+
+# 3. Also add `alternates: …` to src/membership.njk (the English source)
+#    if not already present.
+
+# 4. Register in data/i18n-state.json:
+#    "src/membership.njk": {
+#      "fr": {
+#        "file": "src/membership.fr.njk",
+#        "source_sha1": "…",
+#        "translated_on": "YYYY-MM-DD",
+#        "status": "beta"
+#      }
+#    }
+
+# 5. Stamp the SHA so CI passes
+python3 scripts/check-i18n-drift.py --mark-fresh src/membership.njk fr
+
+# 6. Build, screenshot the new page, ship the PR
+npx @11ty/eleventy --serve
+```
+
+### 4. The drift checker
+
+`scripts/check-i18n-drift.py` reads `data/i18n-state.json` and compares the recorded SHA-1 of each English source to the current SHA-1. Output:
+
+```
+SOURCE              LANG  STATUS  NOTE
+src/index.njk       fr    ✓ fresh 2026-05-22
+src/initiative.njk  fr    ! stale last: 2026-05-22
+src/policy.njk      de    ✗ missing  expected src/policy.de.njk
+```
+
+CI runs this on every push and PR (`.github/workflows/i18n-drift.yml`). A stale or missing translation blocks the PR until you either re-translate + re-stamp, or revert the source change.
+
+### 5. Refreshing after the English source changes
+
+When you edit `src/index.njk`, the next CI run will fail the drift check:
+
+```
+src/index.njk       fr    ! stale last: 2026-05-22
+src/index.njk       de    ! stale last: 2026-05-22
+```
+
+Two options:
+
+- **Substantive edit** — re-translate `index.fr.njk` and `index.de.njk` to match (DeepL, native speaker, etc.), then:
+  ```
+  python3 scripts/check-i18n-drift.py --mark-fresh src/index.njk fr
+  python3 scripts/check-i18n-drift.py --mark-fresh src/index.njk de
+  ```
+- **Trivial edit (typo, link, image swap)** — accept that the translations will lag for that detail. Either port the change quickly, or just re-stamp the SHA to silence CI:
+  ```
+  python3 scripts/check-i18n-drift.py --mark-fresh src/index.njk fr
+  python3 scripts/check-i18n-drift.py --mark-fresh src/index.njk de
+  ```
+  Use judgment — re-stamping without translating is a maintainer override, not the default workflow.
+
+### 6. Promoting a beta translation
+
+While `status: "beta"` is set on a page's front-matter, the yellow ribbon at the top of the page says "Beta translation — the English version is authoritative." This signals to users that the translation hasn't been reviewed by a native speaker.
+
+To promote to "reviewed":
+
+1. Drop `status: "beta"` from the page's front-matter (`src/page.fr.njk`).
+2. Update `data/i18n-state.json` for that page+lang: change `"status": "beta"` to `"status": "reviewed"` and add `"reviewed_by": "<name or initials>"`.
+3. The ribbon stops rendering. The drift checker continues to track the SHA as before.
+
+## Translation policy
+
+- **Chrome strings** (nav, footer, buttons): machine translation is fine; reviewed manually for tone.
+- **Page prose** (the visible content of each `.fr` / `.de` page): DeepL Free or Google Translate first pass + manual cleanup. Mark as `beta`.
+- **Legal pages** (privacy, T&C, accessibility): translate via DeepL for accessibility, but **the English version remains the legally binding text**. The beta ribbon notes this. A native-speaker legal review is required to promote to "reviewed".
+- **Names, dates, URLs, brand strings** (EISS, ESSC, Stripe, COST, NetSec): never translate.
+- **Member bios and other data files** (`src/_data/board.json`, `src/_data/panels2022.js`): stay in whichever language they were written in. Only the chrome around them gets translated.
+
+## What's currently translated
+
+Run `python3 scripts/check-i18n-drift.py` for the live answer. As of the initial v2.0.0 release:
+
+| Page | EN | FR | DE |
+|---|---|---|---|
+| `/index.html` | ✅ | ✅ beta | ✅ beta |
+| `/initiative.html` | ✅ | ✅ beta | ✅ beta |
+| `/membership.html` | ✅ | ✅ beta | ✅ beta |
+| All other pages | ✅ | — | — |
+
+Untranslated pages keep the language-switcher chips visible but routes FR/DE clicks to the language homepage (`/index.fr.html` or `/index.de.html`). Auto-redirect via the saved `localStorage.eiss-lang` only happens from EN → FR/DE when an alternate is declared in the page head.
+
+## Cost model
+
+Zero recurring cost. Translations are static `.njk` files committed to the repo. Translation tools used: any free machine-translation service (DeepL Free, Google Translate web UI) for the first pass, and native-speaker volunteers (board / membership) for reviews. Only the GitHub Actions runner minutes count, which the public-repo allowance covers.

--- a/scripts/check-i18n-drift.py
+++ b/scripts/check-i18n-drift.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Translation-drift checker for the EISS website.
+
+Ported from netsec.github.io/scripts/check-i18n-drift.py with paths
+adapted to EISS's Eleventy/Nunjucks layout (src/page.njk for English,
+src/page.fr.njk and src/page.de.njk for translations).
+
+Reads data/i18n-state.json, which records for every translated page
+the SHA-1 of the English source .njk file at the time the translation
+was made. Compares against the current SHA-1 of the English source and
+reports which translations are stale.
+
+No network calls. No API keys. Costs nothing to run.
+
+Workflow when a translation drifts
+----------------------------------
+  1. Open the English source (e.g. src/policy.njk) and the translated
+     sibling (e.g. src/policy.fr.njk) side by side.
+  2. Manually port the changes across — use any free tool
+     (DeepL Free, Google Translate, a native-speaker volunteer).
+  3. When done, refresh the `source_sha1` and `translated_on` fields
+     in data/i18n-state.json by running:
+        python3 scripts/check-i18n-drift.py --mark-fresh src/policy.njk fr
+
+Usage
+-----
+  python3 scripts/check-i18n-drift.py
+      → report drift (exit 0 fresh, 1 stale, 2 missing file)
+  python3 scripts/check-i18n-drift.py --mark-fresh <source> <lang>
+      → bless a refreshed translation
+"""
+from __future__ import annotations
+import argparse
+import hashlib
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+STATE = ROOT / "data" / "i18n-state.json"
+
+
+def sha1(path: Path) -> str:
+    """SHA-1 of a file's bytes. We hash the raw bytes (not a parsed
+    template tree) because we want any meaningful edit — including
+    markup, attribute, or front-matter changes — to be flagged for
+    review."""
+    h = hashlib.sha1()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(64 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load_state() -> dict:
+    return json.loads(STATE.read_text(encoding="utf-8"))
+
+
+def save_state(state: dict) -> None:
+    STATE.write_text(
+        json.dumps(state, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def report(state: dict) -> int:
+    """Print a status table. Return 0 if everything is fresh, 1 if
+    anything has drifted, 2 if a translated file is missing."""
+    exit_code = 0
+    rows: list[tuple[str, str, str, str]] = []
+    for src, langs in state.get("translations", {}).items():
+        src_path = ROOT / src
+        if not src_path.exists():
+            rows.append((src, "—", "missing", "English source not found"))
+            exit_code = max(exit_code, 2)
+            continue
+        current = sha1(src_path)
+        for lang, meta in langs.items():
+            tgt_path = ROOT / meta["file"]
+            if not tgt_path.exists():
+                rows.append((src, lang, "missing", f'expected {meta["file"]}'))
+                exit_code = max(exit_code, 2)
+                continue
+            recorded = meta.get("source_sha1", "")
+            if recorded == current:
+                rows.append((src, lang, "fresh", meta.get("translated_on", "?")))
+            else:
+                rows.append((src, lang, "stale", f'last: {meta.get("translated_on", "?")}'))
+                exit_code = max(exit_code, 1)
+
+    if not rows:
+        print("No translations registered in data/i18n-state.json.")
+        return 0
+
+    w_src = max(max(len(r[0]) for r in rows), len("SOURCE")) + 2
+    w_lang = max(max(len(r[1]) for r in rows), len("LANG")) + 2
+    w_status = max(max(len(r[2]) for r in rows), len("STATUS")) + 2
+    print(f'{"SOURCE":<{w_src}}{"LANG":<{w_lang}}{"STATUS":<{w_status}}NOTE')
+    print("-" * (w_src + w_lang + w_status + 40))
+    for src, lang, status, note in rows:
+        marker = {"fresh": "✓", "stale": "!", "missing": "✗"}.get(status, "·")
+        status_cell = f"{marker} {status}"
+        print(f'{src:<{w_src}}{lang:<{w_lang}}{status_cell:<{w_status}}{note}')
+
+    if exit_code == 0:
+        print("\nAll translations match their English sources.")
+    elif exit_code == 1:
+        print(
+            "\nSome translations have drifted. Re-translate the affected\n"
+            "pages, then run:\n"
+            "  python3 scripts/check-i18n-drift.py --mark-fresh <source> <lang>"
+        )
+    else:
+        print("\nERROR: at least one expected file is missing on disk.")
+    return exit_code
+
+
+def mark_fresh(state: dict, source: str, lang: str) -> int:
+    entry = state.get("translations", {}).get(source, {}).get(lang)
+    if entry is None:
+        print(f"ERROR: no entry for {source} / {lang} in i18n-state.json")
+        return 2
+    src_path = ROOT / source
+    tgt_path = ROOT / entry["file"]
+    if not src_path.exists() or not tgt_path.exists():
+        print(f"ERROR: source or target file missing for {source} / {lang}")
+        return 2
+    entry["source_sha1"] = sha1(src_path)
+    entry["translated_on"] = date.today().isoformat()
+    save_state(state)
+    print(f"Marked {entry['file']} as fresh against {source}.")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--mark-fresh",
+        nargs=2,
+        metavar=("SOURCE", "LANG"),
+        help='Record that the named translation has been refreshed against the current English source (e.g. "src/policy.njk fr").',
+    )
+    args = p.parse_args()
+    state = load_state()
+    if args.mark_fresh:
+        return mark_fresh(state, args.mark_fresh[0], args.mark_fresh[1])
+    return report(state)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/_data/i18n.js
+++ b/src/_data/i18n.js
@@ -1,0 +1,300 @@
+/**
+ * Multilingual string catalog for chrome + UI labels.
+ *
+ * Architecture overview
+ * ---------------------
+ * EISS ships three locale variants per translated page, using NetSec's
+ * file-suffix pattern:
+ *   /board.html       (English, authoritative)
+ *   /board.fr.html    (French,  beta until native-speaker review)
+ *   /board.de.html    (German,  beta until native-speaker review)
+ *
+ * Page prose lives in those per-locale .njk files (src/board.fr.njk etc.).
+ * THIS file holds the chrome strings — nav labels, footer labels, buttons,
+ * common UI — looked up from base.njk + includes via `{{ t.nav.home }}`
+ * style. Adding a new chrome string: add it under each language key here;
+ * surface it from a template with `{% set t = i18n[page.lang or "en"] %}`
+ * (already plumbed in base.njk).
+ *
+ * NOT translated here
+ * -------------------
+ * - Anything inside per-page .njk source — that goes in the page itself.
+ * - Anything inside src/_data/board.json — member bios stay in whichever
+ *   language the member submitted them (matches NetSec's approach).
+ * - Personal names, dates, URLs, ESSC / EISS / Stripe brand strings.
+ *
+ * Maintenance
+ * -----------
+ * - The English catalog is the source of truth.
+ * - When you add a key, ADD IT TO ALL THREE LANGUAGE OBJECTS. The drift
+ *   script (scripts/check-i18n-drift.py) doesn't validate this catalog
+ *   structure — that's a manual discipline.
+ * - The `betaRibbon` strings appear on every FR/DE page until a native
+ *   reviewer signs off and changes `status` in data/i18n-state.json.
+ */
+
+const locales = {
+  en: {
+    code: "en",
+    name: "English",
+    htmlLang: "en",
+    htmlNameInOwnLang: "English",
+
+    nav: {
+      home: "Home",
+      conferences: "Conferences",
+      programmes: "Programmes",
+      initiative: "The Initiative",
+      membership: "Membership",
+      events: "Events",
+      brandLabel: "EISS",
+    },
+    skipLink: "Skip to content",
+
+    themeToggle: {
+      switchToDark: "Switch to dark mode",
+      switchToLight: "Switch to light mode",
+    },
+
+    langSwitcher: {
+      label: "Language",
+      en: "EN",
+      fr: "FR",
+      de: "DE",
+      enTitle: "English",
+      frTitle: "Français (bêta)",
+      deTitle: "Deutsch (Beta)",
+    },
+
+    footer: {
+      tagline: "The largest and most diverse European gathering of scholars and practitioners on security issues.",
+      conferencesHeading: "Conferences",
+      programmesHeading: "Programmes",
+      aboutHeading: "About",
+      conferencesItems: {
+        c2026: "2026 — Stockholm",
+        c2025: "2025 — Thessaloniki",
+        c2024: "2024 — Prague",
+        allPast: "All past conferences",
+      },
+      programmesItems: {
+        netsec: "NetSec Summer School",
+        euroswamos: "Euro-SWAMOS",
+        coercion: "Coercive Statecraft",
+        globalRisks: "Global Risks Survey",
+      },
+      aboutItems: {
+        initiative: "The Initiative",
+        people: "The People",
+        membership: "Membership",
+        newsletter: "Newsletter",
+        contact: "Contact",
+      },
+      followUs: "Follow us",
+      socialLabel: {
+        linkedin: "EISS on LinkedIn",
+        twitter: "EISS on Twitter / X",
+        youtube: "EISS on YouTube",
+      },
+      copyright: "© Copyright 2018 — {{year}} European Initiative for Security Studies — All rights reserved | Tous droits réservés. Any third-party image and content remains the property of its owners as indicated in their respective description, unless specified otherwise below.",
+      imageCredits: "Euro-SWAMOS images © Marine Nationale, EEAS, État-Major des Armées, NATO CCDCOE. Prague image cc-by-2.0 Moyan Brenn. Barcelona image royalty-free stock photo (ID: 1795930126 Pajor Pawel).",
+      legalStatus: "EISS is a registered charity (W751263001) under French law. | L'EISS est une association loi 1901 enregistrée sous le numéro W751263001 au Répertoire National des Associations, et appartenant au champ de l'économie sociale et solidaire.",
+      legalLinks: {
+        terms: "Terms and Conditions",
+        privacy: "Privacy Policy",
+        accessibility: "Accessibility",
+        sitemap: "Site map",
+      },
+    },
+
+    betaRibbon: {
+      text: "Beta translation — the English version is authoritative.",
+      goToEnglish: "View in English",
+      // English never shows the ribbon, but the strings still need to
+      // exist for symmetry with fr/de.
+    },
+
+    untranslatedNotice: {
+      // Shown when the user lands on /something.fr.html for a page that
+      // doesn't actually have a French translation yet — they get
+      // redirected to the language homepage instead, with this banner.
+      text: "This page is not yet available in {{language}}. You're seeing the {{language}} home page; the original page is available in English.",
+      backToOriginal: "View the original page in English",
+    },
+  },
+
+  fr: {
+    code: "fr",
+    name: "French",
+    htmlLang: "fr",
+    htmlNameInOwnLang: "Français",
+
+    nav: {
+      home: "Accueil",
+      conferences: "Conférences",
+      programmes: "Programmes",
+      initiative: "L'Initiative",
+      membership: "Adhésion",
+      events: "Événements",
+      brandLabel: "EISS",
+    },
+    skipLink: "Aller au contenu",
+
+    themeToggle: {
+      switchToDark: "Passer au mode sombre",
+      switchToLight: "Passer au mode clair",
+    },
+
+    langSwitcher: {
+      label: "Langue",
+      en: "EN",
+      fr: "FR",
+      de: "DE",
+      enTitle: "English",
+      frTitle: "Français (bêta)",
+      deTitle: "Deutsch (Beta)",
+    },
+
+    footer: {
+      tagline: "Le plus grand et le plus divers rassemblement européen de chercheurs et praticiens sur les questions de sécurité.",
+      conferencesHeading: "Conférences",
+      programmesHeading: "Programmes",
+      aboutHeading: "À propos",
+      conferencesItems: {
+        c2026: "2026 — Stockholm",
+        c2025: "2025 — Thessalonique",
+        c2024: "2024 — Prague",
+        allPast: "Toutes les conférences passées",
+      },
+      programmesItems: {
+        netsec: "École d'été NetSec",
+        euroswamos: "Euro-SWAMOS",
+        coercion: "Coercition étatique",
+        globalRisks: "Sondage Global Risks",
+      },
+      aboutItems: {
+        initiative: "L'Initiative",
+        people: "L'équipe",
+        membership: "Adhésion",
+        newsletter: "Lettre d'information",
+        contact: "Contact",
+      },
+      followUs: "Suivez-nous",
+      socialLabel: {
+        linkedin: "EISS sur LinkedIn",
+        twitter: "EISS sur Twitter / X",
+        youtube: "EISS sur YouTube",
+      },
+      copyright: "© Copyright 2018 — {{year}} European Initiative for Security Studies — All rights reserved | Tous droits réservés. Toute image et tout contenu tiers restent la propriété de leurs détenteurs respectifs comme indiqué dans leur description, sauf mention contraire ci-dessous.",
+      imageCredits: "Images Euro-SWAMOS © Marine Nationale, EEAS, État-Major des Armées, OTAN CCDCOE. Image de Prague cc-by-2.0 Moyan Brenn. Image de Barcelone photo de stock libre de droits (ID : 1795930126 Pajor Pawel).",
+      legalStatus: "EISS is a registered charity (W751263001) under French law. | L'EISS est une association loi 1901 enregistrée sous le numéro W751263001 au Répertoire National des Associations, et appartenant au champ de l'économie sociale et solidaire.",
+      legalLinks: {
+        terms: "Conditions générales",
+        privacy: "Politique de confidentialité",
+        accessibility: "Accessibilité",
+        sitemap: "Plan du site",
+      },
+    },
+
+    betaRibbon: {
+      text: "Traduction bêta — la version anglaise fait foi.",
+      goToEnglish: "Voir en anglais",
+    },
+
+    untranslatedNotice: {
+      text: "Cette page n'est pas encore disponible en {{language}}. Vous voyez la page d'accueil en {{language}} ; la page originale est disponible en anglais.",
+      backToOriginal: "Voir la page originale en anglais",
+    },
+  },
+
+  de: {
+    code: "de",
+    name: "German",
+    htmlLang: "de",
+    htmlNameInOwnLang: "Deutsch",
+
+    nav: {
+      home: "Startseite",
+      conferences: "Konferenzen",
+      programmes: "Programme",
+      initiative: "Die Initiative",
+      membership: "Mitgliedschaft",
+      events: "Veranstaltungen",
+      brandLabel: "EISS",
+    },
+    skipLink: "Zum Inhalt springen",
+
+    themeToggle: {
+      switchToDark: "Zum dunklen Modus wechseln",
+      switchToLight: "Zum hellen Modus wechseln",
+    },
+
+    langSwitcher: {
+      label: "Sprache",
+      en: "EN",
+      fr: "FR",
+      de: "DE",
+      enTitle: "English",
+      frTitle: "Français (bêta)",
+      deTitle: "Deutsch (Beta)",
+    },
+
+    footer: {
+      tagline: "Die größte und vielfältigste europäische Versammlung von Wissenschaftlern und Praktikern zu Sicherheitsfragen.",
+      conferencesHeading: "Konferenzen",
+      programmesHeading: "Programme",
+      aboutHeading: "Über uns",
+      conferencesItems: {
+        c2026: "2026 — Stockholm",
+        c2025: "2025 — Thessaloniki",
+        c2024: "2024 — Prag",
+        allPast: "Alle vergangenen Konferenzen",
+      },
+      programmesItems: {
+        netsec: "NetSec Sommerschule",
+        euroswamos: "Euro-SWAMOS",
+        coercion: "Coercive Statecraft",
+        globalRisks: "Global Risks-Umfrage",
+      },
+      aboutItems: {
+        initiative: "Die Initiative",
+        people: "Die Personen",
+        membership: "Mitgliedschaft",
+        newsletter: "Newsletter",
+        contact: "Kontakt",
+      },
+      followUs: "Folgen Sie uns",
+      socialLabel: {
+        linkedin: "EISS auf LinkedIn",
+        twitter: "EISS auf Twitter / X",
+        youtube: "EISS auf YouTube",
+      },
+      copyright: "© Copyright 2018 — {{year}} European Initiative for Security Studies — All rights reserved | Tous droits réservés. Alle Drittanbieter-Bilder und -Inhalte bleiben das Eigentum ihrer jeweiligen Besitzer, wie in ihrer Beschreibung angegeben, sofern nicht anders unten vermerkt.",
+      imageCredits: "Euro-SWAMOS Bilder © Marine Nationale, EEAS, État-Major des Armées, NATO CCDCOE. Prag-Bild cc-by-2.0 Moyan Brenn. Barcelona-Bild lizenzfreies Stockfoto (ID: 1795930126 Pajor Pawel).",
+      legalStatus: "EISS is a registered charity (W751263001) under French law. | L'EISS est une association loi 1901 enregistrée sous le numéro W751263001 au Répertoire National des Associations, et appartenant au champ de l'économie sociale et solidaire.",
+      legalLinks: {
+        terms: "Allgemeine Geschäftsbedingungen",
+        privacy: "Datenschutzerklärung",
+        accessibility: "Barrierefreiheit",
+        sitemap: "Sitemap",
+      },
+    },
+
+    betaRibbon: {
+      text: "Beta-Übersetzung — die englische Version ist verbindlich.",
+      goToEnglish: "Auf Englisch anzeigen",
+    },
+
+    untranslatedNotice: {
+      text: "Diese Seite ist noch nicht auf {{language}} verfügbar. Sie sehen die {{language}}-Startseite; die Originalseite ist auf Englisch verfügbar.",
+      backToOriginal: "Originalseite auf Englisch ansehen",
+    },
+  },
+};
+
+// Languages we ship a switcher chip for, in display order.
+// Declared separately so templates can iterate without knowing the
+// internal locale object shape.
+const order = ["en", "fr", "de"];
+
+module.exports = Object.assign({ _order: order }, locales);

--- a/src/_includes/beta-ribbon.njk
+++ b/src/_includes/beta-ribbon.njk
@@ -1,0 +1,17 @@
+{# Beta-translation ribbon.
+   Rendered by base.njk only when the page's front-matter sets `status: "beta"`.
+   When a native speaker reviews and the page front-matter changes to
+   `status: "reviewed"`, the ribbon disappears with no other change.
+   Variables in scope (from base.njk):
+     - `t` — chrome catalog for the current locale
+     - `alternates.en` — URL of the English source (for the "view original" link)
+#}
+<div class="beta-ribbon" role="note" aria-label="{{ t.betaRibbon.text }}">
+  <div class="container beta-ribbon-inner">
+    <span class="beta-ribbon-badge" aria-hidden="true">β</span>
+    <span class="beta-ribbon-text">{{ t.betaRibbon.text }}</span>
+    {% if alternates and alternates.en %}
+      <a class="beta-ribbon-link" href="{{ alternates.en }}" hreflang="en">{{ t.betaRibbon.goToEnglish }}</a>
+    {% endif %}
+  </div>
+</div>

--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -1,4 +1,9 @@
+{# Footer consumes the active-locale catalog `t` from base.njk.
+   Brand+legal text is i18n'd, but link `href` values stay constant
+   (and where possible point at the appropriate-language sibling
+   when one exists). #}
 {% from "icons.njk" import icon %}
+{%- set langSuffix = "" if lang == "en" else "." + lang -%}
 <footer class="site-footer" role="contentinfo">
   <div class="container footer">
     <div class="footer-grid">
@@ -8,75 +13,70 @@
           <span>{{ site.fullName }}</span>
         </div>
         <p class="text-subtle">
-          The largest and most diverse European gathering of scholars and practitioners on security issues.
+          {{ t.footer.tagline }}
         </p>
       </div>
 
       <div>
-        <h2>Conferences</h2>
+        <h2>{{ t.footer.conferencesHeading }}</h2>
         <ul class="footer-list">
-          <li><a href="/2026.html">2026 — Stockholm</a></li>
-          <li><a href="/2025.html">2025 — Thessaloniki</a></li>
-          <li><a href="/2024.html">2024 — Prague</a></li>
-          <li><a href="/past.html">All past conferences</a></li>
+          <li><a href="/2026{{ langSuffix }}.html">{{ t.footer.conferencesItems.c2026 }}</a></li>
+          <li><a href="/2025{{ langSuffix }}.html">{{ t.footer.conferencesItems.c2025 }}</a></li>
+          <li><a href="/2024{{ langSuffix }}.html">{{ t.footer.conferencesItems.c2024 }}</a></li>
+          <li><a href="/past{{ langSuffix }}.html">{{ t.footer.conferencesItems.allPast }}</a></li>
         </ul>
       </div>
 
       <div>
-        <h2>Programmes</h2>
+        <h2>{{ t.footer.programmesHeading }}</h2>
         <ul class="footer-list">
-          <li><a href="/NetSecSchool.html">NetSec Summer School</a></li>
-          <li><a href="/euroswamos.html">Euro-SWAMOS</a></li>
-          <li><a href="/coercion.html">Coercive Statecraft</a></li>
-          <li><a href="/GlobalRisks.html">Global Risks Survey</a></li>
+          <li><a href="/NetSecSchool{{ langSuffix }}.html">{{ t.footer.programmesItems.netsec }}</a></li>
+          <li><a href="/euroswamos{{ langSuffix }}.html">{{ t.footer.programmesItems.euroswamos }}</a></li>
+          <li><a href="/coercion{{ langSuffix }}.html">{{ t.footer.programmesItems.coercion }}</a></li>
+          <li><a href="/GlobalRisks{{ langSuffix }}.html">{{ t.footer.programmesItems.globalRisks }}</a></li>
         </ul>
       </div>
 
       <div>
-        <h2>About</h2>
+        <h2>{{ t.footer.aboutHeading }}</h2>
         <ul class="footer-list">
-          <li><a href="/initiative.html">The Initiative</a></li>
-          <li><a href="/board.html">The People</a></li>
-          <li><a href="/membership.html">Membership</a></li>
-          <li><a href="{{ site.newsletterUrl }}" target="_blank" rel="noopener">Newsletter</a></li>
-          <li><a href="mailto:{{ site.contactEmail }}">Contact</a></li>
+          <li><a href="/initiative{{ langSuffix }}.html">{{ t.footer.aboutItems.initiative }}</a></li>
+          <li><a href="/board{{ langSuffix }}.html">{{ t.footer.aboutItems.people }}</a></li>
+          <li><a href="/membership{{ langSuffix }}.html">{{ t.footer.aboutItems.membership }}</a></li>
+          <li><a href="{{ site.newsletterUrl }}" target="_blank" rel="noopener">{{ t.footer.aboutItems.newsletter }}</a></li>
+          <li><a href="mailto:{{ site.contactEmail }}">{{ t.footer.aboutItems.contact }}</a></li>
         </ul>
       </div>
     </div>
 
-    <div class="footer-social" aria-label="Follow EISS on social media">
-      <span class="footer-social-label">Follow us</span>
-      <a class="footer-social-link" href="{{ site.social.linkedin }}" target="_blank" rel="noopener" aria-label="EISS on LinkedIn">
+    <div class="footer-social" aria-label="{{ t.footer.followUs }}">
+      <span class="footer-social-label">{{ t.footer.followUs }}</span>
+      <a class="footer-social-link" href="{{ site.social.linkedin }}" target="_blank" rel="noopener" aria-label="{{ t.footer.socialLabel.linkedin }}">
         {{ icon("linkedin") }}
       </a>
-      <a class="footer-social-link" href="{{ site.social.twitter }}" target="_blank" rel="noopener" aria-label="EISS on Twitter / X">
+      <a class="footer-social-link" href="{{ site.social.twitter }}" target="_blank" rel="noopener" aria-label="{{ t.footer.socialLabel.twitter }}">
         {{ icon("twitter") }}
       </a>
-      <a class="footer-social-link" href="{{ site.social.youtube }}" target="_blank" rel="noopener" aria-label="EISS on YouTube">
+      <a class="footer-social-link" href="{{ site.social.youtube }}" target="_blank" rel="noopener" aria-label="{{ t.footer.socialLabel.youtube }}">
         {{ icon("youtube") }}
       </a>
     </div>
 
     <div class="footer-fineprint">
       <p>
-        <em>© Copyright 2018 — {{ "" | year }} European Initiative for Security Studies — All rights reserved | Tous droits réservés.
-        Any third-party image and content remains the property of its owners as indicated in their respective description, unless specified otherwise below.</em>
+        <em>{{ t.footer.copyright | replace("{{year}}", "" | year) }}</em>
       </p>
       <p>
-        <em>Euro-SWAMOS images © Marine Nationale, EEAS, État-Major des Armées, NATO CCDCOE.<br>
-        Prague image cc-by-2.0 Moyan Brenn.<br>
-        Barcelona image royalty-free stock photo (ID: 1795930126 Pajor Pawel).</em>
+        <em>{{ t.footer.imageCredits }}</em>
       </p>
       <p>
-        EISS is a registered charity (W751263001) under French law. |
-        L'EISS est une association loi 1901 enregistrée sous le numéro W751263001
-        au Répertoire National des Associations, et appartenant au champ de l'économie sociale et solidaire.
+        {{ t.footer.legalStatus }}
       </p>
       <p>
-        <a href="/refund.html">Terms and Conditions</a> ·
-        <a href="/policy.html">Privacy Policy</a> ·
-        <a href="/accessibility.html">Accessibility</a> ·
-        <a href="/sitemap.html">Site map</a>
+        <a href="/refund{{ langSuffix }}.html">{{ t.footer.legalLinks.terms }}</a> ·
+        <a href="/policy{{ langSuffix }}.html">{{ t.footer.legalLinks.privacy }}</a> ·
+        <a href="/accessibility{{ langSuffix }}.html">{{ t.footer.legalLinks.accessibility }}</a> ·
+        <a href="/sitemap{{ langSuffix }}.html">{{ t.footer.legalLinks.sitemap }}</a>
       </p>
     </div>
   </div>

--- a/src/_includes/nav.njk
+++ b/src/_includes/nav.njk
@@ -1,19 +1,31 @@
+{# Nav consumes `t` (the active-locale chrome catalog) and `lang` from base.njk.
+   Nav-item href / key / external flag stay in src/_data/site.js;
+   only the visible text label is looked up from `t.nav.<key>`. #}
 <header class="site-header">
   <nav class="container nav" aria-label="Primary">
-    <a class="nav-brand" href="/" aria-label="EISS — {{ site.fullName }}, home">
+    <a class="nav-brand" href="{{ '/' if lang == 'en' else '/index.' + lang + '.html' }}" aria-label="EISS — {{ site.fullName }}, home">
       <span class="nav-brand-mark" aria-hidden="true">E</span>
-      <span>EISS</span>
+      <span>{{ t.nav.brandLabel }}</span>
     </a>
 
     <ul class="nav-links" id="primary-nav" data-nav-menu>
       {% for item in site.nav %}
         {% if item.key != "home" %}
+          {%- set itemHref = item.href -%}
+          {%- if not item.external and lang != "en" -%}
+            {# For translated pages, point at the .lang.html sibling.
+               `replace` is a no-op on URLs without `.html` (e.g. "/"
+               and external URLs). We don't validate existence here —
+               if a sibling is missing, the page's own beta banner (and
+               the lang-switcher fallback) handle the experience. #}
+            {%- set itemHref = item.href | replace(".html", "." + lang + ".html") -%}
+          {%- endif -%}
           <li>
             <a class="nav-link"
-               href="{{ item.href }}"
+               href="{{ itemHref }}"
                {% if item.external %}target="_blank" rel="noopener"{% endif %}
                {% if item.key == navKey %}aria-current="page"{% endif %}>
-              {{ item.text }}
+              {{ t.nav[item.key] }}
             </a>
           </li>
         {% endif %}
@@ -21,11 +33,25 @@
     </ul>
 
     <div class="nav-actions">
+      {# Language switcher chips. Always shows all 3; on untranslated
+         pages the FR/DE chip falls back to the language homepage
+         (the `alternates` lookup handles the difference). #}
+      <div class="lang-switcher" role="group" aria-label="{{ t.langSwitcher.label }}">
+        {% for L in i18n._order %}
+          {%- set href = alternates[L] if alternates and alternates[L] else ('/' if L == 'en' else '/index.' + L + '.html') -%}
+          <a class="lang-chip"
+             href="{{ href }}"
+             hreflang="{{ L }}"
+             {% if L == lang %}aria-current="true"{% endif %}
+             title="{{ t.langSwitcher[L + 'Title'] }}">{{ t.langSwitcher[L] }}</a>
+        {% endfor %}
+      </div>
+
       {% include "theme-toggle.njk" %}
       <button class="icon-btn nav-menu-toggle"
               type="button"
               data-menu-toggle
-              aria-label="Toggle navigation menu"
+              aria-label="{{ t.nav.brandLabel }} — menu"
               aria-controls="primary-nav"
               aria-expanded="false">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/src/_includes/theme-toggle.njk
+++ b/src/_includes/theme-toggle.njk
@@ -1,4 +1,4 @@
-<button class="icon-btn theme-toggle" type="button" data-theme-toggle aria-label="Switch theme">
+<button class="icon-btn theme-toggle" type="button" data-theme-toggle aria-label="{{ t.themeToggle.switchToDark }} / {{ t.themeToggle.switchToLight }}">
   <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
     <circle cx="12" cy="12" r="4"/>
     <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -1,5 +1,23 @@
+{# Resolve the active locale and its chrome catalog.
+   - `lang` comes from page front-matter (e.g. `lang: fr` on /index.fr.html).
+     Untranslated pages have no `lang`, so they default to English.
+   - `t` is the chrome catalog (nav labels, footer labels, UI strings).
+     Available to this template AND every included partial via Nunjucks
+     variable scoping. See src/_data/i18n.js for the full schema.
+   - `status` (page front-matter, only set on .fr / .de pages) is either
+     "beta" or "reviewed". Surfaced as a `data-i18n-status` attribute on
+     <html> so the beta ribbon (src/_includes/beta-ribbon.njk) can render
+     conditionally without a JS check. #}
+{# `lang` arrives as a top-level front-matter variable on translated pages
+   (e.g. `lang: fr` on /index.fr.html). Default to "en" when absent. Using
+   `_lang` so we don't clobber the front-matter value via `set`. #}
+{%- set _lang = lang or "en" -%}
+{%- set t = i18n[_lang] -%}
+{# Keep the `lang` variable usable downstream — make sure includes see
+   the resolved value, not `undefined` on EN pages. #}
+{%- set lang = _lang -%}
 <!doctype html>
-<html lang="en">
+<html lang="{{ lang }}"{% if status %} data-i18n-status="{{ status }}"{% endif %}>
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -15,6 +33,21 @@
   {% else %}
     <link rel="canonical" href="{{ site.url }}{{ page.url }}">
   {% endif %}
+
+  {# hreflang alternates. Only emitted when the page declares `alternates`
+     in its front-matter — most pages currently don't, and that's fine
+     (English-only pages don't need alternates). The shape is:
+       alternates:
+         en: /index.html
+         fr: /index.fr.html
+         de: /index.de.html  #}
+  {% if alternates %}
+    {%- for L in i18n._order -%}
+      {% if alternates[L] %}<link rel="alternate" hreflang="{{ L }}" href="{{ site.url }}{{ alternates[L] }}">{% endif %}
+    {%- endfor -%}
+    <link rel="alternate" hreflang="x-default" href="{{ site.url }}{{ alternates.en or page.url }}">
+  {% endif %}
+
   {# Favicon stack — SVG for modern browsers (any size, theme-tolerant),
      PNG fallbacks for legacy + iOS home-screen + Android PWA. Generated from
      src/assets/favicon.svg; sizes pinned to standard 32/16 (legacy),
@@ -32,6 +65,7 @@
   <meta property="og:title" content="{{ title or site.fullName }}">
   <meta property="og:description" content="{{ description or site.description }}">
   <meta property="og:url" content="{{ site.url }}{{ redirectTo or page.url }}">
+  <meta property="og:locale" content="{{ lang }}_{{ lang | upper }}">
   <meta property="og:image" content="{{ site.url }}{{ metaImage or site.defaultMetaImage }}">
   <meta property="og:image:alt" content="{{ title or site.fullName }}">
 
@@ -64,10 +98,30 @@
   </script>
 
   <script>
+    // 1) Restore the user's chosen theme (light/dark) before paint to
+    //    avoid a flash. 2) If the user has a language preference saved
+    //    and they're landing on the English page but a translation
+    //    exists, redirect to the translated version. Done in <head> so
+    //    it fires before the body renders. Never auto-redirects AWAY
+    //    from English unless an alternate is declared in the head —
+    //    English is the unfailable fallback.
     (function(){
       try {
-        var t = localStorage.getItem('eiss-theme');
-        if (t === 'light' || t === 'dark') document.documentElement.setAttribute('data-theme', t);
+        var theme = localStorage.getItem('eiss-theme');
+        if (theme === 'light' || theme === 'dark') {
+          document.documentElement.setAttribute('data-theme', theme);
+        }
+      } catch(_) {}
+
+      try {
+        var saved = localStorage.getItem('eiss-lang');
+        var current = document.documentElement.lang || 'en';
+        if (saved && saved !== current && current === 'en' && saved !== 'en') {
+          var alt = document.querySelector('link[rel="alternate"][hreflang="' + saved + '"]');
+          if (alt && alt.href && alt.href !== location.href) {
+            location.replace(alt.href);
+          }
+        }
       } catch(_) {}
     })();
   </script>
@@ -78,7 +132,9 @@
   <link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body>
-  <a class="skip-link" href="#main">Skip to content</a>
+  <a class="skip-link" href="#main">{{ t.skipLink }}</a>
+
+  {% if status == "beta" %}{% include "beta-ribbon.njk" %}{% endif %}
 
   {% include "nav.njk" %}
 
@@ -89,5 +145,15 @@
   {% include "footer.njk" %}
 
   <script src="/assets/js/theme.js" defer></script>
+  <script>
+    // Save the user's chosen language when they click a switcher chip,
+    // so subsequent visits to English pages can auto-redirect them.
+    document.addEventListener('click', function(e) {
+      var chip = e.target.closest('.lang-switcher a[hreflang]');
+      if (chip) {
+        try { localStorage.setItem('eiss-lang', chip.getAttribute('hreflang')); } catch(_) {}
+      }
+    });
+  </script>
 </body>
 </html>

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -270,6 +270,106 @@ h4 { font-size: var(--fs-lg); }
   flex-shrink: 0;
 }
 
+/* ---------- language switcher chips (EN / FR / DE) ---------- */
+.lang-switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  margin-right: var(--space-3);
+}
+
+.lang-chip {
+  padding: 4px 9px;
+  border-radius: 9999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  text-decoration: none;
+  line-height: 1;
+  transition: color var(--motion-fast) var(--ease-out),
+              background var(--motion-fast) var(--ease-out);
+}
+
+.lang-chip:hover {
+  color: var(--text);
+  background: var(--accent-soft);
+}
+
+.lang-chip[aria-current="true"] {
+  color: white;
+  background: var(--accent);
+}
+
+/* On narrow viewports the chips can wrap below the nav.
+   Hidden on the smallest mobile widths to keep the top bar tidy —
+   users can still switch via the footer or by editing the URL. */
+@media (max-width: 480px) {
+  .lang-switcher { display: none; }
+}
+
+/* ---------- beta-translation ribbon ---------- */
+/* Rendered by src/_includes/beta-ribbon.njk when page front-matter
+   sets status: "beta". Sits above the nav so it's the first thing
+   visible — matches NetSec's pattern. */
+.beta-ribbon {
+  background: hsl(45, 95%, 92%);
+  color: hsl(35, 85%, 22%);
+  border-bottom: 1px solid hsl(45, 70%, 75%);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-snug);
+}
+
+[data-theme="dark"] .beta-ribbon {
+  background: hsl(45, 35%, 18%);
+  color: hsl(45, 80%, 85%);
+  border-bottom-color: hsl(45, 40%, 28%);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .beta-ribbon {
+    background: hsl(45, 35%, 18%);
+    color: hsl(45, 80%, 85%);
+    border-bottom-color: hsl(45, 40%, 28%);
+  }
+}
+
+.beta-ribbon-inner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding-block: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.beta-ribbon-badge {
+  flex: none;
+  display: inline-grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: hsl(35, 85%, 50%);
+  color: white;
+  font-size: 12px;
+  font-weight: 800;
+  font-style: italic;
+}
+
+.beta-ribbon-text { flex: 1; }
+
+.beta-ribbon-link {
+  color: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+  white-space: nowrap;
+}
+
+.beta-ribbon-link:hover { text-decoration: none; }
+
 /* ---------- skip link ---------- */
 .skip-link {
   position: absolute;

--- a/src/index.de.njk
+++ b/src/index.de.njk
@@ -1,0 +1,139 @@
+---
+layout: base.njk
+permalink: /index.de.html
+title: false
+description: Wir sind die größte und vielfältigste europäische Versammlung von Wissenschaftlern und Praktikern zu Sicherheitsfragen.
+metaImage: /assets/images/index-meta.jpg
+navKey: home
+lang: de
+status: beta
+alternates:
+  en: /index.html
+  fr: /index.fr.html
+  de: /index.de.html
+---
+{% from "icons.njk" import icon %}
+
+<section class="hero" aria-labelledby="hero-title">
+  <div class="hero-bg" aria-hidden="true">
+    <img src="/assets/images/8e43301e-7945-4a0c-aac2-04719ac702a8-1600x900.jpg"
+         alt=""
+         loading="eager"
+         fetchpriority="high"
+         width="1600" height="900">
+  </div>
+  <div class="container hero-inner">
+    <h1 id="hero-title" class="reveal">Die Europäische Initiative für Sicherheitsstudien</h1>
+    <p class="hero-tagline reveal reveal-delay-1">
+      Die größte und vielfältigste europäische Versammlung von Wissenschaftlern und Praktikern zu Sicherheitsfragen.
+    </p>
+    <div class="hero-actions reveal reveal-delay-2">
+      <a class="btn btn-primary" href="/2026.de.html">ESSC 2026 entdecken {{ icon("arrow-right") }}</a>
+      <a class="btn btn-ghost" href="/initiative.de.html">Über die Initiative</a>
+    </div>
+    <p class="reveal reveal-delay-3" style="margin-top: var(--space-6); font-size: var(--fs-sm); color: hsl(0 0% 100% / 0.85);">
+      <a href="{{ site.newsletterUrl }}" target="_blank" rel="noopener" style="color: inherit;">{{ icon("bell", "icon-inline") }}Newsletter abonnieren</a>
+      <span aria-hidden="true">&nbsp;·&nbsp;</span>
+      <a href="{{ site.social.youtube }}" target="_blank" rel="noopener" style="color: inherit;">{{ icon("youtube", "icon-inline") }}Unserem YouTube-Kanal folgen</a>
+      <span aria-hidden="true">&nbsp;·&nbsp;</span>
+      <a href="mailto:{{ site.contactEmail }}" style="color: inherit;">{{ icon("mail", "icon-inline") }}Kontakt</a>
+    </p>
+  </div>
+</section>
+
+<section class="section" aria-labelledby="featured-title">
+  <div class="container">
+    <article class="card featured">
+      <div>
+        <div class="featured-eyebrow">Nächste Konferenz</div>
+        <h2 id="featured-title">European Security Conference 2026</h2>
+        <p class="featured-orgs">
+          Gemeinsam organisiert von der COST-Aktion NetSec, der Europäischen Initiative für Sicherheitsstudien (EISS)
+          und der Universität Stockholm.
+        </p>
+        <div class="featured-meta">
+          <div>
+            <strong>{{ icon("calendar", "icon-inline") }}Datum</strong>
+            11. — 12. Juni 2026
+          </div>
+          <div>
+            <strong>{{ icon("map-pin", "icon-inline") }}Ort</strong>
+            Universität Stockholm
+          </div>
+        </div>
+        <div>
+          <a class="btn btn-primary" href="/2026.de.html">Mehr über die ESSC&nbsp;2026 erfahren {{ icon("arrow-right") }}</a>
+        </div>
+      </div>
+      <aside class="featured-date" aria-hidden="true">
+        <div class="month">Juni</div>
+        <div class="day">11<span aria-hidden="true">–</span>12</div>
+        <div class="year">2026 · Stockholm</div>
+      </aside>
+    </article>
+  </div>
+</section>
+
+<section class="section-tight" aria-labelledby="news-title">
+  <div class="container">
+    <article class="card announcement">
+      <div>
+        <div class="announcement-eyebrow">Brüssel, 10. Oktober 2025</div>
+        <h2 id="news-title">EISS startet Großinitiative zur Vernetzung der europäischen Sicherheitsstudien</h2>
+        <p class="lead">
+          Dank der großzügigen Unterstützung der Organisation
+          <a href="https://www.cost.eu" target="_blank" rel="noopener">European Cooperation in Science and Technology</a>
+          (COST) startet EISS — gemeinsam mit einem Dutzend Institutionen in ganz Europa —
+          <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">„Networking European Security Knowledge“ (NetSec)</a>,
+          ein vierjähriges Programm zur Bewältigung der Fragmentierung der intellektuellen und
+          analytischen Basis des Kontinents im Bereich der Sicherheitsstudien.
+        </p>
+        <p>
+          Dr. Hugo Meijer, Gründungsdirektor von EISS, und Dr. Marie Robin, Schatzmeisterin von EISS,
+          fungieren als Vorsitzender bzw. stellvertretende Vorsitzende der NetSec-Aktion.
+        </p>
+
+        <blockquote class="pullquote">
+          „Der Start von NetSec ist ein großer Schritt in der Entwicklung von EISS und seinen Partnern.
+          Achten Sie auf politische Workshops, Sommerschulen und Konferenzen in den nächsten vier Jahren.“
+          <cite>— Dr. Hugo Meijer, Vorsitzender der NetSec-Aktion und Gründungsdirektor von EISS</cite>
+        </blockquote>
+
+        <div>
+          <a class="btn btn-secondary" href="https://netsec-cost.eu/" target="_blank" rel="noopener">
+            Mehr über NetSec erfahren {{ icon("external-link") }}
+          </a>
+        </div>
+      </div>
+
+      <figure class="announcement-figure">
+        <img src="/assets/images/1760518013943-1280x720.jpg"
+             alt="Mitglieder des NetSec-Managementkomitees bei der Auftaktveranstaltung in Brüssel."
+             loading="lazy"
+             width="1280" height="720">
+        <figcaption>
+          Mitglieder des NetSec-Managementkomitees bei der Auftaktveranstaltung in Brüssel —
+          Dr. Moritz Weiss (Leiter der WG1, oben) und Dr. Hugo Meijer (Vorsitzender der Aktion und Gründungsdirektor von EISS, unten).
+        </figcaption>
+      </figure>
+    </article>
+  </div>
+</section>
+
+<section class="section" aria-labelledby="join-title">
+  <div class="container">
+    <div class="join">
+      <h2 id="join-title">Werden Sie Mitglied</h2>
+      <p>
+        Mitglieder erhalten exklusiven Zugang zu unseren Online- und Hybrid-Veranstaltungen.
+        Tickets für unsere Jahreskonferenz beinhalten bereits eine einjährige Mitgliedschaft.
+      </p>
+      <div class="join-actions">
+        <a class="btn btn-primary" href="/membership.de.html#content19-b9">{{ icon("user-plus") }} Mitglied werden</a>
+        <a class="btn btn-secondary" href="https://billing.stripe.com/p/login/3cscOuaesfHceC4dQQ" target="_blank" rel="noopener">
+          Mitgliedschaft verwalten {{ icon("external-link") }}
+        </a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/index.fr.njk
+++ b/src/index.fr.njk
@@ -1,0 +1,139 @@
+---
+layout: base.njk
+permalink: /index.fr.html
+title: false
+description: Nous sommes le plus grand et le plus divers rassemblement européen de chercheurs et praticiens sur les questions de sécurité.
+metaImage: /assets/images/index-meta.jpg
+navKey: home
+lang: fr
+status: beta
+alternates:
+  en: /index.html
+  fr: /index.fr.html
+  de: /index.de.html
+---
+{% from "icons.njk" import icon %}
+
+<section class="hero" aria-labelledby="hero-title">
+  <div class="hero-bg" aria-hidden="true">
+    <img src="/assets/images/8e43301e-7945-4a0c-aac2-04719ac702a8-1600x900.jpg"
+         alt=""
+         loading="eager"
+         fetchpriority="high"
+         width="1600" height="900">
+  </div>
+  <div class="container hero-inner">
+    <h1 id="hero-title" class="reveal">L'Initiative européenne pour les études de sécurité</h1>
+    <p class="hero-tagline reveal reveal-delay-1">
+      Le plus grand et le plus divers rassemblement européen de chercheurs et praticiens sur les questions de sécurité.
+    </p>
+    <div class="hero-actions reveal reveal-delay-2">
+      <a class="btn btn-primary" href="/2026.fr.html">Découvrir l'ESSC 2026 {{ icon("arrow-right") }}</a>
+      <a class="btn btn-ghost" href="/initiative.fr.html">À propos de l'Initiative</a>
+    </div>
+    <p class="reveal reveal-delay-3" style="margin-top: var(--space-6); font-size: var(--fs-sm); color: hsl(0 0% 100% / 0.85);">
+      <a href="{{ site.newsletterUrl }}" target="_blank" rel="noopener" style="color: inherit;">{{ icon("bell", "icon-inline") }}S'abonner à notre lettre d'information</a>
+      <span aria-hidden="true">&nbsp;·&nbsp;</span>
+      <a href="{{ site.social.youtube }}" target="_blank" rel="noopener" style="color: inherit;">{{ icon("youtube", "icon-inline") }}Suivre notre chaîne YouTube</a>
+      <span aria-hidden="true">&nbsp;·&nbsp;</span>
+      <a href="mailto:{{ site.contactEmail }}" style="color: inherit;">{{ icon("mail", "icon-inline") }}Nous contacter</a>
+    </p>
+  </div>
+</section>
+
+<section class="section" aria-labelledby="featured-title">
+  <div class="container">
+    <article class="card featured">
+      <div>
+        <div class="featured-eyebrow">Prochaine conférence</div>
+        <h2 id="featured-title">European Security Conference 2026</h2>
+        <p class="featured-orgs">
+          Organisée conjointement par l'Action COST NetSec, l'Initiative européenne pour les études de sécurité (EISS),
+          et l'Université de Stockholm.
+        </p>
+        <div class="featured-meta">
+          <div>
+            <strong>{{ icon("calendar", "icon-inline") }}Dates</strong>
+            11 — 12 juin 2026
+          </div>
+          <div>
+            <strong>{{ icon("map-pin", "icon-inline") }}Lieu</strong>
+            Université de Stockholm
+          </div>
+        </div>
+        <div>
+          <a class="btn btn-primary" href="/2026.fr.html">En savoir plus sur l'ESSC&nbsp;2026 {{ icon("arrow-right") }}</a>
+        </div>
+      </div>
+      <aside class="featured-date" aria-hidden="true">
+        <div class="month">Juin</div>
+        <div class="day">11<span aria-hidden="true">–</span>12</div>
+        <div class="year">2026 · Stockholm</div>
+      </aside>
+    </article>
+  </div>
+</section>
+
+<section class="section-tight" aria-labelledby="news-title">
+  <div class="container">
+    <article class="card announcement">
+      <div>
+        <div class="announcement-eyebrow">Bruxelles, 10 octobre 2025</div>
+        <h2 id="news-title">EISS lance une initiative majeure pour mettre en réseau les études européennes de sécurité</h2>
+        <p class="lead">
+          Grâce au généreux soutien de l'organisation
+          <a href="https://www.cost.eu" target="_blank" rel="noopener">European Cooperation in Science and Technology</a>
+          (COST), EISS — aux côtés d'une douzaine d'institutions à travers l'Europe — lance
+          <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">« Networking European Security Knowledge » (NetSec)</a>,
+          un programme de quatre ans visant à remédier à la fragmentation de la base intellectuelle et
+          analytique du continent dans le domaine des études de sécurité.
+        </p>
+        <p>
+          Le Dr Hugo Meijer, directeur fondateur d'EISS, et la Dre Marie Robin, trésorière d'EISS,
+          assurent respectivement la présidence et la vice-présidence de l'Action NetSec.
+        </p>
+
+        <blockquote class="pullquote">
+          « Le lancement de NetSec représente une étape majeure dans le développement d'EISS et de ses partenaires.
+          Restez attentifs aux ateliers politiques, écoles d'été et conférences à venir au cours des quatre prochaines années. »
+          <cite>— Dr Hugo Meijer, président de l'Action NetSec et directeur fondateur d'EISS</cite>
+        </blockquote>
+
+        <div>
+          <a class="btn btn-secondary" href="https://netsec-cost.eu/" target="_blank" rel="noopener">
+            En savoir plus sur NetSec {{ icon("external-link") }}
+          </a>
+        </div>
+      </div>
+
+      <figure class="announcement-figure">
+        <img src="/assets/images/1760518013943-1280x720.jpg"
+             alt="Membres du comité de gestion NetSec lors du lancement à Bruxelles."
+             loading="lazy"
+             width="1280" height="720">
+        <figcaption>
+          Membres du comité de gestion NetSec lors de l'événement de lancement à Bruxelles —
+          Dr Moritz Weiss (responsable du WG1, en haut) et Dr Hugo Meijer (président de l'Action et directeur fondateur d'EISS, en bas).
+        </figcaption>
+      </figure>
+    </article>
+  </div>
+</section>
+
+<section class="section" aria-labelledby="join-title">
+  <div class="container">
+    <div class="join">
+      <h2 id="join-title">Rejoignez-nous</h2>
+      <p>
+        Les membres bénéficient d'un accès exclusif à nos événements en ligne et hybrides.
+        Les billets pour notre conférence annuelle incluent déjà une adhésion d'un an.
+      </p>
+      <div class="join-actions">
+        <a class="btn btn-primary" href="/membership.fr.html#content19-b9">{{ icon("user-plus") }} Devenir membre</a>
+        <a class="btn btn-secondary" href="https://billing.stripe.com/p/login/3cscOuaesfHceC4dQQ" target="_blank" rel="noopener">
+          Gérer mon adhésion {{ icon("external-link") }}
+        </a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/index.njk
+++ b/src/index.njk
@@ -5,6 +5,11 @@ title: false
 description: We are the largest and most diverse European gathering of scholars and practitioners on security issues.
 metaImage: /assets/images/index-meta.jpg
 navKey: home
+lang: en
+alternates:
+  en: /index.html
+  fr: /index.fr.html
+  de: /index.de.html
 ---
 {% from "icons.njk" import icon %}
 

--- a/src/initiative.de.njk
+++ b/src/initiative.de.njk
@@ -1,0 +1,158 @@
+---
+layout: base.njk
+permalink: /initiative.de.html
+title: Die Initiative
+description: Die Europäische Initiative für Sicherheitsstudien (EISS) ist ein europaweites multidisziplinäres Netzwerk von Wissenschaftlern zur Konsolidierung der Sicherheitsstudien in Europa.
+metaImage: /assets/images/initiative-meta.jpg
+navKey: initiative
+lang: de
+status: beta
+alternates:
+  en: /initiative.html
+  fr: /initiative.fr.html
+  de: /initiative.de.html
+---
+{% from "icons.njk" import icon %}
+
+<header class="page-header">
+  <div class="container">
+    <span class="eyebrow">Über uns</span>
+    <h1>Die Initiative</h1>
+    <p class="page-lead">
+      Die Europäische Initiative für Sicherheitsstudien (EISS) ist ein europaweites multidisziplinäres
+      Netzwerk von Wissenschaftlern, die das Ziel teilen, die Sicherheitsstudien in Europa zu konsolidieren.
+    </p>
+  </div>
+</header>
+
+<section class="section">
+  <div class="container">
+    <article class="prose">
+      <p>Konkret verfolgt EISS zwei Hauptziele:</p>
+    </article>
+
+    <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr)); margin-block: var(--space-7);">
+      <article class="tile">
+        <div class="tile-icon" aria-hidden="true">{{ icon("users-round") }}</div>
+        <h2>Ein Netzwerk aufbauen</h2>
+        <p>
+          Aufbau und Pflege eines europaweiten Netzwerks im Bereich der Sicherheitsstudien. Dadurch
+          erhalten die individuellen und kollektiven Forschungsprojekte, die derzeit in Europa und
+          darüber hinaus laufen, Sichtbarkeit.
+        </p>
+      </article>
+      <article class="tile">
+        <div class="tile-icon" aria-hidden="true">{{ icon("globe") }}</div>
+        <h2>Eine Plattform schaffen</h2>
+        <p>
+          Etablierung eines Forums für den Ideenaustausch, um neue gemeinsame Forschungsprojekte
+          zu fördern und internationale Forschungspartnerschaften aufzubauen.
+        </p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="section-tight" id="what-makes-us-unique">
+  <div class="container">
+    <article class="card" style="padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8));">
+      <h2>Was uns auszeichnet</h2>
+      <p class="lead">
+        EISS hat drei Hauptmerkmale: (1) thematisch orientiert und offen für alle theoretischen
+        Ansätze, (2) multidisziplinär und interdisziplinär, und (3) geografisch inklusiv.
+      </p>
+
+      <dl class="definition-list">
+        <div>
+          <dt>Offen für alle Ansätze</dt>
+          <dd>
+            EISS beschränkt sich nicht auf einen spezifischen theoretischen Ansatz der Sicherheitsstudien,
+            sondern strebt Inklusivität an. Dies spiegelt sich beispielsweise in den Panels der
+            EISS-Konferenz wider, die eine breite Palette von Themen aus dem weiten Feld der
+            Sicherheitsstudien abdecken. EISS begrüßt Beiträge sowohl zu sogenannten „traditionellen"
+            als auch „nicht-traditionellen" Sicherheitsfragen.
+          </dd>
+        </div>
+        <div>
+          <dt>Multidisziplinär</dt>
+          <dd>
+            EISS ist multidisziplinär und interdisziplinär, da hier unter anderem Historiker,
+            Politikwissenschaftler, Wirtschaftswissenschaftler, Geographen, Anthropologen und
+            Soziologen zusammenkommen, die ein gemeinsames Interesse an der Weiterentwicklung
+            der Sicherheitsstudien in Europa teilen.
+          </dd>
+        </div>
+        <div>
+          <dt>Geografisch inklusiv</dt>
+          <dd>
+            EISS strebt geografisch größtmögliche Inklusivität an und integriert Wissenschaftler
+            aus ganz Europa (Süd-, Ost-, Nord- und Westeuropa). Gleichzeitig begrüßt EISS Projekte
+            zu jeder Region der Welt. Jedes Jahr wird die Jahreskonferenz im Rotationsverfahren
+            in einem anderen europäischen Land organisiert.
+          </dd>
+        </div>
+        <div>
+          <dt>Offen für alle Hintergründe</dt>
+          <dd>
+            Nachwuchswissenschaftler, Angehörige der Streitkräfte, des diplomatischen Dienstes
+            sowie nationale und internationale Beamte sind alle willkommen.
+          </dd>
+        </div>
+      </dl>
+    </article>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <article class="prose">
+      <h2>Unsere Ambition</h2>
+      <ul>
+        <li>
+          Dazu beitragen, die bestehende Fragmentierung in den europäischen Sicherheitsstudien zu
+          überwinden und ein europäisches Feld der Sicherheitsstudien zu fördern und zu konsolidieren.
+        </li>
+        <li>
+          Beitragen zur Förderung akademischer Exzellenz in Europa und zur Entwicklung einer neuen
+          Generation von Wissenschaftlern, die sich mit ihren Pendants weltweit zu internationalen
+          Sicherheitsfragen engagieren.
+        </li>
+        <li>
+          Ein Netzwerk von Akademikern fördern, die durch akademische Forschung und Lehre zu
+          öffentlichen Debatten beitragen und ein informiertes Urteil über Verteidigungs- und
+          Sicherheitsfragen in der Zivilgesellschaft unterstützen können.
+        </li>
+      </ul>
+    </article>
+  </div>
+</section>
+
+<section class="section-tight" aria-labelledby="people-cta-title">
+  <div class="container">
+    <article class="card" style="display: grid; gap: var(--space-5); grid-template-columns: 1fr; padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8));">
+      <div>
+        <div class="featured-eyebrow">Wer leitet EISS</div>
+        <h2 id="people-cta-title" style="margin-bottom: var(--space-3);">Lernen Sie den Vorstand und das Team kennen</h2>
+        <p class="muted">
+          Unsere Vorstandsmitglieder beraten und steuern die Organisation, insbesondere durch
+          thematische Arbeitsgruppen. Ein kleines Unterstützungsteam wickelt das Tagesgeschäft ab.
+        </p>
+        <p style="margin-top: var(--space-4);">
+          <a class="btn btn-secondary" href="/board.de.html">Die Personen hinter EISS kennenlernen {{ icon("arrow-right") }}</a>
+        </p>
+      </div>
+    </article>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <div class="join">
+      <h2>Werden Sie Mitglied!</h2>
+      <p>Werden Sie Mitglied und schließen Sie sich der Community an.</p>
+      <div class="join-actions">
+        <a class="btn btn-primary" href="/membership.de.html">{{ icon("user-plus") }} Beitreten</a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/initiative.fr.njk
+++ b/src/initiative.fr.njk
@@ -1,0 +1,159 @@
+---
+layout: base.njk
+permalink: /initiative.fr.html
+title: L'Initiative
+description: L'Initiative européenne pour les études de sécurité (EISS) est un réseau européen multidisciplinaire de chercheurs visant à consolider les études de sécurité en Europe.
+metaImage: /assets/images/initiative-meta.jpg
+navKey: initiative
+lang: fr
+status: beta
+alternates:
+  en: /initiative.html
+  fr: /initiative.fr.html
+  de: /initiative.de.html
+---
+{% from "icons.njk" import icon %}
+
+<header class="page-header">
+  <div class="container">
+    <span class="eyebrow">À propos</span>
+    <h1>L'Initiative</h1>
+    <p class="page-lead">
+      L'Initiative européenne pour les études de sécurité (EISS) est un réseau européen multidisciplinaire
+      de chercheurs qui partagent l'objectif de consolider les études de sécurité en Europe.
+    </p>
+  </div>
+</header>
+
+<section class="section">
+  <div class="container">
+    <article class="prose">
+      <p>Plus précisément, les objectifs de l'EISS sont doubles :</p>
+    </article>
+
+    <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr)); margin-block: var(--space-7);">
+      <article class="tile">
+        <div class="tile-icon" aria-hidden="true">{{ icon("users-round") }}</div>
+        <h2>Créer un réseau</h2>
+        <p>
+          Développer et entretenir un réseau européen dans le domaine des études de sécurité. Cela
+          donne de la visibilité à l'ensemble des projets de recherche individuels et collectifs
+          actuellement en cours en Europe et au-delà.
+        </p>
+      </article>
+      <article class="tile">
+        <div class="tile-icon" aria-hidden="true">{{ icon("globe") }}</div>
+        <h2>Créer une plateforme</h2>
+        <p>
+          Établir un forum d'échange d'idées afin de favoriser de nouveaux projets de recherche
+          conjoints et de développer des partenariats de recherche internationaux.
+        </p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="section-tight" id="what-makes-us-unique">
+  <div class="container">
+    <article class="card" style="padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8));">
+      <h2>Ce qui nous distingue</h2>
+      <p class="lead">
+        L'EISS présente trois caractéristiques principales : (1) une approche thématique ouverte à toutes
+        les approches théoriques, (2) une démarche multidisciplinaire et interdisciplinaire,
+        et (3) une inclusion géographique.
+      </p>
+
+      <dl class="definition-list">
+        <div>
+          <dt>Ouverte à toutes les approches</dt>
+          <dd>
+            L'EISS ne se limite pas à une approche théorique spécifique des études de sécurité, mais
+            cherche au contraire à être inclusive. Cela se reflète, par exemple, dans les panels
+            de la conférence EISS, qui couvrent une vaste gamme de thèmes du large champ des études
+            de sécurité. L'EISS accueille les contributions portant aussi bien sur les questions
+            de sécurité dites « traditionnelles » que « non traditionnelles ».
+          </dd>
+        </div>
+        <div>
+          <dt>Multidisciplinaire</dt>
+          <dd>
+            L'EISS est multidisciplinaire et interdisciplinaire en ce qu'elle rassemble, entre autres,
+            historiens, politologues, économistes, géographes, anthropologues et sociologues partageant
+            un intérêt pour le développement des études de sécurité en Europe.
+          </dd>
+        </div>
+        <div>
+          <dt>Géographiquement inclusive</dt>
+          <dd>
+            L'EISS cherche à être aussi inclusive que possible d'un point de vue géographique, intégrant
+            des chercheurs de toute l'Europe (Sud, Est, Nord et Ouest). Dans le même temps, l'EISS
+            accueille les projets portant sur toute région du monde. Chaque année, la conférence
+            annuelle est organisée par rotation dans un pays européen différent.
+          </dd>
+        </div>
+        <div>
+          <dt>Ouverte à tous les profils</dt>
+          <dd>
+            Les chercheurs en début de carrière, les membres des forces armées, des services
+            diplomatiques, ainsi que les fonctionnaires nationaux et internationaux sont tous les bienvenus.
+          </dd>
+        </div>
+      </dl>
+    </article>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <article class="prose">
+      <h2>Notre ambition</h2>
+      <ul>
+        <li>
+          Contribuer à surmonter la fragmentation existante dans les études européennes de sécurité,
+          et favoriser et consolider un champ européen des études de sécurité.
+        </li>
+        <li>
+          Contribuer à promouvoir l'excellence académique en Europe et à nourrir le développement
+          d'une nouvelle génération de chercheurs qui s'engagent sur les questions de sécurité
+          internationale avec leurs homologues à travers le monde.
+        </li>
+        <li>
+          Favoriser un réseau d'universitaires capables de contribuer aux débats publics à travers
+          la recherche et l'enseignement, et de soutenir un jugement éclairé sur les questions de
+          défense et de sécurité au sein de la société civile.
+        </li>
+      </ul>
+    </article>
+  </div>
+</section>
+
+<section class="section-tight" aria-labelledby="people-cta-title">
+  <div class="container">
+    <article class="card" style="display: grid; gap: var(--space-5); grid-template-columns: 1fr; padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8));">
+      <div>
+        <div class="featured-eyebrow">Qui dirige l'EISS</div>
+        <h2 id="people-cta-title" style="margin-bottom: var(--space-3);">Découvrez le bureau et l'équipe</h2>
+        <p class="muted">
+          Les membres de notre bureau conseillent et orientent l'organisation, notamment à travers
+          des groupes de travail thématiques. Une petite équipe de soutien assure les opérations
+          quotidiennes.
+        </p>
+        <p style="margin-top: var(--space-4);">
+          <a class="btn btn-secondary" href="/board.fr.html">Voir les personnes derrière EISS {{ icon("arrow-right") }}</a>
+        </p>
+      </div>
+    </article>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <div class="join">
+      <h2>Rejoignez-nous !</h2>
+      <p>Devenez membre et rejoignez la communauté.</p>
+      <div class="join-actions">
+        <a class="btn btn-primary" href="/membership.fr.html">{{ icon("user-plus") }} Adhérer</a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/initiative.njk
+++ b/src/initiative.njk
@@ -5,6 +5,11 @@ title: The Initiative
 description: The European Initiative for Security Studies (EISS) is a Europe-wide multidisciplinary network of scholars consolidating security studies in Europe.
 metaImage: /assets/images/initiative-meta.jpg
 navKey: initiative
+lang: en
+alternates:
+  en: /initiative.html
+  fr: /initiative.fr.html
+  de: /initiative.de.html
 ---
 {% from "icons.njk" import icon %}
 

--- a/src/membership.de.njk
+++ b/src/membership.de.njk
@@ -1,0 +1,144 @@
+---
+layout: base.njk
+permalink: /membership.de.html
+title: Mitgliedschaft
+description: Schließen Sie sich der EISS-Community an und erhalten Sie exklusiven Zugang zu unseren Online- und Hybridveranstaltungen. Gestaffelte Mitgliedschaft für Studenten, Nachwuchsforscher und etablierte Fachleute.
+navKey: membership
+metaImage: /assets/images/membership-meta.jpg
+lang: de
+status: beta
+alternates:
+  en: /membership.html
+  fr: /membership.fr.html
+  de: /membership.de.html
+---
+{% from "icons.njk" import icon %}
+
+<header class="page-header">
+  <div class="container">
+    <span class="eyebrow">Werden Sie Mitglied</span>
+    <h1>Mitgliedschaft</h1>
+    <p class="page-lead">
+      Schließen Sie sich der Community an, tragen Sie zur Entwicklung der europäischen Sicherheitsstudien
+      bei und profitieren Sie von exklusivem Zugang zu unseren Online- und Hybridveranstaltungen.
+    </p>
+  </div>
+</header>
+
+<section class="section">
+  <div class="container">
+    <h2>Wie unsere Community aussieht</h2>
+    <p class="lead" style="max-width: 44rem;">
+      Wir bemühen uns, unsere Community für alle zugänglich zu machen.
+    </p>
+
+    <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr)); margin-block: var(--space-6);">
+      <article class="tile">
+        <div class="tile-icon" aria-hidden="true">{{ icon("users-round") }}</div>
+        <h3>Offen für alle</h3>
+        <p>
+          Nachwuchswissenschaftler, Angehörige der Streitkräfte, des diplomatischen Dienstes
+          sowie nationale und internationale Beamte.
+        </p>
+      </article>
+      <article class="tile">
+        <div class="tile-icon" aria-hidden="true">{{ icon("lightbulb") }}</div>
+        <h3>Multidisziplinär</h3>
+        <p>Geschichte, Politikwissenschaft, Recht, Philosophie, Wirtschaft, Psychologie, Soziologie usw.</p>
+      </article>
+      <article class="tile">
+        <div class="tile-icon" aria-hidden="true">{{ icon("globe") }}</div>
+        <h3>Geografisch inklusiv</h3>
+        <p>
+          Jedes Jahr wird die Jahreskonferenz im Rotationsverfahren in einem anderen europäischen Land organisiert.
+        </p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="section-tight" id="content19-b9">
+  <div class="container">
+    <h2>Wer sind Sie?</h2>
+    <p class="lead" style="max-width: 44rem;">
+      Drei Mitgliedschaftsstufen vom Studenten bis zum etablierten Profi. Die Preise gelten jährlich;
+      Zahlungen und Verlängerungen werden über Stripe abgewickelt.
+    </p>
+
+    <p style="background: var(--accent-soft); padding: var(--space-3) var(--space-4); border-radius: var(--radius-sm); border-inline-start: 3px solid var(--accent); margin-block: var(--space-5); max-width: 44rem;">
+      <strong>Haben Sie bereits ein Indico-Konto bei uns?</strong>
+      Bitte verwenden Sie dieselbe E-Mail-Adresse bei der Zahlungsregistrierung unten, um Zugang zu
+      Ihrem Mitgliederbereich zu erhalten.
+    </p>
+
+    <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));">
+      <article class="tile">
+        <div class="featured-eyebrow" style="margin-bottom: var(--space-3);">30 € / Jahr</div>
+        <h3>Student</h3>
+        <p>Bachelor- und Masterstudierende.</p>
+        <p style="margin-top: var(--space-4);">
+          <a class="btn btn-primary btn-sm" href="https://buy.stripe.com/6oE7vDfu9dDqdG0fZp" target="_blank" rel="noopener">{{ icon("user-plus") }} Mitglied werden</a>
+        </p>
+      </article>
+      <article class="tile">
+        <div class="featured-eyebrow" style="margin-bottom: var(--space-3);">50 € / Jahr</div>
+        <h3>Doktorand &amp; Nachwuchswissenschaftler</h3>
+        <p>Doktoranden und Postdoktoranden (innerhalb von drei Jahren nach dem Abschluss).</p>
+        <p style="margin-top: var(--space-4);">
+          <a class="btn btn-primary btn-sm" href="https://buy.stripe.com/4gwaHP4Pv6aYbxS9B2" target="_blank" rel="noopener">{{ icon("user-plus") }} Mitglied werden</a>
+        </p>
+      </article>
+      <article class="tile">
+        <div class="featured-eyebrow" style="margin-bottom: var(--space-3);">80 € / Jahr</div>
+        <h3>Etablierte Akademiker oder Fachleute</h3>
+        <p>Akademiker, Entscheidungsträger, Journalisten und andere Fachleute.</p>
+        <p style="margin-top: var(--space-4);">
+          <a class="btn btn-primary btn-sm" href="https://buy.stripe.com/28o7vD95LdDq1Xi4gQ" target="_blank" rel="noopener">{{ icon("user-plus") }} Mitglied werden</a>
+        </p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="section-tight">
+  <div class="container">
+    <article class="card" style="display: grid; gap: var(--space-5); grid-template-columns: 1fr; padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8));">
+      <div>
+        <div class="featured-eyebrow">Bereits Mitglied?</div>
+        <h2 style="margin-bottom: var(--space-3);">Verwalten Sie Ihre Mitgliedschaft</h2>
+        <p class="muted">
+          Aktualisieren Sie Ihre Kontaktdaten, Bankinformationen oder kündigen Sie Ihr Abonnement jederzeit.
+        </p>
+        <p style="margin-top: var(--space-4);">
+          <a class="btn btn-secondary" href="https://billing.stripe.com/p/login/3cscOuaesfHceC4dQQ" target="_blank" rel="noopener">
+            Portal zur Mitgliedschaftsverwaltung {{ icon("external-link") }}
+          </a>
+        </p>
+      </div>
+    </article>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <article class="prose">
+      <h2>Allgemeine Geschäftsbedingungen</h2>
+      <p>
+        Unsere Mitgliedschaft funktioniert nach einem <strong>Abonnementsystem</strong>. Sie verlängert
+        sich automatisch jährlich, kann jedoch jederzeit gekündigt werden. Sie werden 7 Tage vor der
+        Verlängerung per E-Mail benachrichtigt. Bitte achten Sie darauf, Ihre Kontakt- und Bankdaten
+        auf dem neuesten Stand zu halten.
+      </p>
+      <p>
+        Sie können Ihre Mitgliedschaft jederzeit
+        <a href="https://billing.stripe.com/p/login/3cscOuaesfHceC4dQQ" target="_blank" rel="noopener">hier</a>
+        verwalten. Da die Mitgliedsvorteile sofort beginnen, führt eine Kündigung zu einer
+        <em>anteiligen</em> Belastung der hinterlegten Karte. Fehlgeschlagene Zahlungen führen nach
+        15 Tagen zur Kündigung.
+      </p>
+      <p>
+        Lesen Sie die vollständigen <a href="/terms.de.html">Allgemeinen Geschäftsbedingungen</a> für Details.
+      </p>
+    </article>
+  </div>
+</section>

--- a/src/membership.fr.njk
+++ b/src/membership.fr.njk
@@ -1,0 +1,143 @@
+---
+layout: base.njk
+permalink: /membership.fr.html
+title: Adhésion
+description: Rejoignez la communauté EISS et bénéficiez d'un accès exclusif à nos événements en ligne et hybrides. Adhésion par paliers pour les étudiants, jeunes chercheurs et professionnels établis.
+navKey: membership
+metaImage: /assets/images/membership-meta.jpg
+lang: fr
+status: beta
+alternates:
+  en: /membership.html
+  fr: /membership.fr.html
+  de: /membership.de.html
+---
+{% from "icons.njk" import icon %}
+
+<header class="page-header">
+  <div class="container">
+    <span class="eyebrow">Rejoignez-nous</span>
+    <h1>Adhésion</h1>
+    <p class="page-lead">
+      Rejoignez la communauté, contribuez au développement des études européennes de sécurité,
+      et bénéficiez d'un accès exclusif à nos événements en ligne et hybrides.
+    </p>
+  </div>
+</header>
+
+<section class="section">
+  <div class="container">
+    <h2>À quoi ressemble notre communauté</h2>
+    <p class="lead" style="max-width: 44rem;">
+      Nous nous efforçons de rendre notre communauté accessible à tous.
+    </p>
+
+    <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr)); margin-block: var(--space-6);">
+      <article class="tile">
+        <div class="tile-icon" aria-hidden="true">{{ icon("users-round") }}</div>
+        <h3>Ouverte à tous</h3>
+        <p>
+          Chercheurs en début de carrière, membres des forces armées, des services diplomatiques,
+          ainsi que les fonctionnaires nationaux et internationaux.
+        </p>
+      </article>
+      <article class="tile">
+        <div class="tile-icon" aria-hidden="true">{{ icon("lightbulb") }}</div>
+        <h3>Multidisciplinaire</h3>
+        <p>Histoire, sciences politiques, droit, philosophie, économie, psychologie, sociologie, etc.</p>
+      </article>
+      <article class="tile">
+        <div class="tile-icon" aria-hidden="true">{{ icon("globe") }}</div>
+        <h3>Géographiquement inclusive</h3>
+        <p>
+          Chaque année, la conférence annuelle est organisée par rotation dans un pays européen différent.
+        </p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="section-tight" id="content19-b9">
+  <div class="container">
+    <h2>Qui êtes-vous ?</h2>
+    <p class="lead" style="max-width: 44rem;">
+      Trois paliers d'adhésion couvrant les étudiants jusqu'aux professionnels établis. La tarification
+      est annuelle ; les paiements et renouvellements sont gérés par Stripe.
+    </p>
+
+    <p style="background: var(--accent-soft); padding: var(--space-3) var(--space-4); border-radius: var(--radius-sm); border-inline-start: 3px solid var(--accent); margin-block: var(--space-5); max-width: 44rem;">
+      <strong>Vous avez déjà un compte Indico chez nous ?</strong>
+      Veuillez utiliser la même adresse e-mail lors de l'enregistrement de votre paiement ci-dessous
+      pour accéder à votre espace membre.
+    </p>
+
+    <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));">
+      <article class="tile">
+        <div class="featured-eyebrow" style="margin-bottom: var(--space-3);">30 € / an</div>
+        <h3>Étudiant·e</h3>
+        <p>Étudiants en licence et en master.</p>
+        <p style="margin-top: var(--space-4);">
+          <a class="btn btn-primary btn-sm" href="https://buy.stripe.com/6oE7vDfu9dDqdG0fZp" target="_blank" rel="noopener">{{ icon("user-plus") }} Devenir membre</a>
+        </p>
+      </article>
+      <article class="tile">
+        <div class="featured-eyebrow" style="margin-bottom: var(--space-3);">50 € / an</div>
+        <h3>Doctorant·e &amp; jeune chercheur·euse</h3>
+        <p>Chercheurs doctoraux et post-doctoraux (dans les trois ans suivant l'obtention).</p>
+        <p style="margin-top: var(--space-4);">
+          <a class="btn btn-primary btn-sm" href="https://buy.stripe.com/4gwaHP4Pv6aYbxS9B2" target="_blank" rel="noopener">{{ icon("user-plus") }} Devenir membre</a>
+        </p>
+      </article>
+      <article class="tile">
+        <div class="featured-eyebrow" style="margin-bottom: var(--space-3);">80 € / an</div>
+        <h3>Universitaire ou professionnel·le établi·e</h3>
+        <p>Universitaires, décideurs politiques, journalistes et autres professionnels.</p>
+        <p style="margin-top: var(--space-4);">
+          <a class="btn btn-primary btn-sm" href="https://buy.stripe.com/28o7vD95LdDq1Xi4gQ" target="_blank" rel="noopener">{{ icon("user-plus") }} Devenir membre</a>
+        </p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="section-tight">
+  <div class="container">
+    <article class="card" style="display: grid; gap: var(--space-5); grid-template-columns: 1fr; padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8));">
+      <div>
+        <div class="featured-eyebrow">Déjà membre ?</div>
+        <h2 style="margin-bottom: var(--space-3);">Gérez votre adhésion</h2>
+        <p class="muted">
+          Mettez à jour vos coordonnées, vos informations bancaires, ou annulez votre abonnement à tout moment.
+        </p>
+        <p style="margin-top: var(--space-4);">
+          <a class="btn btn-secondary" href="https://billing.stripe.com/p/login/3cscOuaesfHceC4dQQ" target="_blank" rel="noopener">
+            Portail de gestion de l'adhésion {{ icon("external-link") }}
+          </a>
+        </p>
+      </div>
+    </article>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <article class="prose">
+      <h2>Conditions générales</h2>
+      <p>
+        Notre adhésion fonctionne sur la base d'un <strong>système d'abonnement</strong>. Elle se renouvelle
+        automatiquement chaque année, mais vous pouvez l'annuler à tout moment et serez prévenu 7 jours
+        avant le renouvellement par e-mail. Veillez à maintenir vos coordonnées et informations bancaires à jour.
+      </p>
+      <p>
+        Vous pouvez gérer votre adhésion à tout moment
+        <a href="https://billing.stripe.com/p/login/3cscOuaesfHceC4dQQ" target="_blank" rel="noopener">ici</a>.
+        L'adhésion ouvrant droit à des avantages immédiats, son annulation entraînera un prélèvement
+        <em>au prorata</em> sur la carte enregistrée. Les paiements échoués entraîneront une annulation
+        après 15 jours.
+      </p>
+      <p>
+        Consultez les <a href="/terms.fr.html">conditions générales</a> complètes pour plus de détails.
+      </p>
+    </article>
+  </div>
+</section>

--- a/src/membership.njk
+++ b/src/membership.njk
@@ -5,6 +5,11 @@ title: Membership
 description: Join the EISS community and get exclusive access to our online and hybrid events. Tiered membership for students, early-career researchers, and established professionals.
 navKey: membership
 metaImage: /assets/images/membership-meta.jpg
+lang: en
+alternates:
+  en: /membership.html
+  fr: /membership.fr.html
+  de: /membership.de.html
 ---
 {% from "icons.njk" import icon %}
 


### PR DESCRIPTION
## Summary

Adapts the netsec-cost.eu multilingual pattern to EISS, with the file-suffix URL convention (`/page.html`, `/page.fr.html`, `/page.de.html`) ported to Eleventy/Nunjucks.

## What's shipped

### 1. Full i18n plumbing
- **`src/_data/i18n.js`** — chrome string catalog (nav, footer, buttons, beta ribbon, theme toggle, untranslated-page notice) in EN / FR / DE
- **`src/_layouts/base.njk`** — reads `lang` front-matter, resolves `t = i18n[lang]`, emits `hreflang` link tags, conditionally renders the beta ribbon, sets `og:locale`
- **`src/_includes/nav.njk`** — language switcher chips (EN / FR / DE), active chip highlighted, nav link hrefs auto-suffix `.fr` / `.de`
- **`src/_includes/footer.njk`** — same catalog pattern, footer links auto-suffix
- **`src/_includes/beta-ribbon.njk`** — sticky banner shown when `status: "beta"`
- **`src/assets/css/site.css`** — `.lang-switcher` / `.lang-chip` pill row + `.beta-ribbon` styles (light + dark mode)

### 2. Language-preference auto-redirect
`localStorage.eiss-lang` saves the user's chip choice. On the next visit to an English page, if a declared alternate exists for the saved language, the browser replaces() to the translated version. Never redirects AWAY from English — English is the unfailable fallback.

### 3. Three PoC translated pages
| Page | EN | FR | DE |
|---|---|---|---|
| `/index.html` | ✅ | ✅ beta | ✅ beta |
| `/initiative.html` | ✅ | ✅ beta | ✅ beta |
| `/membership.html` | ✅ | ✅ beta | ✅ beta |

All FR/DE pages render the beta ribbon, link back to the English source, and validate in the drift checker.

### 4. Drift detection + CI guard
- **`scripts/check-i18n-drift.py`** — ported from NetSec, paths adapted to `src/*.njk`. Hashes each English source's bytes, compares against `data/i18n-state.json`. Stale or missing translations fail the run.
- **`.github/workflows/i18n-drift.yml`** — runs the checker on every push + PR. Failing job blocks the PR.
- **`data/i18n-state.json`** — initial state with 6 translation entries, all fresh.

### 5. `docs/i18n.md` — maintainer guide
Adding a translation, refreshing after source changes, promoting beta → reviewed, translation policy, cost model.

## What's NOT translated (deferred)

| | |
|---|---|
| **Tier 1 pages remaining** | board, 2026, programmes, events, policy |
| **Tier 2 pages** | terms, accessibility, sitemap, past |
| **Archive pages** | 2019–2025, JPW, NDC, Ukraine, panels, practical, page7/9/20/23, ticket-* — **English only by design** (historical content) |
| **Native-speaker reviews** | All 6 FR/DE pages are `status: "beta"` until a native speaker signs off |
| **Per-page share-card translations** | The Open Graph share cards still render English titles regardless of page locale. An enhancement to `scripts/make-share-cards.py` could produce `*-meta.{fr,de}.jpg` variants. |

Each follow-up translation is one file copy + DeepL pass + drift re-stamp away.

## Verified locally

Preview MCP screenshots in dark + light mode for:
- `/index.fr.html` — beta ribbon, FR nav, FR content, FR chip highlighted ✅
- `/index.de.html` — beta ribbon, DE nav, DE content, DE chip highlighted ✅
- `/initiative.de.html` — full DE page including tiles + definition list + ambition bullets ✅
- Build clean: 53 HTML files (was 47; +6 from translated pages)
- Drift script: all 6 entries fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)