### PR TITLE
v2.18.0: /events empty-state polish

### DIFF
--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -60,14 +60,14 @@
     "src/events.njk": {
       "fr": {
         "file": "src/events.fr.njk",
-        "source_sha1": "2c1b725ed397925e6e0beb2f101cb47301c6afbf",
-        "translated_on": "2026-05-22",
+        "source_sha1": "019ad5e121384431669c96d2ee778568046a78d9",
+        "translated_on": "2026-05-23",
         "status": "beta"
       },
       "de": {
         "file": "src/events.de.njk",
-        "source_sha1": "2c1b725ed397925e6e0beb2f101cb47301c6afbf",
-        "translated_on": "2026-05-22",
+        "source_sha1": "019ad5e121384431669c96d2ee778568046a78d9",
+        "translated_on": "2026-05-23",
         "status": "beta"
       }
     },

--- a/src/_includes/indico-events-list.njk
+++ b/src/_includes/indico-events-list.njk
@@ -1,5 +1,11 @@
 {# Upcoming-events-from-Indico section.
-   Renders nothing when `indico.upcoming` is empty.
+
+   When `indico.upcoming` is empty:
+     - if `showEmptyState` is truthy, render an empty-state placeholder
+       so the page doesn't feel half-complete (used on /events).
+     - otherwise render nothing (used on /index, where an empty block
+       would be clutter on the homepage).
+
    Consumed by /index and /events in all three languages.
 
    This partial is included from the CHILD page template (not base.njk),
@@ -16,12 +22,15 @@
            syncedAt: "ISO-8601", source: "...", lookaheadDays: N }
      - `limit` (optional, default null) — slice the list to N entries.
        Use 5 on the homepage; omit on /events to show everything.
+     - `showEmptyState` (optional, default false) — render a placeholder
+       when there are no events. Used by /events; opt-in.
 #}
 {% from "icons.njk" import icon %}
 {%- set _lang = lang or "en" -%}
 {%- set t = i18n[_lang] -%}
+{%- set _hasEvents = indico.upcoming and indico.upcoming.length -%}
 
-{% if indico.upcoming and indico.upcoming.length %}
+{% if _hasEvents %}
 <section class="section-tight indico-events" aria-labelledby="indico-events-title">
   <div class="container">
     <div class="featured-eyebrow" style="margin-bottom: var(--space-3);">{{ t.indicoEvents.sectionEyebrow }}</div>
@@ -58,6 +67,26 @@
         {{ t.indicoEvents.viewAll }} {{ icon("external-link") }}
       </a>
     </p>
+  </div>
+</section>
+{% elif showEmptyState %}
+<section class="section-tight indico-events indico-events--empty" aria-labelledby="indico-events-title">
+  <div class="container">
+    <div class="featured-eyebrow" style="margin-bottom: var(--space-3);">{{ t.indicoEvents.sectionEyebrow }}</div>
+    <h2 id="indico-events-title">{{ t.indicoEvents.noEventsTitle }}</h2>
+    <article class="card indico-events-empty-card">
+      <div class="indico-events-empty-icon" aria-hidden="true">{{ icon("calendar") }}</div>
+      <div>
+        <p class="lead muted" style="margin: 0 0 var(--space-3);">
+          {{ t.indicoEvents.noEventsBody }}
+        </p>
+        <p style="margin: 0;">
+          <a class="btn btn-secondary btn-sm" href="https://indico.eiss-europa.com/" target="_blank" rel="noopener">
+            {{ t.indicoEvents.viewAll }} {{ icon("external-link") }}
+          </a>
+        </p>
+      </div>
+    </article>
   </div>
 </section>
 {% endif %}

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -1737,6 +1737,39 @@ h4 { font-size: var(--fs-lg); }
   align-items: center;
 }
 
+/* Empty-state card on /events when no upcoming events are synced.
+   Visible only when the page sets `showEmptyState = true`. The icon
+   echoes the calendar idiom used on event rows; the body explains
+   how events will appear here once published. */
+.indico-events-empty-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-5);
+  align-items: center;
+  padding: clamp(var(--space-5), 2vw + 1rem, var(--space-6));
+}
+
+.indico-events-empty-icon {
+  display: grid;
+  place-items: center;
+  width: 64px;
+  height: 64px;
+  border-radius: var(--radius-md);
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 1.6em;
+}
+
+@media (max-width: 540px) {
+  .indico-events-empty-card {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+  .indico-events-empty-icon {
+    justify-self: center;
+  }
+}
+
 /* On narrow screens drop to a stacked layout so the title gets full width. */
 @media (max-width: 640px) {
   .indico-event {

--- a/src/events.de.njk
+++ b/src/events.de.njk
@@ -26,6 +26,7 @@ alternates:
 </header>
 
 {% set limit = null %}
+{% set showEmptyState = true %}
 {% include "indico-events-list.njk" %}
 
 <section class="section">

--- a/src/events.fr.njk
+++ b/src/events.fr.njk
@@ -26,6 +26,7 @@ alternates:
 </header>
 
 {% set limit = null %}
+{% set showEmptyState = true %}
 {% include "indico-events-list.njk" %}
 
 <section class="section">

--- a/src/events.njk
+++ b/src/events.njk
@@ -25,9 +25,11 @@ alternates:
 </header>
 
 {# Auto-synced upcoming events from indico.eiss-europa.com — full list,
-   no limit. Hides entirely when the synced list is empty (see
-   src/_data/indico.json). #}
+   no limit. When the synced list is empty (see src/_data/indico.json)
+   the partial renders an empty-state placeholder rather than disappearing
+   — opt in via showEmptyState. #}
 {% set limit = null %}
+{% set showEmptyState = true %}
 {% include "indico-events-list.njk" %}
 
 <section class="section">


### PR DESCRIPTION
The upcoming-events section on \`/events\` previously hid itself completely when \`indico.upcoming\` was empty (the default state until members publish events). Page felt half-complete between the page header and the three-formats grid.

Add an opt-in empty-state placeholder rendered when the page sets \`showEmptyState = true\` — a single card with a calendar icon, a short body, and the existing \"View all events on Indico\" CTA. Homepage stays unchanged (no section on empty — that block would be homepage clutter).

i18n strings (\`noEventsTitle\`, \`noEventsBody\`) already existed from v2.4.0 — they were defined but never rendered. Now they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)