### PR TITLE
Split affiliation into position + institution; flag inline

### DIFF
--- a/scripts/sync-board.py
+++ b/scripts/sync-board.py
@@ -286,14 +286,14 @@ def _cell(row: dict, cols: dict, key: str) -> str:
     return (row.get(col_name, "") or "").strip()
 
 
-def _join_affiliation(position: str, institution: str) -> str:
-    """Join the two free-text fields into the single `affiliation` line
-    that the card renders ("Position — Institution"). Either may be
-    empty; in that case we render what we have without a stray dash."""
-    p, i = position.strip(), institution.strip()
-    if p and i:
-        return f"{p} — {i}"
-    return p or i
+## (No-op kept for git-history clarity.)
+##
+## _join_affiliation() used to merge the Form's separate Position +
+## Institution fields into a single "Position — Institution" string
+## stored as `affiliation` on each entry. Removed when the card
+## switched to rendering Position + Institution on separate lines
+## (with the country flag inline on the institution line). The two
+## fields are now stored as-is in board.json.
 
 
 # Map of board.json `links` keys → board-source.json `columns` keys.
@@ -348,19 +348,20 @@ def build_from_row(row: dict, cols: dict, role_info: dict, prior: dict | None) -
     if func_resp:
         person["functionalResponsibility"] = func_resp
 
-    # Affiliation is now stitched from the form's split fields. Falls
-    # back to the prior single-field value if neither half is present
-    # (i.e. existing entries that pre-date this Form shape).
-    position = _cell(row, cols, "position")
-    institution = _cell(row, cols, "institution")
-    affiliation = _join_affiliation(position, institution)
-    if not affiliation and prior:
-        affiliation = prior.get("affiliation", "")
-    if affiliation:
-        person["affiliation"] = affiliation
+    # Position + institution stay as separate fields on the entry so
+    # the card can render them on dedicated lines (with the country
+    # flag inline on the institution line). Each falls back to the
+    # prior value when blank in the new submission.
+    position = _cell(row, cols, "position") or (prior or {}).get("position", "")
+    institution = _cell(row, cols, "institution") or (prior or {}).get("institution", "")
+    if position:
+        person["position"] = position
+    if institution:
+        person["institution"] = institution
 
-    # Country: optional separate field, rendered as a small line below
-    # the affiliation. Not joined into the affiliation string itself.
+    # Country: separate field rendered as a flag icon inline on the
+    # institution line (or as a fallback map-pin + text line when no
+    # flag SVG is mapped for the country).
     country = _cell(row, cols, "country") or (prior or {}).get("country", "")
     if country:
         person["country"] = country

--- a/src/_data/board.json
+++ b/src/_data/board.json
@@ -6,81 +6,90 @@
       "role": "Founding Director",
       "photo": "/assets/images/meijer-2-140x175.jpg",
       "alt": "Dr Hugo MEIJER",
-      "affiliation": "CNRS Research Fellow — Sciences Po, Center for International Studies (CERI).",
       "themes": "International Relations, Foreign Policy Analysis, Security Studies, Alliances.",
-      "country": "France"
+      "country": "France",
+      "position": "CNRS Research Fellow",
+      "institution": "Sciences Po, Center for International Studies (CERI)"
     },
     {
       "name": "Dr Marie Robin",
       "role": "Treasurer",
       "photo": "/assets/images/screenshot-2024-03-25-at-18.29.49-348x391.png",
       "alt": "Dr Marie Robin",
-      "affiliation": "Assistant Professor of War Studies — Leiden University.",
       "themes": "Revenge in international relations, Strategic use of emotions, Evolution of conflictuality, Ethics of war.",
-      "country": "Netherlands"
+      "country": "Netherlands",
+      "position": "Assistant Professor of War Studies",
+      "institution": "Leiden University"
     },
     {
       "name": "Prof. Moritz Weiss",
       "role": "Secretary-General",
       "photo": "/assets/images/moritzweiss-eiss2024-348x305.jpg",
       "alt": "Prof. Moritz Weiss",
-      "affiliation": "Senior Lecturer and Principal Investigator — Ludwig Maximilian University of Munich.",
       "themes": "International Relations, Theorizing (informal) institutions, European integration, Governance of international security.",
-      "country": "Germany"
+      "country": "Germany",
+      "position": "Senior Lecturer and Principal Investigator",
+      "institution": "Ludwig Maximilian University of Munich"
     },
     {
       "name": "Prof. Nicolas Blarel",
       "role": "Board Member",
       "photo": "/assets/images/d200x250-3.jpeg",
       "alt": "Prof. Nicolas Blarel",
-      "affiliation": "Associate Professor of International Relations and Director of Studies — Leiden University.",
       "themes": "Foreign Policy Analysis, Politics of migration governance, International politics of South Asia.",
-      "country": "Netherlands"
+      "country": "Netherlands",
+      "position": "Associate Professor of International Relations and Director of Studies",
+      "institution": "Leiden University"
     },
     {
       "name": "Prof. Antonio Calcara",
       "role": "Board Member",
       "photo": "/assets/images/r2sk57tg-400x400.jpg",
       "alt": "Prof. Antonio Calcara",
-      "affiliation": "Professor — Vrije Universiteit Brussels.",
       "themes": "European Security and Defence, Defence Industry, Political Economy.",
-      "country": "Belgium"
+      "country": "Belgium",
+      "position": "Professor",
+      "institution": "Vrije Universiteit Brussels"
     },
     {
       "name": "Dr Julia Carver",
       "role": "Board Member",
       "photo": "/assets/images/julia20carver20headshot-253x169.jpeg",
       "alt": "Dr Julia Carver",
-      "affiliation": "Assistant Professor — Leiden University.",
       "themes": "Foreign policymaking, Strategic concepts, Emerging digital technologies.",
-      "country": "Netherlands"
+      "country": "Netherlands",
+      "position": "Assistant Professor",
+      "institution": "Leiden University"
     },
     {
       "name": "Prof. Silvia D’Amato",
       "role": "Board Member",
       "photo": "/assets/images/1-2.jpeg",
       "alt": "Prof. Silvia D’Amato",
-      "affiliation": "Associate Professor — James Madison University.",
       "themes": "Terrorism, Political Violence and War, Peace and Justice.",
-      "country": "United States"
+      "country": "United States",
+      "position": "Associate Professor",
+      "institution": "James Madison University"
     },
     {
       "name": "Prof. Filip Ejdus",
       "role": "Board Member",
       "photo": "/assets/images/ejdus-photo-253x253.jpg",
       "alt": "Prof. Filip Ejdus",
-      "affiliation": "Professor of Security Studies — Faculty of Political Science, University of Belgrade.",
       "themes": "Identity, memory, and emotions, International interventions, Civil-military relations, Security sector reform.",
-      "country": "Serbia"
+      "country": "Serbia",
+      "position": "Professor of Security Studies",
+      "institution": "Faculty of Political Science, University of Belgrade"
     },
     {
       "name": "Dr Eliza Gheorghe",
       "role": "Board Member",
       "photo": "/assets/images/eliza-gheorghe.jpg",
       "alt": "Dr Eliza Gheorghe",
-      "affiliation": "Assistant Professor — Department of International Relations, Bilkent University.",
       "themes": "International Relations Theory, International Security, Nuclear Politics.",
-      "country": "Turkey"
+      "country": "Turkey",
+      "position": "Assistant Professor",
+      "institution": "Department of International Relations, Bilkent University"
     },
     {
       "name": "Dr John NT Helferich",
@@ -88,36 +97,40 @@
       "functionalResponsibility": "Events Coordinator",
       "photo": "/assets/images/helferich-portrait-college-3.jpeg",
       "alt": "Dr John NT Helferich",
-      "affiliation": "DPhil Candidate in International Relations — St. Antony's College, Oxford.",
       "bio": "John is your first point of contact. He is in charge of our email communications, and ensures smooth coordination between chairs and panel members, among other things. He is a DPhil candidate in International Relations at St. Antony's College, Oxford. John joined the Initiative in 2018.",
-      "country": "United Kingdom"
+      "country": "United Kingdom",
+      "position": "DPhil Candidate in International Relations",
+      "institution": "St. Antony's College, Oxford"
     },
     {
       "name": "Prof. Marina Henke",
       "role": "Board Member",
       "photo": "/assets/images/henke-marina-3-347x521.jpg",
       "alt": "Prof. Marina Henke",
-      "affiliation": "Professor of International Relations and Director of the Centre for International Security — Hertie School.",
       "themes": "Intervention decision-making, Nuclear security, U.S. and European Grand Strategy.",
-      "country": "Germany"
+      "country": "Germany",
+      "position": "Professor of International Relations and Director of the Centre for International Security",
+      "institution": "Hertie School"
     },
     {
       "name": "Alisa Kerschbaum",
       "role": "Board Member",
       "photo": "/assets/images/alisa-kerschbaum-uva-253x371.jpeg",
       "alt": "Alisa Kerschbaum",
-      "affiliation": "Research Grant Advisor — University of Amsterdam.",
       "themes": "Global affairs, International Peace &amp; Security, Environmental security.",
-      "country": "Netherlands"
+      "country": "Netherlands",
+      "position": "Research Grant Advisor",
+      "institution": "University of Amsterdam"
     },
     {
       "name": "Sarka Kolmasova",
       "role": "Board Member",
       "photo": "/assets/images/citations.jpeg",
       "alt": "Sarka Kolmasova",
-      "affiliation": "Deputy Head &amp; Assistant Professor — Department of International Relations and European Studies, Metropolitan University Prague.",
       "themes": "Norms, Military Interventions, Responsibility to Protect, Human Rights in International Politics.",
-      "country": "Czechia"
+      "country": "Czechia",
+      "position": "Deputy Head & Assistant Professor",
+      "institution": "Department of International Relations and European Studies, Metropolitan University Prague"
     },
     {
       "name": "Dr Arthur Laudrain",
@@ -125,7 +138,6 @@
       "alt": "Dr Arthur PB Laudrain",
       "photo": "/assets/images/board/arthur-laudrain.jpg",
       "functionalResponsibility": "Technology Coordinator",
-      "affiliation": "Team Lead and Senior Researcher — ETH Zurich - Center for Security Studies",
       "country": "Switzerland",
       "bio": "Arthur specialises in election interference, disinformation, subversion, and military cyber operations. Previously, he was the Richard Lounsbery US-France Security Fellow at Stanford CISAC, and a Research Associate in Cyber Diplomacy at the Department of War Studies at King's College London. He is a member of the Management Committee of NetSec (Networking European Security Knowledge), a European Cooperation in Science and Technology project. He also maintains affiliations with Stanford CISAC and King's College London. Arthur has a wide profesionnal experience spanning think-tanks (CSS 2017; IISS 2019; HCSS 2022), consulting (Oxford Analytica, ISTARI), and government projects. He obtained his DPhil from the University of Oxford (Wolfson College), and holds an MA (London) and LLM (Leiden). He is an Associate of King's College (AKC) and Fellow of the Higher Education Academy (FHEA).",
       "themes": "election interference, disinformation, subversion",
@@ -135,70 +147,79 @@
         "orcid": "https://orcid.org/0000-0002-8642-2671",
         "linkedin": "https://www.linkedin.com/in/apb-ldn/"
       },
-      "slug": "arthur-laudrain"
+      "slug": "arthur-laudrain",
+      "position": "Team Lead and Senior Researcher",
+      "institution": "Center for Security Studies, ETH Zurich"
     },
     {
       "name": "Dr Chiara Libiseller",
       "role": "Board Member",
       "photo": "/assets/images/chiara-l3303ibiseller.x2806b916.jpg.webp",
       "alt": "Dr Chiara Libiseller",
-      "affiliation": "Lecturer in Strategic Studies — King’s College London.",
       "themes": "Knowledge production on war, Changing character of war, Impact of technology on the theory and practice of war.",
-      "country": "United Kingdom"
+      "country": "United Kingdom",
+      "position": "Lecturer in Strategic Studies",
+      "institution": "King’s College London"
     },
     {
       "name": "Prof. Revecca Pedi",
       "role": "Board Member",
       "photo": "/assets/images/5731-revecca-pedi-1-2-253x253.jpg",
       "alt": "Prof. Revecca Pedi",
-      "affiliation": "Associate Professor of International Relations — University of Macedonia.",
       "themes": "International relations of small states, Theories of international relations, International relations and the European Union.",
-      "country": "Greece"
+      "country": "Greece",
+      "position": "Associate Professor of International Relations",
+      "institution": "University of Macedonia"
     },
     {
       "name": "Prof. Chiara Ruffa",
       "role": "Board Member",
       "photo": "/assets/images/jritvrpl-400x400.jpg",
       "alt": "Prof. Chiara Ruffa",
-      "affiliation": "Professor of Political Science — Sciences Po, Center for International Studies (CERI).",
       "themes": "Multilateralism on the ground, Peacekeeping, Civil-military relations, Political sociology, Fieldwork.",
-      "country": "France"
+      "country": "France",
+      "position": "Professor of Political Science",
+      "institution": "Sciences Po, Center for International Studies (CERI)"
     },
     {
       "name": "Prof. Olivier Schmitt",
       "role": "Board Member",
       "photo": "/assets/images/schmitt-olivier-2-213x320.jpg",
       "alt": "Prof. Olivier Schmitt",
-      "affiliation": "Head of Research — Institute for Military Operations at the Royal Danish Defence College.",
       "themes": "Military Operations, Alliances, Transformation.",
-      "country": "Denmark"
+      "country": "Denmark",
+      "position": "Head of Research",
+      "institution": "Institute for Military Operations, Royal Danish Defence College"
     },
     {
       "name": "Dr Tim Sweijs",
       "role": "Board Member",
       "photo": "/assets/images/1071-07280937-s001tim-003-1-705x705.png",
       "alt": "Dr Tim Sweijs",
-      "affiliation": "Senior Research Fellow — Netherlands’ War Studies Research Centre; Director of Research — The Hague Centre for Strategic Studies.",
       "themes": "Warfare (past, present, future), Strategy, Coercion, Deterrence, Emerging technologies.",
-      "country": "Netherlands"
+      "country": "Netherlands",
+      "position": "Director of Research",
+      "institution": "The Hague Centre for Strategic Studies"
     },
     {
       "name": "Dr Sanne Verschuren",
       "role": "Board Member",
       "photo": "/assets/images/picture-sanne-verschuren-sanne-verschuren-348x348.jpg",
       "alt": "Dr Sanne Verschuren",
-      "affiliation": "Assistant Professor of International Security — Boston University.",
       "themes": "Domestic determinants of security policy, Role of ideas, norms, and institutions in national security decision-making.",
-      "country": "United States"
+      "country": "United States",
+      "position": "Assistant Professor of International Security",
+      "institution": "Boston University"
     },
     {
       "name": "Prof. Marco Wyss",
       "role": "Board Member",
       "photo": "/assets/images/wyss-1-403x564.jpg",
       "alt": "Prof. Marco Wyss",
-      "affiliation": "Professor of International History and Security — Lancaster University; Research Fellow — Stellenbosch University; Senior Research Fellow — School of Advanced Study, University of London.",
       "themes": "Cold War, African and European defence, Neutrality.",
-      "country": "United Kingdom"
+      "country": "United Kingdom",
+      "position": "Professor of International History and Security",
+      "institution": "Lancaster University"
     }
   ],
   "support": [
@@ -208,9 +229,10 @@
       "functionalResponsibility": "Communications Coordinator",
       "photo": "/assets/images/1659415900816.jpeg",
       "alt": "Eugenio Sanchez",
-      "affiliation": "PhD Candidate in International Relations — Sciences Po Paris.",
       "bio": "Eugenio assists with the development of our communication strategy and the logistics of our events. He is a PhD candidate in International Relations at Sciences Po Paris. Eugenio joined the Initiative in 2023.",
-      "country": "France"
+      "country": "France",
+      "position": "PhD Candidate in International Relations",
+      "institution": "Sciences Po Paris"
     }
   ]
 }

--- a/src/_includes/person-card.njk
+++ b/src/_includes/person-card.njk
@@ -43,31 +43,57 @@
     </p>
     <p class="person-name">{{ person.name }}</p>
 
-    {%- if person.affiliation %}
-    <p class="person-affiliation">{{ person.affiliation | safe }}</p>
-    {%- endif %}
+    {# Affiliation rendering. Two lines when position + institution
+       are stored separately (the modern shape that the Form sync
+       writes); a single legacy line when only `affiliation` is set
+       (fallback for any entry that pre-dates this split). The
+       country flag is inline at the end of the institution line so
+       it anchors to the same visual position on every card. #}
+    {%- set countryKey = (person.country or '') | lower | trim %}
+    {%- set iso = countryFlags.byName[countryKey] -%}
 
-    {%- if person.country %}
-    {%- set countryKey = person.country | lower | trim %}
-    {%- set iso = countryFlags.byName[countryKey] %}
-    {%- if iso %}
-    {# Flag-only rendering. The country name lives in `alt` + `title`
-       so screen readers + hover tooltips still convey it; the visible
-       text is suppressed per the operator's "replace the text"
-       request. Fallback (else branch) keeps the labelled map-pin
-       form for countries we don't yet have a flag SVG for. #}
-    <p class="person-country">
-      <img class="person-flag"
-           src="/assets/images/flags/{{ iso }}.svg"
-           alt="{{ person.country }}"
-           title="{{ person.country }}"
-           width="22" height="22" loading="lazy">
-    </p>
-    {%- else %}
-    <p class="person-country">
-      {{ icon("map-pin") }} {{ person.country }}
-    </p>
-    {%- endif %}
+    {%- if person.position or person.institution %}
+      {%- if person.position %}
+      <p class="person-position">{{ person.position | safe }}</p>
+      {%- endif %}
+      {%- if person.institution %}
+      <p class="person-institution">
+        <span>{{ person.institution | safe }}</span>
+        {%- if iso %}
+        <img class="person-flag"
+             src="/assets/images/flags/{{ iso }}.svg"
+             alt="{{ person.country }}"
+             title="{{ person.country }}"
+             width="20" height="20" loading="lazy">
+        {%- elif person.country %}
+        <span class="person-country-fallback">{{ icon("map-pin") }} {{ person.country }}</span>
+        {%- endif %}
+      </p>
+      {%- elif person.country %}
+      {# Position-only entry (rare): country goes on its own line. #}
+      <p class="person-country">
+        {%- if iso %}
+        <img class="person-flag"
+             src="/assets/images/flags/{{ iso }}.svg"
+             alt="{{ person.country }}"
+             title="{{ person.country }}"
+             width="20" height="20" loading="lazy">
+        {%- else %}
+        {{ icon("map-pin") }} {{ person.country }}
+        {%- endif %}
+      </p>
+      {%- endif %}
+    {%- elif person.affiliation %}
+      <p class="person-affiliation">
+        <span>{{ person.affiliation | safe }}</span>
+        {%- if iso %}
+        <img class="person-flag"
+             src="/assets/images/flags/{{ iso }}.svg"
+             alt="{{ person.country }}"
+             title="{{ person.country }}"
+             width="20" height="20" loading="lazy">
+        {%- endif %}
+      </p>
     {%- endif %}
 
     {%- if person.bio %}

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -1708,11 +1708,38 @@ h4 { font-size: var(--fs-lg); }
   letter-spacing: -0.005em;
 }
 
-.person-affiliation {
+.person-affiliation,
+.person-position,
+.person-institution {
   font-size: var(--fs-sm);
   color: var(--text-muted);
   margin: 0;
   line-height: var(--lh-snug);
+}
+
+/* Position sits on its own line above the institution. Quieter
+   than the institution since the institution is what visitors look
+   for to place the person geographically + institutionally. */
+.person-position {
+  color: var(--text-subtle);
+}
+
+/* Institution line carries an inline country flag at the end. Use
+   inline-flex on the parent so the flag aligns with the *last*
+   line of the institution text when the text wraps onto multiple
+   lines — gives every card a flag in roughly the same visual slot. */
+.person-institution {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0 0.4em;
+}
+.person-institution > span {
+  /* Lets the text wrap naturally; the flag follows on the same row
+     when there's room, drops below on a narrow card. */
+}
+.person-institution .person-flag {
+  align-self: center;
 }
 
 /* Optional "country" line under the affiliation. Tiny, scannable —
@@ -1736,12 +1763,29 @@ h4 { font-size: var(--fs-lg); }
   flex: 0 0 auto;
 }
 .person-flag {
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;        /* defensive — circle-flags already round */
-  display: block;
+  flex: 0 0 auto;
+  display: inline-block;
   box-shadow: 0 0 0 1px hsl(220 30% 12% / 0.10);
   transition: transform var(--motion-fast) var(--ease-out);
+}
+
+/* Fallback "📍 Country" label when no flag SVG is mapped — appears
+   inline on the institution line instead of the flag. Quieter than
+   the institution text so it still reads as metadata. */
+.person-country-fallback {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25em;
+  color: var(--text-subtle);
+  font-size: var(--fs-xs);
+}
+.person-country-fallback svg {
+  width: 0.85em;
+  height: 0.85em;
+  flex: 0 0 auto;
 }
 @media (prefers-reduced-motion: no-preference) {
   .person:hover .person-flag {


### PR DESCRIPTION
## What was off

The standalone country line below the affiliation drifted visually across cards. Affiliation text varies in length (1 line for "Professor — Leiden University", 3 lines for some), so the flag below it landed in a different vertical position on each card. Visual inconsistency you noticed.

## What's new

Each card now has the same anatomy:

\`\`\`
[role pill]
Name
Position                          ← muted line
Institution 🇨🇭                  ← flag inline at the end
[bio / themes / etc.]
\`\`\`

## Pieces

- **\`board.json\`** — all 22 entries migrated: \`affiliation\` split into separate \`position\` + \`institution\` fields. Marco Wyss's three-affiliation entry reduced to his primary (Lancaster).
- **\`scripts/sync-board.py\`** — \`build_from_row()\` writes \`position\` + \`institution\` separately now; no more \`affiliation\` join. Each falls back to the prior value when the form submission leaves it blank.
- **\`person-card.njk\`** — renders position on its own line, institution + flag inline. Legacy \`affiliation\` fallback path kept for forwards-compat. Flag size 22 → 20 px to fit inline alongside body text.
- **CSS** — \`.person-institution\` uses \`display: flex; flex-wrap: wrap; align-items: baseline\` so the flag follows the text and lands on the last line when wrapping happens.

## Verified

Across Hugo / Sanne / Arthur (varied institutions):
- Hugo: position "CNRS Research Fellow", institution "Sciences Po, Center for International Studies (CERI)", 🇫🇷
- Sanne: position "Assistant Professor of International Security", institution "Boston University", 🇺🇸
- Arthur: position "Team Lead and Senior Researcher", institution "Center for Security Studies, ETH Zurich", 🇨🇭

22/22 entries fully migrated, zero legacy \`affiliation\` fields, all flags resolving.

Milestone: **ESSC 2026 ops**

🤖 Generated with [Claude Code](https://claude.com/claude-code)