### PR TITLE
v2.13.0: probe round 2 — schema inspection + /export/ coverage

### DIFF
--- a/scripts/probe-indico-api.py
+++ b/scripts/probe-indico-api.py
@@ -1,39 +1,40 @@
 #!/usr/bin/env python3
 """
-One-shot probe of Indico's API surface.
+One-shot probe of Indico's API surface — round 2.
 
 PURPOSE
 =======
 We want to detect registration-form state (open/closed) automatically.
-Indico exposes data through several overlapping APIs, and which one
-returns what is version-dependent. Rather than guessing in production
-code, this script tries a handful of candidate URLs and reports back
-how each responded.
+Round 1 (v2.12) established that:
+  - /api/v1/* doesn't exist on this Indico installation (everything
+    returned ~90 KB of HTML — the standard 404 / login page)
+  - /export/event/{id}.json with ?apikey=… returns 200 OK JSON
 
-WHAT IT LOGS
-============
-Status code, content-type, and response size — never bodies. Bodies
-might contain attendee names, emails, or other PII; even with a private
-GitHub Actions log it's better to keep them out.
+Round 2 focuses on the legacy /export/* API where authentication
+actually works. It expands the candidate list with various ?detail=…
+levels and probes for registration-specific endpoints. To make the
+output actually useful for choosing the right endpoint:
+
+  - For 200-OK JSON responses, we print the top-level keys (schema,
+    not data — keys aren't PII).
+  - For tiny responses (<300 bytes), we print the body verbatim. Tiny
+    payloads are almost always error envelopes — useful to interpret.
+
+WHAT IT NEVER PRINTS
+====================
+  - The token (env var, never echoed)
+  - Full response bodies above 300 bytes
+  - Individual field values from large JSON responses
 
 HOW TO RUN
 ==========
-Via GitHub Actions: Actions → "Probe Indico API (manual)" → Run
-workflow. The token comes from the same INDICO_API_TOKEN repo secret
-as the daily sync.
-
-Read the log; share the summary table back with Claude. The PR
-following this one wires the winning endpoint into the daily sync.
-
-WHAT IT DOES NOT DO
-===================
-- Doesn't modify any Indico state (every call is GET)
-- Doesn't write to the repo
-- Doesn't print response bodies
-- Doesn't print the token (the token is in env; we never echo env)
+Actions → "Probe Indico API (manual)" → Run workflow. Paste the
+output back to Claude; the next PR wires the winning endpoint into
+the daily sync.
 """
 from __future__ import annotations
 
+import json
 import os
 import sys
 
@@ -45,100 +46,145 @@ except ImportError:
 
 INDICO_BASE = "https://indico.eiss-europa.com"
 TOKEN = os.environ.get("INDICO_API_TOKEN", "")
-
-# The 2026 ESSC event (id=22) is the working example — that's the
-# event whose registration state we eventually want to read.
 EVENT_ID = "22"
 
-# Candidate endpoints to probe. Each row: (path, attempt_bearer,
-# attempt_apikey). The two flags decide which auth strategies to try
-# for that path — some endpoints accept Bearer, some accept the
-# legacy ?apikey= query parameter, some accept both.
-CANDIDATES: list[tuple[str, bool, bool]] = [
-    # ---- Newer REST API (Bearer-token-friendly) -----------------------
-    (f"/api/v1/events/{EVENT_ID}",                          True,  False),
-    (f"/api/v1/event/{EVENT_ID}",                            True,  False),
-    (f"/api/v1/events/{EVENT_ID}/registration-forms",        True,  False),
-    (f"/api/v1/event/{EVENT_ID}/registration-forms",         True,  False),
-    (f"/api/v1/events/{EVENT_ID}/registrations",             True,  False),
-    (f"/api/v1/event/{EVENT_ID}/registrations",              True,  False),
-    # ---- Indico's management URL family (sometimes JSON) -------------
-    (f"/event/{EVENT_ID}/manage/registration/",              True,  False),
-    # ---- Legacy /export/ API (apikey query param) --------------------
-    (f"/export/event/{EVENT_ID}.json",                       False, True),
-    (f"/export/event/{EVENT_ID}/registrants.json",           False, True),
-    (f"/export/event/{EVENT_ID}/registrationform.json",      False, True),
+# Each row: (label, path, params, use_bearer_header)
+# `params` is merged with `?apikey=…` at request time when use_bearer_header
+# is False. Labels are deliberately short and don't contain the literal word
+# "Bearer" — that string in the log triggers GitHub Actions' secret-masker
+# in some configurations, which redacts the entire surrounding column.
+CANDIDATES: list[tuple[str, str, dict, bool]] = [
+    # ---- /export/event/{id}.json across detail levels ------------------
+    ("qry/base",        f"/export/event/{EVENT_ID}.json", {}, False),
+    ("qry/contribs",    f"/export/event/{EVENT_ID}.json", {"detail": "contributions"}, False),
+    ("qry/sessions",    f"/export/event/{EVENT_ID}.json", {"detail": "sessions"}, False),
+    ("qry/subcontribs", f"/export/event/{EVENT_ID}.json", {"detail": "subcontributions"}, False),
+    # ---- Registration-flavoured /export/ paths -------------------------
+    ("qry/regform",     f"/export/event/{EVENT_ID}/registrationForm.json", {}, False),    # camel
+    ("qry/regforms",    f"/export/event/{EVENT_ID}/registrationForms.json", {}, False),   # plural camel
+    ("qry/regs",        f"/export/event/{EVENT_ID}/registrations.json", {}, False),
+    ("qry/regs.csv",    f"/export/event/{EVENT_ID}/registrants.csv", {}, False),
+    # ---- Whatever /event/{id}/manage/registration/ actually returns ----
+    ("hdr/manage-reg",  f"/event/{EVENT_ID}/manage/registration/", {}, True),
+    ("qry/manage-reg",  f"/event/{EVENT_ID}/manage/registration/", {}, False),
+    # ---- Newer-style endpoints worth one more try ----------------------
+    ("hdr/api-evt",     f"/api/event/{EVENT_ID}", {}, True),
+    ("hdr/api-evts",    f"/api/events/{EVENT_ID}", {}, True),
+    ("hdr/api-reg",     f"/api/event/{EVENT_ID}/registration", {}, True),
+    # ---- Category endpoint, authenticated ------------------------------
+    ("qry/cat-1",       f"/export/categ/1.json", {"from": "today", "to": "today+540d"}, False),
 ]
 
 
-def probe(url: str, params: dict | None = None, headers: dict | None = None) -> dict:
-    """Return a small dict describing the response without echoing
-    the body. `status` covers HTTP errors too; we never raise."""
+def probe(label: str, path: str, params: dict, use_bearer: bool) -> dict:
+    """Make the request; return a small descriptor. No bodies above
+    PEEK_LIMIT bytes are returned, and key listings only — never field
+    values from anything larger."""
+    PEEK_LIMIT = 300
+
+    url = f"{INDICO_BASE}{path}"
+    headers = {"Accept": "application/json"}
+    if use_bearer:
+        headers["Authorization"] = f"Bearer {TOKEN}"
+        req_params = dict(params)
+    else:
+        req_params = dict(params)
+        req_params["apikey"] = TOKEN
+
     try:
-        r = requests.get(url, params=params, headers=headers, timeout=20)
-        return {
-            "status": r.status_code,
-            "content_type": (r.headers.get("content-type") or "").split(";")[0].strip(),
-            "bytes": len(r.content),
-        }
+        r = requests.get(url, params=req_params, headers=headers, timeout=20)
     except Exception as exc:  # noqa: BLE001
-        return {"status": "EXC", "content_type": "", "bytes": 0, "error": str(exc)[:80]}
+        return {"status": "EXC", "ct": "", "bytes": 0, "error": str(exc)[:80]}
+
+    descriptor = {
+        "status": r.status_code,
+        "ct": (r.headers.get("content-type") or "").split(";")[0].strip(),
+        "bytes": len(r.content),
+        "keys": None,
+        "preview": None,
+    }
+
+    # For 200-OK JSON responses, surface the top-level shape so we can
+    # tell at a glance whether a response carries registration data.
+    if r.status_code == 200 and "json" in descriptor["ct"].lower():
+        try:
+            data = r.json()
+            descriptor["keys"] = _top_level_schema(data)
+        except Exception as exc:  # noqa: BLE001
+            descriptor["error"] = f"json-parse: {exc!s:.80}"
+
+    # For tiny responses, print the body verbatim — almost certainly
+    # an error envelope. 300 bytes is too small for any PII payload.
+    if descriptor["bytes"] <= PEEK_LIMIT:
+        descriptor["preview"] = r.text.strip().replace("\n", " ")[:PEEK_LIMIT]
+
+    return descriptor
+
+
+def _top_level_schema(data) -> str:
+    """Render a one-line summary of a JSON payload's shape so we can
+    spot a registration-relevant response without showing values.
+    Recurses one level into the standard Indico HTTPAPIResult envelope."""
+    if isinstance(data, dict):
+        keys = sorted(data.keys())
+        # Drill into Indico's HTTPAPIResult shape if present.
+        if "results" in data and isinstance(data.get("results"), list) and data["results"]:
+            first = data["results"][0]
+            if isinstance(first, dict):
+                nested = sorted(first.keys())
+                return (
+                    "{" + ", ".join(keys) + "} ; results[0]: {"
+                    + ", ".join(nested) + "}"
+                )
+        return "{" + ", ".join(keys) + "}"
+    if isinstance(data, list):
+        return f"[len={len(data)}]"
+    return type(data).__name__
 
 
 def main() -> None:
     if not TOKEN:
         sys.exit("No INDICO_API_TOKEN in env. Set the repo secret and re-run.")
 
-    print(f"Probing {INDICO_BASE} with bot token (event id={EVENT_ID}).")
-    print("Status codes only; no response bodies will be printed.\n")
+    print(f"Probing {INDICO_BASE} (event id={EVENT_ID}) — round 2.")
+    print("Status codes + content-types + top-level keys only.")
+    print("Tiny responses (<300 bytes) are printed verbatim; "
+          "larger ones never are.\n")
 
-    headers_bearer = {
-        "Accept": "application/json",
-        "Authorization": f"Bearer {TOKEN}",
-    }
-    headers_anon = {"Accept": "application/json"}
+    print(f"{'LABEL':<14} {'STATUS':<7} {'CONTENT-TYPE':<22} {'BYTES':>7}  PATH")
+    print("-" * 130)
 
-    rows: list[tuple[str, str, dict]] = []
-
-    for path, try_bearer, try_apikey in CANDIDATES:
-        url = f"{INDICO_BASE}{path}"
-        if try_bearer:
-            rows.append((path, "Bearer", probe(url, headers=headers_bearer)))
-        if try_apikey:
-            rows.append((
-                path,
-                "?apikey",
-                probe(url, params={"apikey": TOKEN}, headers=headers_anon),
-            ))
-
-    # Pretty-print a markdown-ish summary that's easy to copy-paste
-    # back into a chat / PR comment.
-    print(f"{'PATH':<58} {'AUTH':<8} {'STATUS':<8} {'CONTENT-TYPE':<24} {'BYTES':>8}")
-    print("-" * 110)
-    for path, auth, res in rows:
+    rows = []
+    for label, path, params, use_bearer in CANDIDATES:
+        res = probe(label, path, params, use_bearer)
+        rows.append((label, path, params, res))
+        param_str = ""
+        if params:
+            param_str = "  ?" + "&".join(f"{k}={v}" for k, v in params.items() if k != "apikey")
         print(
-            f"{path:<58} {auth:<8} {str(res['status']):<8} "
-            f"{res['content_type']:<24} {res['bytes']:>8}"
+            f"{label:<14} {str(res['status']):<7} {res['ct']:<22} {res['bytes']:>7}  "
+            f"{path}{param_str}"
         )
-        if "error" in res:
-            print(f"  ! {res['error']}")
+        if res.get("keys"):
+            print(f"  ↳ shape: {res['keys']}")
+        if res.get("preview"):
+            print(f"  ↳ body : {res['preview']}")
+        if res.get("error"):
+            print(f"  ! err  : {res['error']}")
 
-    # Heuristic verdict
     print()
-    winners = [r for r in rows if isinstance(r[2]["status"], int) and 200 <= r[2]["status"] < 300]
+    winners = [
+        (label, path, res)
+        for label, path, _, res in rows
+        if isinstance(res["status"], int) and 200 <= res["status"] < 300
+        and "json" in (res["ct"] or "").lower()
+    ]
     if winners:
-        print(f"✓ {len(winners)} endpoint(s) returned 2xx:")
-        for path, auth, res in winners:
-            print(f"    {auth:<8} {path}  ({res['content_type']}, {res['bytes']} bytes)")
-        print("\nNext: paste this table into chat. Claude will wire the "
-              "best-fit endpoint into scripts/sync-indico.py in v2.13.")
+        print(f"✓ {len(winners)} JSON 200-OK endpoint(s):")
+        for label, path, res in winners:
+            print(f"    {label:<14} {path}  ({res['bytes']} bytes)")
     else:
-        print("✗ No endpoint returned 2xx with this token.")
-        print("  Likely causes:")
-        print("    - token scope too narrow (issue a new one with read:user "
-              "and/or read:registrants)")
-        print("    - bot user not a manager on the event/category")
-        print("    - this Indico version uses paths not in the candidate list")
+        print("✗ Still no JSON 200-OK endpoint with this token.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What round 1 told us

- \`/api/v1/*\` doesn't exist on this Indico installation (every Bearer call → ~90 KB HTML, the standard 404 / login page)
- \`/export/event/22.json\` with \`?apikey=…\` authenticates cleanly (200 OK, 10 KB JSON)

So the legacy \`/export/\` API is the path. We just need to find the right path within it.

## What round 2 adds

Two affordances that make the output actually decisive:

- **Top-level keys printed for 200-OK JSON responses.** Keys are schema, not data. They tell us at a glance whether a response carries registration-relevant fields, without revealing any values.
- **Bodies printed verbatim for <300-byte responses.** That tier is too small to hold attendee data — almost always an error envelope. Useful to interpret the 135-byte JSON we saw from \`/event/22/manage/registration/\`.

Expanded candidate list:
- \`/export/event/{id}.json\` across all \`?detail=…\` levels
- \`/export/event/{id}/registrationForm.json\`, \`registrationForms.json\`, \`registrations.json\`
- \`/event/{id}/manage/registration/\` via both auth styles
- \`/export/categ/1.json\` authenticated

Also fixes the cosmetic GitHub-Actions-masking issue from round 1 — auth labels no longer contain the literal word "Bearer".

## How to use

1. Merge (auto-merge enabled).
2. Actions → **Probe Indico API (manual)** → **Run workflow**.
3. Paste the table back here. v2.14 wires the discovered endpoint into the daily sync.

## Safety

Same as round 1: read-only, GET only, no commits, no token in logs. The new schema/preview surfaces are deliberately bounded — keys are schema, and the 300-byte body cap is below any reasonable PII payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)