### PR TITLE
v2.16.0: polish-lift bundle — anchors, focus, :target, theme crossfade

### DIFF
--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -219,6 +219,45 @@ button:focus-visible,
   outline: 2px solid var(--accent);
   outline-offset: 3px;
   border-radius: var(--radius-xs);
+  /* Brand-aligned focus halo: a soft accent-soft ring outside the
+     2px outline gives keyboard users a clear, accessible signal
+     without the harsh chrome-blue default browser ring. */
+  box-shadow: 0 0 0 6px var(--accent-soft);
+}
+
+/* Anchor targets shouldn't be hidden behind the sticky nav header.
+   ~6rem matches the nav's effective height + a small visual margin.
+   Applies anywhere an in-page anchor (`#programme`, `#venue`,
+   `#arthur-laudrain`, …) is the scroll target. */
+:where([id]) {
+  scroll-margin-top: 6rem;
+}
+
+/* `:target` highlight pulse. When a visitor lands on a deep link
+   (e.g. /board.html#arthur-laudrain), briefly draw an accent-soft
+   ring around the target so they know they've arrived. The pulse
+   fades out after ~1.6s; respects prefers-reduced-motion via the
+   global guard above. */
+:target {
+  animation: targetHighlight 1.6s var(--ease-out) 0.1s both;
+  border-radius: var(--radius-md);
+}
+@keyframes targetHighlight {
+  0%   { box-shadow: 0 0 0 0 var(--accent-soft), 0 0 0 0 var(--accent-soft); }
+  40%  { box-shadow: 0 0 0 8px var(--accent-soft), 0 0 24px 4px var(--accent-soft); }
+  100% { box-shadow: 0 0 0 0 hsl(216 88% 50% / 0), 0 0 0 0 hsl(216 88% 50% / 0); }
+}
+
+/* View Transitions API: smooth cross-fade on theme toggle.
+   When document.startViewTransition() is available (see
+   assets/js/theme.js), the browser takes a snapshot of the old DOM,
+   applies the new theme, and cross-fades between the two snapshots
+   over the duration below. Browsers without the API fall back to the
+   instant attribute swap — same end state, just no animation. */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 220ms;
+  animation-timing-function: var(--ease-out);
 }
 
 p {

--- a/src/assets/js/theme.js
+++ b/src/assets/js/theme.js
@@ -32,11 +32,26 @@
     };
     updateLabel();
 
+    // Theme-toggle handler. When the View Transitions API is available
+    // (Chrome 111+, Safari 18+), wrap the swap in startViewTransition()
+    // so the browser cross-fades between the old and new themes. Other
+    // browsers fall back to the instant attribute swap — same end
+    // state, just no animation. Respects prefers-reduced-motion: when
+    // the user has asked for less motion we skip the transition wrapper
+    // unconditionally.
+    const reducedMotion = matchMedia("(prefers-reduced-motion: reduce)");
     btn.addEventListener("click", () => {
       const next = currentEffective() === "dark" ? "light" : "dark";
-      applyTheme(next);
-      try { localStorage.setItem(STORAGE_KEY, next); } catch (_) {}
-      updateLabel();
+      const doSwap = () => {
+        applyTheme(next);
+        try { localStorage.setItem(STORAGE_KEY, next); } catch (_) {}
+        updateLabel();
+      };
+      if (document.startViewTransition && !reducedMotion.matches) {
+        document.startViewTransition(doSwap);
+      } else {
+        doSwap();
+      }
     });
 
     matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {


### PR DESCRIPTION
Four small UX treatments that compound. All CSS-only except for one small JS hook around the existing theme toggle. ~60-line diff.

| # | Treatment | What it does |
|---|---|---|
| 1 | Anchor offset | \`scroll-margin-top: 6rem\` on every \`[id]\` so deep links land below the sticky nav |
| 2 | \`:target\` pulse | A soft accent-coloured ring pulses around the target for ~1.6s on arrival |
| 3 | Focus-ring upgrade | Existing outline gains a soft \`--accent-soft\` halo via box-shadow |
| 4 | Theme-toggle view transition | Light/Dark swap now cross-fades on Chrome 111+ / Safari 18+ via \`document.startViewTransition()\`; falls back to instant on others |

All respect \`prefers-reduced-motion\`. No template, build, or backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)