### PR TITLE
v2.19.0: custom 404 page

### DIFF
--- a/src/404.njk
+++ b/src/404.njk
@@ -1,0 +1,67 @@
+---
+layout: base.njk
+permalink: /404.html
+title: 404 — Page not found
+description: The page you tried to reach doesn't exist on eiss-europa.com. Quick links to where you probably wanted to go.
+lang: en
+navKey: ""
+# GitHub Pages auto-serves this file for any unmatched path on the apex
+# domain. Keep it permalinked exactly at /404.html so GH Pages finds it.
+---
+{% from "icons.njk" import icon %}
+{# Child templates don't inherit `t` from base.njk because Eleventy
+   renders the child first then injects it into the layout. Derive
+   locally so the i18n catalog is reachable from the markup below. #}
+{%- set t = i18n[lang or "en"] -%}
+
+<section class="notfound" aria-labelledby="notfound-title">
+  <div class="container">
+    <p class="notfound-eyebrow" aria-hidden="true">{{ t.notFound.eyebrow }}</p>
+    <h1 id="notfound-title">{{ t.notFound.heading }}</h1>
+    <p class="lead notfound-body">{{ t.notFound.body }}</p>
+
+    <h2 class="notfound-section-title">{{ t.notFound.tryInstead }}</h2>
+    <ul class="notfound-links" role="list">
+      <li>
+        <a href="/2026.html">
+          {{ icon("calendar") }}
+          <span>{{ t.notFound.quickLinks.nextConference }}</span>
+        </a>
+      </li>
+      <li>
+        <a href="/past.html">
+          {{ icon("book-open") }}
+          <span>{{ t.notFound.quickLinks.pastConferences }}</span>
+        </a>
+      </li>
+      <li>
+        <a href="/membership.html">
+          {{ icon("user-plus") }}
+          <span>{{ t.notFound.quickLinks.membership }}</span>
+        </a>
+      </li>
+      <li>
+        <a href="/board.html">
+          {{ icon("users") }}
+          <span>{{ t.notFound.quickLinks.board }}</span>
+        </a>
+      </li>
+      <li>
+        <a href="/events.html">
+          {{ icon("users-round") }}
+          <span>{{ t.notFound.quickLinks.events }}</span>
+        </a>
+      </li>
+      <li>
+        <a href="/initiative.html">
+          {{ icon("lightbulb") }}
+          <span>{{ t.notFound.quickLinks.initiative }}</span>
+        </a>
+      </li>
+    </ul>
+
+    <p class="notfound-home">
+      <a class="btn btn-primary" href="/">{{ t.notFound.backHome }} {{ icon("arrow-right") }}</a>
+    </p>
+  </div>
+</section>

--- a/src/_data/i18n.js
+++ b/src/_data/i18n.js
@@ -195,6 +195,25 @@ const locales = {
       },
     },
 
+    notFound: {
+      // 404 page strings. GitHub Pages auto-serves /404.html for any
+      // unmatched path on the apex domain, so this surfaces whenever
+      // someone hits a typo'd URL or follows a stale link.
+      eyebrow: "404",
+      heading: "We couldn't find that page",
+      body: "The page you tried to reach doesn't exist, or it moved during the migration off Mobirise. The links below cover most of what people look for.",
+      backHome: "Back to the home page",
+      tryInstead: "Try one of these instead",
+      quickLinks: {
+        nextConference: "Next ESSC conference",
+        pastConferences: "Past conferences",
+        membership: "Membership",
+        board: "The board",
+        events: "Members' events",
+        initiative: "About the Initiative",
+      },
+    },
+
     registrationBadge: {
       // Live status badge on annual conference pages (/2026, /2027, ...).
       // Status is computed at build time from conferences.js dates and
@@ -347,6 +366,22 @@ const locales = {
       },
     },
 
+    notFound: {
+      eyebrow: "404",
+      heading: "Page introuvable",
+      body: "La page que vous cherchez n'existe pas, ou a été déplacée lors de la migration depuis Mobirise. Les liens ci-dessous couvrent la plupart des destinations recherchées.",
+      backHome: "Retour à l'accueil",
+      tryInstead: "Essayez plutôt l'une de ces pages",
+      quickLinks: {
+        nextConference: "Prochaine conférence ESSC",
+        pastConferences: "Conférences passées",
+        membership: "Adhésion",
+        board: "L'équipe",
+        events: "Événements des membres",
+        initiative: "À propos de l'Initiative",
+      },
+    },
+
     registrationBadge: {
       upcoming: "Inscriptions ouvertes",
       closed: "Inscriptions fermées",
@@ -490,6 +525,22 @@ const locales = {
         roundtable: "Runder Tisch",
         keynote: "Keynote",
         conclusion: "Abschluss",
+      },
+    },
+
+    notFound: {
+      eyebrow: "404",
+      heading: "Seite nicht gefunden",
+      body: "Die gesuchte Seite existiert nicht oder wurde während der Migration von Mobirise verschoben. Die folgenden Links decken die meisten Ziele ab.",
+      backHome: "Zurück zur Startseite",
+      tryInstead: "Versuchen Sie stattdessen eine dieser Seiten",
+      quickLinks: {
+        nextConference: "Nächste ESSC-Konferenz",
+        pastConferences: "Vergangene Konferenzen",
+        membership: "Mitgliedschaft",
+        board: "Das Team",
+        events: "Mitgliederveranstaltungen",
+        initiative: "Über die Initiative",
       },
     },
 

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -2263,6 +2263,93 @@ h4 { font-size: var(--fs-lg); }
   }
 }
 
+/* ---------- 404 page ---------------------------------------------------
+   The /404.html GitHub Pages auto-serves for any unmatched path. Tries
+   to be more useful than the default "Page not found" by surfacing the
+   six destinations people actually look for, each with an icon. */
+.notfound {
+  padding-block: clamp(var(--space-7), 6vw + 1rem, var(--space-9));
+  text-align: center;
+}
+
+.notfound-eyebrow {
+  font-size: clamp(4rem, 8vw + 1rem, 7rem);
+  font-weight: 900;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  margin: 0 0 var(--space-2);
+  background: linear-gradient(180deg, var(--accent) 0%, var(--accent-hover) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  opacity: 0.85;
+}
+
+.notfound h1 {
+  font-size: clamp(1.75rem, 1.4rem + 1.8vw, 2.5rem);
+  margin: 0 auto var(--space-4);
+  max-width: 24ch;
+}
+
+.notfound-body {
+  max-width: 44rem;
+  margin: 0 auto var(--space-7);
+  color: var(--text-muted);
+}
+
+.notfound-section-title {
+  font-size: var(--fs-base);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-subtle);
+  margin: 0 0 var(--space-4);
+}
+
+.notfound-links {
+  list-style: none;
+  padding: 0;
+  margin: 0 auto var(--space-7);
+  max-width: 56rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(15rem, 100%), 1fr));
+  gap: var(--space-3);
+}
+
+.notfound-links a {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-5);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text);
+  text-align: left;
+  transition: transform var(--motion-base) var(--ease-out),
+              box-shadow var(--motion-base) var(--ease-out),
+              border-color var(--motion-base) var(--ease-out);
+}
+
+.notfound-links a:hover,
+.notfound-links a:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-2);
+  border-color: var(--accent);
+  text-decoration: none;
+}
+
+.notfound-links a > svg {
+  width: 24px;
+  height: 24px;
+  flex: none;
+  color: var(--accent);
+}
+
+.notfound-home {
+  margin: 0;
+}
+
 /* ---------- print stylesheet -------------------------------------------
    Optimised for attendees printing the conference programme. Forces a
    light theme regardless of OS / toggle, strips chrome (nav, footer,


### PR DESCRIPTION
Replaces GitHub Pages' default monospace 'Page not found' with a brand-aligned page. Big gradient '404' eyebrow, friendly headline acknowledging the Mobirise migration, six destination cards (next conference / past / membership / board / events / initiative), back-home CTA. Screenshot in commit message. EN-only — GH Pages serves a single 404.html.

🤖 Generated with [Claude Code](https://claude.com/claude-code)