### PR TITLE
sync-board: descriptive PR titles based on what changed

### DIFF
--- a/.github/workflows/sync-board.yml
+++ b/.github/workflows/sync-board.yml
@@ -59,6 +59,7 @@ jobs:
         run: pip install -r scripts/requirements.txt
 
       - name: Run sync script and capture diff
+        id: sync
         run: |
           set -o pipefail
           python3 scripts/sync-board.py | tee /tmp/sync-board.txt
@@ -81,7 +82,12 @@ jobs:
           branch: board-sync/auto
           base: master
           delete-branch: true
-          title: "data: sync board bios from Google Form"
+          # Title is computed by sync-board.py based on the kind of
+          # change (photo-only, single update, addition, etc.) so the
+          # PR list reads at a glance. Falls back to the generic
+          # multi-change title when the script doesn't emit one (e.g.
+          # version of the script that pre-dates this output).
+          title: ${{ steps.sync.outputs.title || 'data: sync board bios from Google Form' }}
           commit-message: |
             data: sync board.json from Google Form
 

--- a/scripts/sync-board.py
+++ b/scripts/sync-board.py
@@ -581,6 +581,76 @@ def diff_summary(old: dict, new: dict) -> str:
     return "\n".join(lines)
 
 
+def compute_pr_title(
+    prior_raw: dict, new_data: dict, photos_changed: list[str]
+) -> str | None:
+    """Compose a short, situation-specific PR title for the auto-sync
+    PR that the workflow opens. Returns None when nothing changed
+    (the workflow won't open a PR in that case anyway).
+
+    Cases:
+      - photo-only, 1 person: "data: refresh headshot for <name>"
+      - photo-only, N people: "data: refresh N headshots"
+      - 1 addition:           "data: add <name> to the board"
+      - 1 removal:            "data: remove <name> from the board"
+      - 1 update:             "data: update bio for <name>"
+      - everything else:      "data: sync board bios (N changes)"
+    """
+    def by_name(d: dict) -> dict[str, dict]:
+        return {p["name"]: p for p in d.get("members", []) + d.get("support", [])}
+
+    old_p, new_p = by_name(prior_raw), by_name(new_data)
+    added = sorted(set(new_p) - set(old_p))
+    removed = sorted(set(old_p) - set(new_p))
+    changed = sorted(
+        n for n in (set(old_p) & set(new_p))
+        if json.dumps(old_p[n], sort_keys=True)
+        != json.dumps(new_p[n], sort_keys=True)
+    )
+    n_json = len(added) + len(removed) + len(changed)
+    n_photo = len(photos_changed)
+
+    if n_json == 0 and n_photo == 0:
+        return None
+
+    # Photo-only change(s) — surface the case the previous version of
+    # this script swallowed.
+    if n_json == 0 and n_photo > 0:
+        if n_photo == 1:
+            slug = Path(photos_changed[0]).stem  # e.g. "arthur-laudrain"
+            name = next(
+                (n for n in new_p if slugify(n) == slug),
+                slug.replace("-", " ").title(),
+            )
+            return f"data: refresh headshot for {name}"
+        return f"data: refresh {n_photo} headshots"
+
+    # Single, unambiguous JSON change → describe it specifically.
+    if n_photo == 0 and len(added) == 1 and not removed and not changed:
+        return f"data: add {added[0]} to the board"
+    if n_photo == 0 and not added and len(removed) == 1 and not changed:
+        return f"data: remove {removed[0]} from the board"
+    if n_photo == 0 and not added and not removed and len(changed) == 1:
+        return f"data: update bio for {changed[0]}"
+
+    # Everything else (multi-change runs, mixed JSON + photo) — fall
+    # back to a count.
+    total = n_json + n_photo
+    plural = "" if total == 1 else "s"
+    return f"data: sync board bios ({total} change{plural})"
+
+
+def emit_github_output(key: str, value: str) -> None:
+    """Write `key=value` to $GITHUB_OUTPUT when running under GitHub
+    Actions, so the next workflow step can read it as a step output.
+    No-op outside CI."""
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(f"{key}={value}\n")
+
+
 def main() -> None:
     config = json.loads(CONFIG.read_text())
     csv_url = (config.get("sheet", {}).get("csv_url") or "").strip()
@@ -684,6 +754,13 @@ def main() -> None:
         print()
         print("No substantive changes — leaving src/_data/board.json untouched.")
         return
+
+    # Emit the PR title for the workflow's create-pull-request step.
+    # Computed before we mutate anything so the function sees the
+    # before/after pair cleanly.
+    title = compute_pr_title(prior_raw, new_data, PHOTOS_CHANGED)
+    if title:
+        emit_github_output("title", title)
 
     if json_unchanged and PHOTOS_CHANGED:
         print()


### PR DESCRIPTION
## Why

Previous auto-PR title was static — "data: sync board bios from Google Form" — regardless of whether the run brought in a single photo refresh, a new board member, or five updates. The PR list gave you no sense of what was in each one.

## What's new

`scripts/sync-board.py` now computes a situation-specific title at the end of `main()` and writes it to `$GITHUB_OUTPUT`. The workflow reads it via `${{ steps.sync.outputs.title }}` and falls back to the old static title when the script doesn't emit one (defensive).

| Scenario | Resulting title |
|---|---|
| Photo-only, 1 person | `data: refresh headshot for Dr Arthur Laudrain` |
| Photo-only, N people | `data: refresh N headshots` |
| 1 new member | `data: add Dr Jane Doe to the board` |
| 1 removal | `data: remove Dr Hugo Meijer from the board` |
| 1 bio update | `data: update bio for Dr Arthur Laudrain` |
| Anything else (mixed / multi) | `data: sync board bios (N changes)` |

## Verified

- Unit tested against the 7 scenarios — each produces the expected title
- Mocked a photo-only change locally with `GITHUB_OUTPUT=/tmp/...` set → confirmed `title=data: refresh headshot for Dr Arthur Laudrain` written to the file
- Workflow expression uses `|| 'fallback'` so a script that doesn't emit the title still works

## Test plan

- [ ] Submit a fresh photo via the Form → workflow opens an auto-PR titled `data: refresh headshot for <your name>`
- [ ] Submit a fresh photo AND change your bio → workflow opens an auto-PR titled `data: sync board bios (2 changes)`
- [ ] Don't change anything but re-run the workflow → no PR (`No substantive changes`)

Milestone: **Maintenance & reliability**

🤖 Generated with [Claude Code](https://claude.com/claude-code)