### PR TITLE
v2.11.0: authenticated Indico sync pipeline (read-only)

### DIFF
--- a/.github/workflows/sync-indico.yml
+++ b/.github/workflows/sync-indico.yml
@@ -56,6 +56,15 @@ jobs:
         run: pip install -r scripts/requirements.txt
 
       - name: Run sync script
+        env:
+          # Optional Indico API token (read-only, on a dedicated
+          # service account). Unlocks endpoints that aren't anonymously
+          # accessible — registration form state, auth-gated video
+          # links, etc. If the secret is absent, the script falls back
+          # to anonymous mode and the sync still works for public
+          # endpoints. To set: repo Settings → Secrets and variables →
+          # Actions → New secret named `INDICO_API_TOKEN`.
+          INDICO_API_TOKEN: ${{ secrets.INDICO_API_TOKEN }}
         run: python3 scripts/sync-indico.py
 
       - name: Commit + push if changed

--- a/docs/indico-api-token.md
+++ b/docs/indico-api-token.md
@@ -1,0 +1,131 @@
+# Setting up an Indico API token for the website sync
+
+This guide walks through creating a **read-only** Indico API credential
+that the GitHub Actions sync workflow uses to enrich
+`src/_data/indico.json`. **One-time setup, ~10 minutes.**
+
+The website works without this — the sync falls back to anonymous mode
+and still surfaces public timetable + event data. What the token
+unlocks is anything anonymous access can't see, which over time will
+likely include:
+
+- Registration form state (open/closed) — so we can drop the manual
+  `registrationStatus` override in `src/_data/conferences.js`
+- Auth-gated video-conference URLs (some Indico Zoom integrations
+  require auth)
+- Private event metadata that may matter for future enrichments
+
+## Why a dedicated service account
+
+Don't tie the credential to your personal Indico account:
+
+- API calls are logged under whoever owns the token. With a personal
+  account, every sync run looks like *you* doing it — and revoking it
+  if something goes wrong locks you out of your own admin.
+- A dedicated bot user can be granted just the categories the website
+  reads from, not the operator's full admin reach.
+- If the EISS repo's CI is ever compromised (malicious PR,
+  dependency takeover), you revoke the bot token — your personal
+  account is untouched.
+
+## Step 1 — Create the service-account user
+
+In Indico admin, create a new user:
+
+- Email: an alias you control, e.g. `website-sync@eiss-europa.com`
+- Name: *EISS Website Sync Bot*
+- Password: random, long, stored only in your password manager
+- 2FA: enable if Indico supports it
+
+Confirm the account by following the email link.
+
+## Step 2 — Grant category access
+
+Decide which categories the bot should read. For the current site that's:
+
+- **Annual Conferences** (categoryId 1) — drives `/2026` and the
+  registration status badge
+- **Root category** (categoryId 0) — implicit; the bot can read public
+  category listings without explicit grants
+
+In Indico:
+
+1. Navigate to the **Annual Conferences** category as an admin.
+2. **Manage** → **Protection**.
+3. Add the bot user with role **Reader** (not Manager, not Owner).
+
+Repeat for any other category the website needs to read in future.
+
+## Step 3 — Issue a token
+
+Log in as the bot user. Then:
+
+1. **User preferences** → **API Tokens** → **Add new token**.
+2. Name: `eiss-site-sync` (or similar — appears in the Indico audit log,
+   so make it self-explanatory).
+3. Scopes: pick the *read* scopes you need. At minimum:
+   - `read:legacy_api` — covers the `/export/*` endpoints the sync uses.
+   - `read:user` — sometimes required for type-field on session detail.
+4. **Do not** grant write scopes (`registrants`, `everything`, etc.) for
+   this token. Writes deserve a separate, deliberately-issued token.
+5. Save. Indico shows the token **once**. Copy it now.
+
+## Step 4 — Drop the token into GitHub Actions secrets
+
+In `github.com/EISSeuropa/EISSeuropa.github.io`:
+
+1. **Settings** → **Secrets and variables** → **Actions** → **New
+   repository secret**.
+2. Name: `INDICO_API_TOKEN` (exact spelling — that's what the workflow
+   reads).
+3. Value: paste the token.
+4. **Add secret**.
+
+The token is now encrypted at rest. GitHub Actions decrypts it just-in-
+time when the workflow runs. It never appears in logs.
+
+## Step 5 — Verify
+
+Trigger the sync workflow manually to confirm the credential works:
+
+1. **Actions** → *Sync events from Indico* → **Run workflow**.
+2. Wait ~30 seconds. Open the run log.
+3. The first line of the *Run sync script* step should read:
+   ```
+   Indico sync running in authenticated mode
+   ```
+   If it reads `anonymous mode`, the secret name is wrong or empty.
+4. Confirm the workflow ends with `Pushed indico.json update to master`
+   or `No change — indico.json already up to date`.
+
+## Rotation + audit
+
+- **Calendar a rotation** every 12 months — and any time something
+  concerning happens (suspicious commit, contributor offboarding,
+  security advisory affecting Indico).
+- To rotate: issue a new token under a new name (e.g.
+  `eiss-site-sync-2027`), update the GitHub secret, then **delete the
+  old token in Indico** — not just remove it from the secret.
+- **Check Indico's API access log periodically.** If you see calls you
+  don't recognise, revoke the token immediately and tell Claude.
+
+## Revocation
+
+If the token is ever exposed (accidentally pasted into a public
+issue, included in a screenshot, etc.):
+
+1. Indico → bot user → **API Tokens** → revoke the leaked token.
+2. Issue a replacement, update the GitHub secret.
+3. Skim recent Indico API logs for unexpected activity.
+
+## Notes for future Claude sessions
+
+- The token is `${{ secrets.INDICO_API_TOKEN }}` in the workflow and
+  `os.environ.get("INDICO_API_TOKEN")` in `scripts/sync-indico.py`.
+- The `_get` helper in `scripts/sync-indico.py` adds the
+  `Authorization: Bearer …` header when the token is set; the rest of
+  the script is agnostic.
+- **Never** print, log, or echo the token value — even in error paths.
+  The script logs only the mode banner (`authenticated` / `anonymous`).
+- The script falls back to anonymous mode if the env var is missing, so
+  local runs without the token still work for public endpoints.

--- a/scripts/sync-indico.py
+++ b/scripts/sync-indico.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -62,6 +63,17 @@ OUT = ROOT / "src" / "_data" / "indico.json"
 INDICO_BASE = "https://indico.eiss-europa.com"
 ROOT_CATEGORY_ID = 0          # Indico root — returns events from all sub-categories
 LOOK_AHEAD_DAYS = 540          # ~18 months
+
+# Indico API token (read-only, on a dedicated service account). When
+# present we add an `Authorization: Bearer …` header to every Indico
+# call, which unlocks endpoints that anonymous access can't see —
+# notably registration-form state and any video-conference URLs that
+# require auth. The script keeps working without it (anonymous mode),
+# so local runs and emergencies don't need the secret.
+#
+# Storage: GitHub Actions secret named `INDICO_API_TOKEN`, surfaced
+# to the workflow step via `env:`. NEVER hardcode the token here.
+INDICO_API_TOKEN = os.environ.get("INDICO_API_TOKEN")
 ANNUAL_CONFERENCE_CATEGORY_IDS = {1}  # ESSC editions — routed into `annualConferences` bucket
 
 # Classification — three signals, in priority order. A session ends
@@ -115,6 +127,17 @@ VC_URL_TOKENS = ("zoom.us", "meet.google", "teams.microsoft", "webex.com")
 # Common Eleventy/JS will compare ISO strings lexicographically and this works
 # fine for "is this future" comparisons as long as we always include the time.
 ISO_FMT = "%Y-%m-%dT%H:%M:%S"
+
+
+def _get(url: str) -> requests.Response:
+    """One-stop HTTP GET that adds the bearer token when present.
+    Pulled out so we don't have three almost-identical request lines
+    drifting from each other (one would inevitably forget to add the
+    auth header). The token is NEVER logged."""
+    headers = {"Accept": "application/json"}
+    if INDICO_API_TOKEN:
+        headers["Authorization"] = f"Bearer {INDICO_API_TOKEN}"
+    return requests.get(url, timeout=30, headers=headers)
 
 
 def _combine_indico_datetime(d: dict) -> str | None:
@@ -188,7 +211,7 @@ def fetch_timetable(event_id: str) -> dict:
     url = f"{INDICO_BASE}/export/timetable/{event_id}.json"
     print(f"GET {url}", file=sys.stderr)
     try:
-        r = requests.get(url, timeout=30, headers={"Accept": "application/json"})
+        r = _get(url)
         r.raise_for_status()
         payload = r.json()
     except Exception as exc:  # noqa: BLE001 — sync is best-effort
@@ -206,7 +229,7 @@ def fetch_session_type(event_id: str, session_id) -> str | None:
         return None
     url = f"{INDICO_BASE}/export/event/{event_id}/session/{session_id}.json"
     try:
-        r = requests.get(url, timeout=30, headers={"Accept": "application/json"})
+        r = _get(url)
         r.raise_for_status()
         payload = r.json()
     except Exception as exc:  # noqa: BLE001 — best-effort enrichment
@@ -340,7 +363,7 @@ def fetch_events() -> list[dict]:
         f"&detail=events&order=start"
     )
     print(f"GET {url}", file=sys.stderr)
-    r = requests.get(url, timeout=30, headers={"Accept": "application/json"})
+    r = _get(url)
     r.raise_for_status()
     payload = r.json()
     if payload.get("_type") != "HTTPAPIResult":
@@ -352,6 +375,11 @@ def fetch_events() -> list[dict]:
 
 
 def main() -> None:
+    # Log whether we're authenticated — without ever printing the token.
+    # Useful to confirm in CI that the secret is wired correctly.
+    mode = "authenticated" if INDICO_API_TOKEN else "anonymous"
+    print(f"Indico sync running in {mode} mode", file=sys.stderr)
+
     raw_events = fetch_events()
     print(f"Fetched {len(raw_events)} event(s) from Indico", file=sys.stderr)
 


### PR DESCRIPTION
## Summary

Wires an optional \`INDICO_API_TOKEN\` env var into the sync script and the daily workflow. When set, every Indico call gets an \`Authorization: Bearer …\` header — unlocking endpoints anonymous access can't see (registration form state, auth-gated Zoom URLs, …). When unset, the script falls back to anonymous mode and continues to work for public endpoints. So local runs don't need the credential.

This is the **plumbing**. No new endpoints are called yet — those land in v2.12+ once you've created the token and we can confirm the auto-detect returns useful data.

## What's in this PR

- \`scripts/sync-indico.py\`:
  - Reads \`INDICO_API_TOKEN\` from env
  - New \`_get(url)\` helper centralises auth-header injection — three existing call sites route through it, so no future drift
  - Mode banner logged at startup (\`authenticated\` / \`anonymous\`) for CI visibility. **Token value never printed.**
- \`.github/workflows/sync-indico.yml\`: passes the secret via \`env:\` on the sync step
- \`docs/indico-api-token.md\`: end-to-end operator guide — dedicated service account, Reader role on Annual Conferences, read-only token, rotation + audit hygiene

## After merge: your action items

1. Create the bot user \`website-sync@eiss-europa.com\` in Indico admin (see docs/indico-api-token.md for the click-by-click)
2. Grant it **Reader** on the Annual Conferences category
3. Issue a read-only token; do **not** share the value with me
4. Add it as repo secret \`INDICO_API_TOKEN\`
5. Trigger *Actions → Sync events from Indico → Run workflow* — confirm the log shows \`Indico sync running in authenticated mode\`

Then ping me and I'll ship v2.12 (registration-state auto-detect → drop the manual override in conferences.js).

## Test plan

- [x] Script still runs in anonymous mode without the env var — confirmed
- [x] \`npx @11ty/eleventy\` builds clean (71 files)
- [x] No template / data changes — site output identical
- [ ] After secret is added: workflow run shows \`authenticated mode\` banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)