### PR TITLE
Fix translation drift on /2026 and /policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ## [Unreleased]
 
+### Fixed
+
+- Translation drift on `/2026` (fr + de) and `/policy` (fr + de) accumulated from PRs #77 → #80. The map-embed include is now propagated to `src/2026.fr.njk` and `src/2026.de.njk`; the Google Maps disclosure in `policy.fr.njk` / `policy.de.njk` was already in place from #77 → #78 and just needed re-stamping. CI `i18n drift check` returns green again.
+
 ### Added
 
 - Google Maps embed in the `/2026` venue section, framed in a frosted-glass card with a 16:9 aspect ratio (`src/_includes/map-embed.njk` + `mapEmbed` field on `conferences.js` entries). The iframe loads on page view rather than behind a click — direct embed reads better and the `/policy` §3 no-social-widgets stance is preserved (Maps isn't a social-media widget). Hidden in print. Reusable: any future `/YYYY` page picks up the embed by adding a `mapEmbed` block to its conferences.js entry.

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -116,14 +116,14 @@
     "src/2026.njk": {
       "fr": {
         "file": "src/2026.fr.njk",
-        "source_sha1": "bc030ab097256366e3048b8d9a32214428f7bbe2",
-        "translated_on": "2026-05-22",
+        "source_sha1": "86a922a511c3619ee1481ff59d40040a7db3db70",
+        "translated_on": "2026-05-23",
         "status": "beta"
       },
       "de": {
         "file": "src/2026.de.njk",
-        "source_sha1": "bc030ab097256366e3048b8d9a32214428f7bbe2",
-        "translated_on": "2026-05-22",
+        "source_sha1": "86a922a511c3619ee1481ff59d40040a7db3db70",
+        "translated_on": "2026-05-23",
         "status": "beta"
       }
     },
@@ -158,14 +158,14 @@
     "src/policy.njk": {
       "fr": {
         "file": "src/policy.fr.njk",
-        "source_sha1": "ca94b0b5315c3055500a46c0ed204913d9004264",
-        "translated_on": "2026-05-22",
+        "source_sha1": "3fea2cfecec8be2dda9d16339af7500299634256",
+        "translated_on": "2026-05-23",
         "status": "beta"
       },
       "de": {
         "file": "src/policy.de.njk",
-        "source_sha1": "ca94b0b5315c3055500a46c0ed204913d9004264",
-        "translated_on": "2026-05-22",
+        "source_sha1": "3fea2cfecec8be2dda9d16339af7500299634256",
+        "translated_on": "2026-05-23",
         "status": "beta"
       }
     }

--- a/src/2026.de.njk
+++ b/src/2026.de.njk
@@ -64,6 +64,10 @@ alternates:
         Jedes Jahr wird die European Security Conference in einem anderen europäischen Land organisiert.
         Die Konferenz 2026 findet im Rahmen der COST-Aktion NetSec an der Universität Stockholm statt.
       </p>
+      {% set year = "2026" %}
+      {% if conferences.byYear[year].mapEmbed %}
+        {% include "map-embed.njk" %}
+      {% endif %}
       <p>
         <a class="btn btn-secondary btn-sm"
            href="https://www.google.com/maps/search/?api=1&query=Stockholm+University"

--- a/src/2026.fr.njk
+++ b/src/2026.fr.njk
@@ -64,6 +64,10 @@ alternates:
         Chaque année, la European Security Conference est organisée dans un pays européen différent.
         La conférence 2026 se tiendra à l'Université de Stockholm, dans le cadre de l'Action COST NetSec.
       </p>
+      {% set year = "2026" %}
+      {% if conferences.byYear[year].mapEmbed %}
+        {% include "map-embed.njk" %}
+      {% endif %}
       <p>
         <a class="btn btn-secondary btn-sm"
            href="https://www.google.com/maps/search/?api=1&query=Stockholm+University"


### PR DESCRIPTION
## Summary

PRs #77 → #80 edited the EN source of `/2026` (map-embed include) and `/policy` (Google Maps disclosure) without re-stamping the FR/DE translation registry. The \`i18n drift check\` CI workflow has been failing on master since.

- Propagate the map-embed include from \`src/2026.njk\` to \`src/2026.fr.njk\` and \`src/2026.de.njk\` (matching the surrounding venue-section structure).
- \`/policy.fr\` and \`/policy.de\` were already updated in lockstep with EN in #77 → #78; they just needed re-stamping in \`data/i18n-state.json\`.
- Re-stamped all four pages via \`scripts/check-i18n-drift.py --mark-fresh\`. CI returns green.

## Test plan

- [ ] CI \`i18n drift check\` passes on this PR.
- [ ] \`/fr/2026.html\` and \`/de/2026.html\` show the Google Maps embed in the venue section.
- [ ] \`/fr/policy.html\` and \`/de/policy.html\` mention Google Maps in §5.

Milestone: **Maintenance & reliability** (recurring drift hygiene)

🤖 Generated with [Claude Code](https://claude.com/claude-code)