### PR TITLE
Remove year_joined from the board Form pipeline + docs

### DIFF
--- a/docs/board-bios-setup.md
+++ b/docs/board-bios-setup.md
@@ -47,12 +47,11 @@ just don't merge.
 |---|---|---|---|
 | 1 | **Full name (with title — Dr / Prof / Mr / Ms)** | Short answer | ✅ |
 | 2 | **Your role** | Dropdown — see roles table below | ✅ |
-| 3 | **Year you joined the EISS board / support team (optional)** | Short answer | ⬜ |
-| 4 | **Position and institution (e.g. 'Associate Professor — Leiden University')** | Short answer | ✅ |
-| 5 | **Research themes (3–5 short phrases, comma-separated)** | Short answer | ⬜ |
-| 6 | **Long bio (optional — used for the support-team display style)** | Paragraph | ⬜ |
-| 7 | **Headshot photo (optional)** | File upload — image only — max 5 MB | ⬜ |
-| 8 | **I consent to publication of my bio on eiss-europa.com** | Checkboxes — single option | ✅ |
+| 3 | **Position and institution (e.g. 'Associate Professor — Leiden University')** | Short answer | ✅ |
+| 4 | **Research themes (3–5 short phrases, comma-separated)** | Short answer | ⬜ |
+| 5 | **Long bio (optional — used for the support-team display style)** | Paragraph | ⬜ |
+| 6 | **Headshot photo (optional)** | File upload — image only — max 5 MB | ⬜ |
+| 7 | **I consent to publication of my bio on eiss-europa.com** | Checkboxes — single option | ✅ |
 
 **Dropdown options for "Your role"** — must match exactly the `label`
 values in `scripts/board-source.json` → `roles` table. Current list:
@@ -70,11 +69,6 @@ values in `scripts/board-source.json` → `roles` table. Current list:
 > (Coordinator titles) get a flowing bio paragraph instead. The script
 > picks the right shape from `kind` in the roles table, looked up by
 > the role label the member chose.
-
-> **Year joined.** Used only for sort order within the "Board Member"
-> tier (longest tenured appears first; missing years sort to the end
-> alphabetically). Founding Director / Treasurer / Secretary-General
-> are unique titles, so year doesn't affect their position.
 
 In *Settings → Responses*, **enable**:
 

--- a/scripts/board-source.json
+++ b/scripts/board-source.json
@@ -13,7 +13,6 @@
     "email": "Email Address",
     "name": "Full name (with title — Dr / Prof / Mr / Ms)",
     "role": "Your role",
-    "year_joined": "Year you joined the EISS board / support team (optional)",
     "affiliation": "Position and institution (e.g. 'Associate Professor — Leiden University')",
     "themes": "Research themes (3–5 short phrases, comma-separated)",
     "bio": "Long bio (optional — used for the support-team display style)",
@@ -21,7 +20,7 @@
     "consent": "I consent to publication of my bio on eiss-europa.com"
   },
 
-  "_roles_doc": "Allowed values for the 'Your role' Form dropdown. The Form question's options must exactly match the `label` values below. `kind` determines which output section the entry lands in (board → /board.html 'Board' grid with research themes; support → 'Support Team' grid with flowing bio). `tier` is the primary sort key — lower tiers appear higher on the page. Within a tier, entries sort by `year_joined` ascending (longest tenured first; missing year sorts to end), then by surname alphabetical. To add a new role: append to this list AND add the matching option to the Form dropdown.",
+  "_roles_doc": "Allowed values for the 'Your role' Form dropdown. The Form question's options must exactly match the `label` values below. `kind` determines which output section the entry lands in (board → /board.html — split into 'Leadership' for tier < 100 and 'Board Members' for tier ≥ 100, with research themes; support → 'Support Team' with flowing bio). `tier` is the primary sort key — lower tiers appear higher on the page. Within a tier, entries sort alphabetical by surname. To add a new role: append to this list AND add the matching option to the Form dropdown.",
 
   "roles": [
     { "label": "Founding Director",          "kind": "board",   "tier": 1 },

--- a/scripts/sync-board.py
+++ b/scripts/sync-board.py
@@ -30,8 +30,7 @@ What it does:
          to Board Member (tier 100).
        - No entries are removed by the sync. To remove someone, edit
          src/_data/board.json directly in a PR (see docs/board-bios-setup.md).
-  4. Sorts each output section by (tier, year_joined ASC, surname ASC).
-     Missing year_joined sorts to the end of its tier.
+  4. Sorts each output section by (tier ASC, surname ASC).
   5. Writes src/_data/board.json only if the content has actually
      changed — so re-running the script when nothing has moved leaves
      a clean working tree.
@@ -74,7 +73,6 @@ PHOTO_DIR = ROOT / "src" / "assets" / "images" / "board"
 
 MAX_PHOTO_WIDTH = 600
 DEFAULT_ROLE = {"label": "Board Member", "kind": "board", "tier": 100}
-UNKNOWN_YEAR = 9999  # sorts to the end of a tier
 
 # ──────────────────────────── helpers ────────────────────────────
 
@@ -132,16 +130,6 @@ def parse_timestamp(raw: str) -> float:
         except ValueError:
             continue
     return 0.0
-
-
-def parse_year(raw: str) -> int:
-    """Parse the optional 'year you joined' field. Returns UNKNOWN_YEAR
-    (sorts to end) for blank or unparseable values. Accepts a bare
-    integer ('2019') or a fragment containing one ('Joined in 2019')."""
-    if not raw:
-        return UNKNOWN_YEAR
-    m = re.search(r"\b(19|20)\d{2}\b", raw)
-    return int(m.group(0)) if m else UNKNOWN_YEAR
 
 
 def consent_ok(raw: str) -> bool:
@@ -433,9 +421,8 @@ def main() -> None:
             )
             role_info = DEFAULT_ROLE
 
-        year = parse_year(row.get(cols.get("year_joined", ""), ""))
         entry = build_from_row(row, cols, role_info, prior)
-        entry["_sort"] = (role_info["tier"], year, surname_key(name))
+        entry["_sort"] = (role_info["tier"], surname_key(name))
 
         if role_info["kind"] == "support":
             support.append(entry)
@@ -448,11 +435,7 @@ def main() -> None:
         if slug in matched_slugs:
             continue
         entry, role_info = carry_over(prior, roles_map)
-        entry["_sort"] = (
-            role_info["tier"],
-            UNKNOWN_YEAR,
-            surname_key(entry["name"]),
-        )
+        entry["_sort"] = (role_info["tier"], surname_key(entry["name"]))
         if role_info["kind"] == "support":
             support.append(entry)
         else:


### PR DESCRIPTION
## Summary

Per your decision: not collecting "year you joined" from board members and not publishing it.

**Frontend**: no change — the field was already not displayed on `/board` (`boardSorted.js` sorts by tier then surname, never touched year_joined). Just cleaning up the Form-pipeline contract.

**Backend** (`scripts/sync-board.py` + `scripts/board-source.json`):
- Dropped `year_joined` from the columns map
- Dropped `parse_year()` helper + `UNKNOWN_YEAR` sentinel
- Simplified sort key from `(tier, year, surname)` to `(tier, surname)`
- Updated columns-doc + roles-doc to reflect the simpler shape

**Docs** (`docs/board-bios-setup.md`):
- Removed the "Year joined" question from the Form questions table (was Q#3; subsequent questions renumbered 3-7)
- Removed the "Year joined" callout note about sort order

The Form has not been published yet (`csv_url` is still empty), so this is purely a contract change — no live data was collected.

Milestone: **Maintenance & reliability**

🤖 Generated with [Claude Code](https://claude.com/claude-code)