### PR TITLE
sync-board: don't swallow photo-only changes in the log

### DIFF
--- a/scripts/sync-board.py
+++ b/scripts/sync-board.py
@@ -74,6 +74,14 @@ PHOTO_DIR = ROOT / "src" / "assets" / "images" / "board"
 MAX_PHOTO_WIDTH = 600
 DEFAULT_ROLE = {"label": "Board Member", "kind": "board", "tier": 100}
 
+# Repo-relative paths of photo files whose bytes were rewritten during
+# the current run. Filled by download_photo() each time a new image
+# differs from what's already on disk. Used by main()'s "did anything
+# change?" check so a photo update doesn't get silently swallowed when
+# the board.json `photo` field string is unchanged (path stays the
+# same; only the file bytes change).
+PHOTOS_CHANGED: list[str] = []
+
 # ──────────────────────────── helpers ────────────────────────────
 
 
@@ -250,8 +258,15 @@ def download_photo(url: str, dest_no_ext: Path) -> str | None:
     else:
         out_bytes = data
 
-    if not (dest.exists() and dest.read_bytes() == out_bytes):
+    bytes_changed = not (dest.exists() and dest.read_bytes() == out_bytes)
+    if bytes_changed:
         dest.write_bytes(out_bytes)
+        # Track on the module so main() can include photo-file changes
+        # in its "did anything change?" decision. board.json paths
+        # don't change when only the photo bytes change (the URL path
+        # stays the same), so without this we'd silently swallow new
+        # uploads.
+        PHOTOS_CHANGED.append(dest.relative_to(ROOT).as_posix())
 
     rel = dest.relative_to(ROOT).as_posix()
     # board.json paths are absolute-from-site-root (e.g. /assets/...);
@@ -663,13 +678,30 @@ def main() -> None:
     new_data["members"] = members
     new_data["support"] = support
 
-    if new_data == prior_raw:
+    json_unchanged = new_data == prior_raw
+
+    if json_unchanged and not PHOTOS_CHANGED:
         print()
         print("No substantive changes — leaving src/_data/board.json untouched.")
         return
 
+    if json_unchanged and PHOTOS_CHANGED:
+        print()
+        print(
+            "board.json bytes unchanged, but headshot file(s) updated "
+            "on disk — the create-pull-request action below will commit them:"
+        )
+        for p in PHOTOS_CHANGED:
+            print(f"  ~ {p}")
+        return
+
     print()
     print(diff_summary(prior_raw, new_data))
+    if PHOTOS_CHANGED:
+        print()
+        print("Headshot file(s) updated on disk:")
+        for p in PHOTOS_CHANGED:
+            print(f"  ~ {p}")
 
     BOARD.write_text(
         json.dumps(new_data, indent=2, ensure_ascii=False) + "\n",


### PR DESCRIPTION
## The misleading message

While debugging Arthur's photo-update test, we discovered that the sync workflow's log line was lying:

> No substantive changes — leaving src/_data/board.json untouched.

Meanwhile, the workflow *did* open auto-PR [#105](https://github.com/EISSeuropa/EISSeuropa.github.io/pull/105) with the new photo. So the script's reporting was wrong, not the workflow.

## Root cause

`sync-board.py`'s "did anything change?" check only compares `board.json` byte-for-byte. But the script also writes photo bytes to `src/assets/images/board/<slug>.jpg` as a side effect of `build_from_row → download_photo`. When a respondent uploads a new photo but their other fields are unchanged:

- `board.json`: identical (the `photo` field is a path string; same string regardless of the photo's *bytes*)
- `<slug>.jpg`: rewritten on disk with new bytes
- Script: prints "no substantive changes"

The `peter-evans/create-pull-request` step that runs *after* the script picks up the disk-level diff and creates the PR anyway — but the script's own log line confused us.

## Fix

Track which photo files actually changed bytes in a module-level list (`PHOTOS_CHANGED`), populated by `download_photo()` when it writes new bytes. `main()` now has three cases:

1. Nothing changed → "No substantive changes" (unchanged from before)
2. `board.json` changed → diff summary (unchanged) + the list of photo files that also changed
3. **Only photos changed** → `"board.json bytes unchanged, but headshot file(s) updated on disk"` + list of files

No workflow changes needed. The create-pull-request action was already correct.

## Test plan

- [ ] Re-run the *Sync board bios from Google Form* workflow
- [ ] If a photo changed but nothing else did, log line now reads honestly
- [ ] If both photo + other fields changed, diff summary + photo list both appear

Milestone: **Maintenance & reliability**

🤖 Generated with [Claude Code](https://claude.com/claude-code)