### PR TITLE
Glue flag to institution text so it never wraps alone

### DIFF
--- a/src/_includes/person-card.njk
+++ b/src/_includes/person-card.njk
@@ -52,48 +52,33 @@
     {%- set countryKey = (person.country or '') | lower | trim %}
     {%- set iso = countryFlags.byName[countryKey] -%}
 
+    {# The country flag (or country-fallback span) sits at the END
+       of the institution text as an inline element, NOT a flex
+       child. A non-breaking space ( ) glues the last word of
+       the institution to the flag so the flag never lands on its
+       own wrapped line — either everything fits, or "(last word)
+       🇨🇭" wraps together. The macro keeps the inline markup
+       consistent across the three render paths. #}
+    {%- macro flag_inline(iso, country, icon) -%}
+      {%- if iso -%}
+        <img class="person-flag" src="/assets/images/flags/{{ iso }}.svg" alt="{{ country }}" title="{{ country }}" width="20" height="20" loading="lazy">
+      {%- elif country -%}
+        <span class="person-country-fallback">{{ icon("map-pin") }} {{ country }}</span>
+      {%- endif -%}
+    {%- endmacro -%}
+
     {%- if person.position or person.institution %}
       {%- if person.position %}
       <p class="person-position">{{ person.position | safe }}</p>
       {%- endif %}
       {%- if person.institution %}
-      <p class="person-institution">
-        <span>{{ person.institution | safe }}</span>
-        {%- if iso %}
-        <img class="person-flag"
-             src="/assets/images/flags/{{ iso }}.svg"
-             alt="{{ person.country }}"
-             title="{{ person.country }}"
-             width="20" height="20" loading="lazy">
-        {%- elif person.country %}
-        <span class="person-country-fallback">{{ icon("map-pin") }} {{ person.country }}</span>
-        {%- endif %}
-      </p>
+      <p class="person-institution">{{ person.institution | safe }}{%- if iso or person.country %}&nbsp;{{ flag_inline(iso, person.country, icon) }}{%- endif %}</p>
       {%- elif person.country %}
       {# Position-only entry (rare): country goes on its own line. #}
-      <p class="person-country">
-        {%- if iso %}
-        <img class="person-flag"
-             src="/assets/images/flags/{{ iso }}.svg"
-             alt="{{ person.country }}"
-             title="{{ person.country }}"
-             width="20" height="20" loading="lazy">
-        {%- else %}
-        {{ icon("map-pin") }} {{ person.country }}
-        {%- endif %}
-      </p>
+      <p class="person-country">{{ flag_inline(iso, person.country, icon) }}</p>
       {%- endif %}
     {%- elif person.affiliation %}
-      <p class="person-affiliation">
-        <span>{{ person.affiliation | safe }}</span>
-        {%- if iso %}
-        <img class="person-flag"
-             src="/assets/images/flags/{{ iso }}.svg"
-             alt="{{ person.country }}"
-             title="{{ person.country }}"
-             width="20" height="20" loading="lazy">
-        {%- endif %}
-      </p>
+      <p class="person-affiliation">{{ person.affiliation | safe }}{%- if iso or person.country %}&nbsp;{{ flag_inline(iso, person.country, icon) }}{%- endif %}</p>
     {%- endif %}
 
     {%- if person.bio %}

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -1724,22 +1724,15 @@ h4 { font-size: var(--fs-lg); }
   color: var(--text-subtle);
 }
 
-/* Institution line carries an inline country flag at the end. Use
-   inline-flex on the parent so the flag aligns with the *last*
-   line of the institution text when the text wraps onto multiple
-   lines — gives every card a flag in roughly the same visual slot. */
+/* Institution line carries an inline country flag at the end. The
+   flag is an inline-block element appended directly after the text,
+   with a non-breaking space ( ) keeping the last word + flag
+   together — so the flag never wraps onto its own line. Plain
+   block-level <p>, no flex (which would treat the whole text as one
+   indivisible flex item and shove the flag onto a new flex line
+   when the text wraps). */
 .person-institution {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: 0 0.4em;
-}
-.person-institution > span {
-  /* Lets the text wrap naturally; the flag follows on the same row
-     when there's room, drops below on a narrow card. */
-}
-.person-institution .person-flag {
-  align-self: center;
+  /* No flex — let inline flow handle the flag placement. */
 }
 
 /* Optional "country" line under the affiliation. Tiny, scannable —
@@ -1766,8 +1759,8 @@ h4 { font-size: var(--fs-lg); }
   width: 20px;
   height: 20px;
   border-radius: 50%;        /* defensive — circle-flags already round */
-  flex: 0 0 auto;
   display: inline-block;
+  vertical-align: -0.3em;    /* sits nicely on the text baseline */
   box-shadow: 0 0 0 1px hsl(220 30% 12% / 0.10);
   transition: transform var(--motion-fast) var(--ease-out);
 }


### PR DESCRIPTION
## What was off

On 4K-ish screens the card grid fits more columns, so each card is narrower. Long institution names ("Sciences Po, Center for International Studies (CERI)", "Ludwig Maximilian University of Munich", etc.) wrapped to 2+ lines, and the flag — sitting as a separate flex item — got pushed onto its OWN line below the wrapped text. Floating-flag-alone, inconsistent visual rhythm card-to-card.

## The fix

Switched from flex layout to plain inline flow with a non-breaking space (\` \`) gluing the last word of the institution to the flag. The flag is now a regular inline-block element appended right after the institution text inside the same \`<p>\`. The nbsp guarantees the last word + flag stay together:

- Best case: everything fits on one line
- Wrap case: "Sciences Po, Center for International ..." / "Studies (CERI) 🇫🇷"  ← (CERI) and 🇫🇷 stay glued

Same approach applied to the legacy \`.person-affiliation\` fallback and the \`.person-country-fallback\` (the labelled map-pin form, for any country we don't yet have a flag SVG for).

Small refactor: a \`flag_inline()\` macro in \`person-card.njk\` dedupes the flag-or-fallback markup across the three render paths.

## Verified

JS-measured at both 1920×1080 and 2560×1440 against the six trouble cards (Meijer, Weiss, Ejdus, Gheorghe, Kolmasova, Laudrain) — flag's vertical center within \`inst.bottom - 1.5×lineHeight\` in every case → confirmed on the last text line, never on its own.

Milestone: **ESSC 2026 ops**

🤖 Generated with [Claude Code](https://claude.com/claude-code)