### PR TITLE
photoOverride: hand-swap headshots when the Form won't let you

### DIFF
--- a/docs/board-bios-setup.md
+++ b/docs/board-bios-setup.md
@@ -156,6 +156,25 @@ This inherits to every file uploaded later.
 *Share* dance on each upload as submissions arrive. More secure, more
 work — fine for ~20 board members.)
 
+### Replacing a photo after a respondent has already submitted
+
+Google Forms does **not** let a respondent replace a file upload when
+editing an existing response (the previous file shows but can't be
+removed). Workaround:
+
+1. The respondent emails you the new photo.
+2. You add the file to `src/assets/images/board/` — any filename;
+   ideally something stable like `firstname-lastname-2026.jpg`.
+3. Open `src/_data/board.json`, find the person's entry, and add:
+   ```json
+   "photoOverride": "/assets/images/board/firstname-lastname-2026.jpg"
+   ```
+4. Commit + push. The card immediately picks up the new photo.
+
+The sync script preserves `photoOverride` across runs — it's never
+overwritten by what's in the Form. To revert to the Form's photo
+again, delete the `photoOverride` line.
+
 ## Step 6 · Test the workflow
 
 After Step 4, trigger the workflow manually:

--- a/scripts/sync-board.py
+++ b/scripts/sync-board.py
@@ -383,11 +383,22 @@ def build_from_row(row: dict, cols: dict, role_info: dict, prior: dict | None) -
 
     # Slug + alt are preserved across syncs if the prior entry has them
     # (a hand-set slug for deep linking, or a custom alt for a11y).
+    #
+    # `photoOverride` is also preserved as-is. Google Forms doesn't let
+    # respondents replace a file upload when editing an existing
+    # response, so the only path to swap a headshot is hand-editing
+    # board.json: the operator uploads a new file to
+    # src/assets/images/board/ and sets `photoOverride` to its path.
+    # The template prefers photoOverride > photo, and the sync never
+    # touches this field — so a manual swap survives every future
+    # Form-driven update.
     if prior:
         if prior.get("slug"):
             person["slug"] = prior["slug"]
         if prior.get("alt"):
             person["alt"] = prior["alt"]
+        if prior.get("photoOverride"):
+            person["photoOverride"] = prior["photoOverride"]
 
     return person
 

--- a/src/_includes/person-card.njk
+++ b/src/_includes/person-card.njk
@@ -25,7 +25,7 @@
 {%- set t = i18n[lang] -%}
 
 <article class="person"{% if person.slug %} id="{{ person.slug }}"{% endif %}>
-  <img class="person-photo" src="{{ person.photo }}" alt="{{ person.alt or person.name }}" loading="lazy">
+  <img class="person-photo" src="{{ person.photoOverride or person.photo }}" alt="{{ person.alt or person.name }}" loading="lazy">
   <div class="person-body">
     <p class="person-role">
       <span class="person-role-primary">{{ person.role }}</span>


### PR DESCRIPTION
## The problem

[Screenshot you sent]: editing your existing Form response, the photo field shows the previously-uploaded file (\`RSD25_cropped...\`) but offers no way to remove or replace it.

This is a long-standing Google Forms limitation — confirmed across many threads on the Google Forms community + Stack Overflow. When a respondent edits a response that includes a file upload, the previous file is locked in. The recommended Google path is "submit a fresh response", which "Limit to 1 response" prevents.

## The workaround in our pipeline

New \`photoOverride\` field on \`board.json\` entries that the sync **never touches**.

- \`person-card.njk\` uses \`person.photoOverride or person.photo\`
- \`scripts/sync-board.py\` preserves \`prior.photoOverride\` across every Form-driven rebuild (alongside the existing \`slug\` + \`alt\` preservation)
- \`docs/board-bios-setup.md\` gains a "Replacing a photo" section with the workflow

## Operator workflow when this comes up

1. Board member emails you the new photo
2. Drop it into \`src/assets/images/board/\` (any filename — \`firstname-lastname-2026.jpg\` is fine)
3. Edit the person's entry in \`board.json\`, add:
   \`\`\`json
   "photoOverride": "/assets/images/board/firstname-lastname-2026.jpg"
   \`\`\`
4. Commit + push

Card immediately uses the new photo. The next sync run respects the override forever. To revert to the Form's photo: just delete the \`photoOverride\` line.

## Test plan

- [ ] Hand-edit Arthur's entry: add \`"photoOverride": "/assets/images/<some-other-image>.jpg"\` → verify card renders the override
- [ ] Run \`python3 scripts/sync-board.py\` → verify the override survives the sync no-op
- [ ] Remove the override → verify card falls back to \`person.photo\`

Milestone: **Maintenance & reliability**

🤖 Generated with [Claude Code](https://claude.com/claude-code)