### PR TITLE
Bio Read-more: line-clamp + toggle, no more sentence cut

### DIFF
--- a/src/_data/boardSorted.js
+++ b/src/_data/boardSorted.js
@@ -94,40 +94,25 @@ function buildTierMap() {
   return map;
 }
 
-// Split a bio into a teaser + remainder for the card's "Read more"
-// expander. The teaser ends at the last word boundary at or before
-// BIO_TEASER_LEN; the remainder is everything after, leading-trimmed.
-// When the bio is shorter than the threshold, returns the full bio
-// as the teaser with an empty remainder.
-const BIO_TEASER_LEN = 180;
-
-function makeBioParts(bio) {
-  const s = (bio || "").trim();
-  if (!s || s.length <= BIO_TEASER_LEN) {
-    return { teaser: s, rest: "" };
-  }
-  let cut = s.lastIndexOf(" ", BIO_TEASER_LEN);
-  // If there's no space in the first 70% of the teaser window
-  // (CJK / very long words), fall back to a hard cut at the limit.
-  if (cut < BIO_TEASER_LEN * 0.7) cut = BIO_TEASER_LEN;
-  return {
-    teaser: s.slice(0, cut),
-    rest: s.slice(cut).replace(/^\s+/, ""),
-  };
-}
+// Heuristic threshold for "this bio is long enough to need a
+// Read-more toggle". The actual visual truncation is done by CSS
+// line-clamp (3 lines), not by character count — but we need a
+// build-time signal to decide whether to render the toggle button
+// at all, so short bios don't get a pointless "Read more" they
+// can't expand into anything new.
+const BIO_LONG_THRESHOLD = 180;
 
 module.exports = function () {
   const esscNames = collectEsscNames();
   const tierByRole = buildTierMap();
 
   function annotate(person) {
-    const { teaser, rest } = makeBioParts(person.bio);
+    const bio = (person.bio || "").trim();
     return {
       ...person,
       tier: tierByRole[person.role] ?? 999,
       isEsscActive: esscNames.has(identityKey(person.name)),
-      bioTeaser: teaser,
-      bioRest: rest,
+      bioIsLong: bio.length > BIO_LONG_THRESHOLD,
     };
   }
 

--- a/src/_data/i18n.js
+++ b/src/_data/i18n.js
@@ -219,6 +219,7 @@ const locales = {
       // Strings used by src/_includes/person-card.njk on /board.
       researchThemes: "Research themes",
       readMore: "Read more",
+      readLess: "Read less",
       linksAriaLabel: "Links",
       // Tooltip + accessible name for the mic icon shown next to people
       // who are chairing, discussing, or speaking at the live ESSC
@@ -405,6 +406,7 @@ const locales = {
     boardPage: {
       researchThemes: "Thèmes de recherche",
       readMore: "Lire la suite",
+      readLess: "Réduire",
       linksAriaLabel: "Liens",
       esscSpeakerTitle: "Préside ou intervient à l'ESSC en cours",
     },
@@ -579,6 +581,7 @@ const locales = {
     boardPage: {
       researchThemes: "Forschungsthemen",
       readMore: "Mehr lesen",
+      readLess: "Weniger anzeigen",
       linksAriaLabel: "Links",
       esscSpeakerTitle: "Leitet oder spricht beim aktuellen ESSC",
     },

--- a/src/_includes/person-card.njk
+++ b/src/_includes/person-card.njk
@@ -53,14 +53,17 @@
     </p>
     {%- endif %}
 
-    {%- if person.bioTeaser %}
-    <div class="person-bio-wrap">
-      <p class="person-bio">{{ person.bioTeaser | safe }}{% if person.bioRest %}<span class="person-bio-ellipsis">…</span>{% endif %}</p>
-      {%- if person.bioRest %}
-      <details class="person-bio-more">
-        <summary>{{ t.boardPage.readMore }}</summary>
-        <p class="person-bio-rest">{{ person.bioRest | safe }}</p>
-      </details>
+    {%- if person.bio %}
+    <div class="person-bio-wrap"{% if person.bioIsLong %} data-collapsible="true"{% endif %}>
+      <p class="person-bio">{{ person.bio | safe }}</p>
+      {%- if person.bioIsLong %}
+      <button type="button"
+              class="person-bio-toggle"
+              aria-expanded="false"
+              data-label-collapsed="{{ t.boardPage.readMore }}"
+              data-label-expanded="{{ t.boardPage.readLess }}">
+        {{ t.boardPage.readMore }}
+      </button>
       {%- endif %}
     </div>
     {%- endif %}

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -1720,58 +1720,70 @@ h4 { font-size: var(--fs-lg); }
   flex: 0 0 auto;
 }
 
-/* Bio teaser with optional Read-more expander. boardSorted.js splits
-   the bio into `teaser` + `rest`; the teaser renders inline always,
-   the rest only when <details> is opened. The trailing ellipsis is
-   visible while the expander is closed, hidden once open (via :has()
-   on the wrapping div). Result: opening the expander reveals only new
-   text rather than repeating the teaser. */
+/* Bio + Read-more toggle. The full bio always renders as a single
+   continuous paragraph (no awkward sentence break across a button);
+   CSS line-clamp visually truncates it to 3 lines when collapsed,
+   with the browser auto-rendering an ellipsis. The button toggles
+   the clamp on/off via a data attribute set by ~5 lines of JS in
+   src/assets/js/theme.js. Short bios (boardSorted.js's bioIsLong
+   = false) skip the toggle entirely. */
 .person-bio-wrap {
   margin: var(--space-3) 0 0;
 }
-.person-bio,
-.person-bio-rest {
+.person-bio {
   font-size: var(--fs-sm);
   color: var(--text-muted);
   line-height: var(--lh-snug);
   margin: 0;
 }
-.person-bio-ellipsis {
-  /* Visually flush with the preceding word; hidden when the rest is
-     unfolded so the prose flows continuously. */
+.person-bio-wrap[data-collapsible="true"] .person-bio {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
-.person-bio-wrap:has(.person-bio-more[open]) .person-bio-ellipsis {
-  display: none;
+.person-bio-wrap[data-expanded="true"] .person-bio {
+  display: block;
+  -webkit-line-clamp: unset;
+  line-clamp: unset;
+  overflow: visible;
 }
-.person-bio-more {
-  margin: var(--space-1) 0 0;
-}
-.person-bio-more > summary {
-  cursor: pointer;
-  color: var(--accent);
-  font-weight: 600;
-  font-size: var(--fs-sm);
-  list-style: none;
-  padding: 0.15rem 0;
+
+.person-bio-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.25em;
+  gap: 0.3em;
+  margin-top: var(--space-1);
+  padding: 0.15rem 0;
+  background: none;
+  border: 0;
+  font: inherit;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--accent);
+  cursor: pointer;
 }
-.person-bio-more > summary::-webkit-details-marker { display: none; }
-.person-bio-more > summary::after {
+.person-bio-toggle:hover {
+  text-decoration: underline;
+}
+.person-bio-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-xs);
+}
+.person-bio-toggle::after {
   content: "▸";
   font-size: 0.85em;
   transition: transform var(--motion-fast) var(--ease-out);
 }
-.person-bio-more[open] > summary::after { transform: rotate(90deg); }
-.person-bio-more > summary:hover { text-decoration: underline; }
-.person-bio-more[open] > summary {
-  /* Once open, quiet the trigger so the prose takes focus. */
+.person-bio-toggle[aria-expanded="true"]::after {
+  transform: rotate(90deg);
+}
+.person-bio-toggle[aria-expanded="true"] {
+  /* Once expanded, quiet the trigger so the prose takes focus. */
   color: var(--text-subtle);
   font-weight: 500;
-}
-.person-bio-more > .person-bio-rest {
-  margin-top: var(--space-2);
 }
 
 /* "Research themes:" line — currently rendered with a thin border-top

--- a/src/assets/js/theme.js
+++ b/src/assets/js/theme.js
@@ -81,3 +81,30 @@
     init();
   }
 })();
+
+/* Bio Read-more toggle on /board. The bio paragraph is line-clamped
+   to 3 lines via CSS by default; this script flips a data attribute
+   on the wrapping div that removes the clamp. Button text + aria-
+   expanded swap to match. Build-time decides which bios get a toggle
+   (boardSorted.js `bioIsLong` boolean) so short bios stay clean. */
+(function () {
+  function bindBioToggle(btn) {
+    btn.addEventListener("click", function () {
+      var wrap = btn.parentElement;
+      var nowExpanded = wrap.dataset.expanded !== "true";
+      wrap.dataset.expanded = String(nowExpanded);
+      btn.setAttribute("aria-expanded", String(nowExpanded));
+      btn.textContent = nowExpanded
+        ? btn.dataset.labelExpanded
+        : btn.dataset.labelCollapsed;
+    });
+  }
+  function init() {
+    document.querySelectorAll(".person-bio-toggle").forEach(bindBioToggle);
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## What was wrong

From the screenshot you shared: the previous design split the bio into **teaser + button + rest**, which meant the button physically sat in the middle of a sentence. When expanded the prose read as:

> ... He is a
> **[ Read more ▾ ]**
> DPhil candidate in International Relations at St. Antony's College, Oxford.

## What's new

The full bio always renders as a single continuous `<p>`. CSS `line-clamp: 3` does the visual truncation when collapsed (browser auto-adds the ellipsis). A small JS toggle flips a data attribute that removes the clamp.

When expanded, the bio is one continuous paragraph. No sentence break across the trigger. The button just sits below.

Verified locally: John's card collapsed = 59px tall (3 lines), expanded = 234px (full bio), button toggles `Read more ↔ Read less`, arrow rotates `▸ → ▾`, `aria-expanded` updates.

## Side cleanups

- Dropped `makeBioParts` + `bioTeaser` + `bioRest` from `src/_data/boardSorted.js` — only `bioIsLong` remains (gate for whether to render the button at all).
- Removed `<details>`-based CSS, replaced with `.person-bio-wrap` + `.person-bio-toggle`.
- Added `readLess` i18n key in EN / FR / DE.
- Toggle is keyboard-accessible (focus-visible outline), `aria-expanded` for screen readers.

## Test plan

- [ ] Bios over ~180 chars show a `Read more` button. Hovering the button underlines it; clicking expands and changes text to `Read less`.
- [ ] Expanded bio reads as one continuous paragraph — no visible cut between teaser and rest.
- [ ] Short bios (Hugo, Marie, etc. — the existing entries already had themes-only) show no button.
- [ ] Toggle is keyboard-reachable; Enter/Space activates.

Milestone: **ESSC 2026 ops** (board UX, ships before ESSC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)