### PR TITLE
v2.12.0: one-shot Indico API probe + datetime.utcnow() fix

### DIFF
--- a/.github/workflows/probe-indico-api.yml
+++ b/.github/workflows/probe-indico-api.yml
@@ -1,0 +1,41 @@
+# One-shot manual probe of Indico's API surface.
+#
+# Used to figure out which Indico endpoint returns registration-form
+# state on this Indico version — different installations expose
+# different paths, so production code (sync-indico.py) waits for an
+# answer from this probe rather than guessing.
+#
+# Read-only. Calls only GET. Doesn't commit or push anything.
+# The log shows status codes + content-types, never response bodies
+# (those could contain attendee PII).
+#
+# To run: Actions → "Probe Indico API (manual)" → Run workflow.
+
+name: Probe Indico API (manual)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: Probe candidate endpoints
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: scripts/requirements.txt
+
+      - name: Install Python dependencies
+        run: pip install -r scripts/requirements.txt
+
+      - name: Run probe
+        env:
+          INDICO_API_TOKEN: ${{ secrets.INDICO_API_TOKEN }}
+        run: python3 scripts/probe-indico-api.py

--- a/docs/indico-api-token.md
+++ b/docs/indico-api-token.md
@@ -118,6 +118,22 @@ issue, included in a screenshot, etc.):
 2. Issue a replacement, update the GitHub secret.
 3. Skim recent Indico API logs for unexpected activity.
 
+## Diagnosing endpoint availability
+
+If the daily sync's auto-detected fields ever stop populating (or you
+want to confirm which Indico endpoints respond to this token's scope),
+trigger the **Probe Indico API (manual)** workflow:
+
+1. Actions → *Probe Indico API (manual)* → **Run workflow**.
+2. Read the log. The summary table shows status codes + content-type
+   for each candidate endpoint. **Bodies are never printed**, so even
+   if registration data is exposed, it doesn't leak into Actions logs.
+3. If anything returned 2xx, share the table with Claude — they'll
+   wire the winning endpoint into the next sync release.
+
+The probe is read-only (GET only), doesn't commit, and uses the same
+token as the daily sync.
+
 ## Notes for future Claude sessions
 
 - The token is `${{ secrets.INDICO_API_TOKEN }}` in the workflow and

--- a/scripts/probe-indico-api.py
+++ b/scripts/probe-indico-api.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+One-shot probe of Indico's API surface.
+
+PURPOSE
+=======
+We want to detect registration-form state (open/closed) automatically.
+Indico exposes data through several overlapping APIs, and which one
+returns what is version-dependent. Rather than guessing in production
+code, this script tries a handful of candidate URLs and reports back
+how each responded.
+
+WHAT IT LOGS
+============
+Status code, content-type, and response size — never bodies. Bodies
+might contain attendee names, emails, or other PII; even with a private
+GitHub Actions log it's better to keep them out.
+
+HOW TO RUN
+==========
+Via GitHub Actions: Actions → "Probe Indico API (manual)" → Run
+workflow. The token comes from the same INDICO_API_TOKEN repo secret
+as the daily sync.
+
+Read the log; share the summary table back with Claude. The PR
+following this one wires the winning endpoint into the daily sync.
+
+WHAT IT DOES NOT DO
+===================
+- Doesn't modify any Indico state (every call is GET)
+- Doesn't write to the repo
+- Doesn't print response bodies
+- Doesn't print the token (the token is in env; we never echo env)
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+try:
+    import requests
+except ImportError:
+    sys.exit("Install deps: pip install -r scripts/requirements.txt")
+
+
+INDICO_BASE = "https://indico.eiss-europa.com"
+TOKEN = os.environ.get("INDICO_API_TOKEN", "")
+
+# The 2026 ESSC event (id=22) is the working example — that's the
+# event whose registration state we eventually want to read.
+EVENT_ID = "22"
+
+# Candidate endpoints to probe. Each row: (path, attempt_bearer,
+# attempt_apikey). The two flags decide which auth strategies to try
+# for that path — some endpoints accept Bearer, some accept the
+# legacy ?apikey= query parameter, some accept both.
+CANDIDATES: list[tuple[str, bool, bool]] = [
+    # ---- Newer REST API (Bearer-token-friendly) -----------------------
+    (f"/api/v1/events/{EVENT_ID}",                          True,  False),
+    (f"/api/v1/event/{EVENT_ID}",                            True,  False),
+    (f"/api/v1/events/{EVENT_ID}/registration-forms",        True,  False),
+    (f"/api/v1/event/{EVENT_ID}/registration-forms",         True,  False),
+    (f"/api/v1/events/{EVENT_ID}/registrations",             True,  False),
+    (f"/api/v1/event/{EVENT_ID}/registrations",              True,  False),
+    # ---- Indico's management URL family (sometimes JSON) -------------
+    (f"/event/{EVENT_ID}/manage/registration/",              True,  False),
+    # ---- Legacy /export/ API (apikey query param) --------------------
+    (f"/export/event/{EVENT_ID}.json",                       False, True),
+    (f"/export/event/{EVENT_ID}/registrants.json",           False, True),
+    (f"/export/event/{EVENT_ID}/registrationform.json",      False, True),
+]
+
+
+def probe(url: str, params: dict | None = None, headers: dict | None = None) -> dict:
+    """Return a small dict describing the response without echoing
+    the body. `status` covers HTTP errors too; we never raise."""
+    try:
+        r = requests.get(url, params=params, headers=headers, timeout=20)
+        return {
+            "status": r.status_code,
+            "content_type": (r.headers.get("content-type") or "").split(";")[0].strip(),
+            "bytes": len(r.content),
+        }
+    except Exception as exc:  # noqa: BLE001
+        return {"status": "EXC", "content_type": "", "bytes": 0, "error": str(exc)[:80]}
+
+
+def main() -> None:
+    if not TOKEN:
+        sys.exit("No INDICO_API_TOKEN in env. Set the repo secret and re-run.")
+
+    print(f"Probing {INDICO_BASE} with bot token (event id={EVENT_ID}).")
+    print("Status codes only; no response bodies will be printed.\n")
+
+    headers_bearer = {
+        "Accept": "application/json",
+        "Authorization": f"Bearer {TOKEN}",
+    }
+    headers_anon = {"Accept": "application/json"}
+
+    rows: list[tuple[str, str, dict]] = []
+
+    for path, try_bearer, try_apikey in CANDIDATES:
+        url = f"{INDICO_BASE}{path}"
+        if try_bearer:
+            rows.append((path, "Bearer", probe(url, headers=headers_bearer)))
+        if try_apikey:
+            rows.append((
+                path,
+                "?apikey",
+                probe(url, params={"apikey": TOKEN}, headers=headers_anon),
+            ))
+
+    # Pretty-print a markdown-ish summary that's easy to copy-paste
+    # back into a chat / PR comment.
+    print(f"{'PATH':<58} {'AUTH':<8} {'STATUS':<8} {'CONTENT-TYPE':<24} {'BYTES':>8}")
+    print("-" * 110)
+    for path, auth, res in rows:
+        print(
+            f"{path:<58} {auth:<8} {str(res['status']):<8} "
+            f"{res['content_type']:<24} {res['bytes']:>8}"
+        )
+        if "error" in res:
+            print(f"  ! {res['error']}")
+
+    # Heuristic verdict
+    print()
+    winners = [r for r in rows if isinstance(r[2]["status"], int) and 200 <= r[2]["status"] < 300]
+    if winners:
+        print(f"✓ {len(winners)} endpoint(s) returned 2xx:")
+        for path, auth, res in winners:
+            print(f"    {auth:<8} {path}  ({res['content_type']}, {res['bytes']} bytes)")
+        print("\nNext: paste this table into chat. Claude will wire the "
+              "best-fit endpoint into scripts/sync-indico.py in v2.13.")
+    else:
+        print("✗ No endpoint returned 2xx with this token.")
+        print("  Likely causes:")
+        print("    - token scope too narrow (issue a new one with read:user "
+              "and/or read:registrants)")
+        print("    - bot user not a manager on the event/category")
+        print("    - this Indico version uses paths not in the candidate list")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync-indico.py
+++ b/scripts/sync-indico.py
@@ -455,7 +455,11 @@ def main() -> None:
             "/2027 to drive the registration status badge and the "
             "Livestreamed sessions block."
         ),
-        "syncedAt": dt.datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        # `utcnow()` is deprecated in Python 3.12 — prefer a timezone-
+        # aware UTC datetime. Render as the same compact "Z"-suffixed
+        # ISO-8601 string the previous version emitted, so consumers
+        # comparing strings lexicographically still work.
+        "syncedAt": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "source": f"{INDICO_BASE}/export/categ/{ROOT_CATEGORY_ID}.json",
         "lookaheadDays": LOOK_AHEAD_DAYS,
         "upcoming": upcoming,


### PR DESCRIPTION
## Why a probe instead of guessing

Indico exposes a couple of overlapping APIs:
- \`/api/v1/*\` — accepts Bearer tokens, surface varies by Indico version
- \`/export/*\` — accepts \`?apikey=…\` query params, often more reliable

We want to detect registration-form state automatically (to drop the manual \`registrationStatus\` override). Rather than guess which endpoint your Indico exposes and risk a sync that 404s every day, this PR adds a **one-shot manual probe** that calls a curated list of candidate URLs with both auth styles, then prints a table of status codes.

## Safety

- **Read-only** — every probe call is a GET.
- **No bodies in logs** — only status codes, content-types, and byte counts. Any registration data would stay in Indico.
- **Manual trigger only** (\`workflow_dispatch\`) — doesn't run on a schedule.
- **Doesn't commit anything** — no repo changes.

## How to use

1. Merge this PR (auto-merge enabled).
2. **Actions → Probe Indico API (manual) → Run workflow.**
3. Paste the summary table from the log back into this thread.
4. v2.13 wires the winning endpoint into the daily sync.

## Also in this PR

- Fixes the Python 3.12 \`DeprecationWarning\` on \`datetime.utcnow()\` that's been showing up in workflow logs. ISO timestamp format unchanged.

## Test plan

- [x] \`probe-indico-api.py\` parses cleanly
- [x] \`sync-indico.py\` still runs end-to-end (anonymous, no warnings)
- [ ] After merge: trigger the probe workflow, share the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)