### PR TITLE
Redesign /initiative: stats, activity tiles, network, origin

### DIFF
--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -18,13 +18,13 @@
     "src/initiative.njk": {
       "fr": {
         "file": "src/initiative.fr.njk",
-        "source_sha1": "2573934240d7f2022afbf2316df0573e96cc9b4c",
+        "source_sha1": "aba65af134341f16b0f4d2bd69220c672b6a804f",
         "translated_on": "2026-05-24",
         "status": "beta"
       },
       "de": {
         "file": "src/initiative.de.njk",
-        "source_sha1": "2573934240d7f2022afbf2316df0573e96cc9b4c",
+        "source_sha1": "aba65af134341f16b0f4d2bd69220c672b6a804f",
         "translated_on": "2026-05-24",
         "status": "beta"
       }

--- a/src/_data/boardSorted.js
+++ b/src/_data/boardSorted.js
@@ -140,5 +140,32 @@ module.exports = function () {
   // Form configuration the sync workflow uses.
   const formUrl = (boardSource.form_url || "").trim();
 
-  return { leadership, boardMembers, support, formUrl };
+  // Distinct countries across the whole team, alphabetised. Each
+  // entry includes the iso code so the /initiative page's flag strip
+  // can render them without re-doing the countryFlags lookup at
+  // template time. Skips empty country fields.
+  const countryFlags = require("./countryFlags.js");
+  const seen = new Set();
+  const countries = [];
+  const allAnnotated = [...annotated, ...(board.support || []).map(annotate)];
+  for (const p of allAnnotated) {
+    if (!p.country) continue;
+    const key = p.country.toLowerCase().trim();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const iso = countryFlags.byName[key] || null;
+    countries.push({ name: p.country, iso });
+  }
+  countries.sort((a, b) => a.name.localeCompare(b.name));
+
+  // Top-line counts the /initiative page uses in the stats row.
+  // peopleTotal includes everyone (board + support); countriesTotal
+  // is the distinct count above.
+  const counts = {
+    peopleTotal: leadership.length + boardMembers.length + support.length,
+    countriesTotal: countries.length,
+    leadershipTotal: leadership.length,
+  };
+
+  return { leadership, boardMembers, support, formUrl, countries, counts };
 };

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -2776,6 +2776,152 @@ h4 { font-size: var(--fs-lg); }
   }
 }
 
+/* ---------- /initiative page components --------------------------------
+   Stats row in the hero, the four-tile "What we do" block, the
+   leadership-faces strip + country-flag strip in "Our network", and
+   the compact CTA strip at the bottom. All bespoke to /initiative —
+   moved out of the inline styles in initiative.njk so they're
+   reusable in FR/DE mirrors and easier to tune. */
+
+/* Hero stats row. Big numbers, small captions. Responsive grid that
+   collapses to 2-up on tablet and 1-up on phones. */
+.stats-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+  gap: var(--space-4) var(--space-5);
+  margin: var(--space-6) 0 0;
+  padding: 0;
+}
+.stats-row .stat {
+  margin: 0;
+}
+.stats-row .stat > dt {
+  font-size: clamp(2rem, 1.4rem + 1.6vw, 2.75rem);
+  font-weight: 700;
+  line-height: 1;
+  color: var(--accent);
+  margin: 0 0 var(--space-2);
+  letter-spacing: -0.02em;
+}
+.stats-row .stat > dd {
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  line-height: var(--lh-snug);
+  margin: 0;
+}
+.stats-row .stat > dd .muted {
+  display: block;
+  font-size: var(--fs-xs);
+}
+
+/* "Learn more →" link inside tiles + cards. Underline appears on
+   hover; arrow shifts a hair to the right. Matches the existing
+   .btn-ghost typography but reads as a plain link. */
+.link-arrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  font-weight: 600;
+  color: var(--accent);
+  text-decoration: none;
+}
+.link-arrow svg {
+  flex: 0 0 auto;
+  transition: transform var(--motion-fast) var(--ease-out);
+}
+.link-arrow:hover { text-decoration: underline; }
+.link-arrow:hover svg { transform: translateX(2px); }
+
+/* Leadership-faces strip in the "Our network" section. Three small
+   circular portraits with role + name underneath, all linked to
+   /board#slug. Wraps on narrow viewports. */
+.leadership-strip {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-5) 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+}
+.leadership-strip > li {
+  flex: 0 1 9rem;
+}
+.leadership-strip a {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-2);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  color: inherit;
+  transition: background var(--motion-fast) var(--ease-out),
+              transform var(--motion-fast) var(--ease-out);
+}
+.leadership-strip a:hover,
+.leadership-strip a:focus-visible {
+  background: var(--surface-strong);
+  transform: translateY(-2px);
+}
+.leadership-strip img {
+  width: 5rem;
+  height: 5rem;
+  border-radius: 50%;
+  object-fit: cover;
+  box-shadow: 0 0 0 1px hsl(220 30% 12% / 0.10);
+}
+.leadership-strip-role {
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+}
+.leadership-strip-name {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--text);
+  line-height: var(--lh-snug);
+}
+
+/* Country-flag strip. Compact horizontal row of every distinct
+   country represented on the team. Each flag carries a tooltip with
+   the country name. Wraps to a second line on narrow viewports. */
+.country-strip {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-5) 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+.country-strip > li { margin: 0; }
+.country-strip img {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: block;
+  box-shadow: 0 0 0 1px hsl(220 30% 12% / 0.10);
+  transition: transform var(--motion-fast) var(--ease-out);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .country-strip img:hover {
+    transform: scale(1.12);
+  }
+}
+
+/* Bottom CTA strip — three pill buttons in a row. Replaces the
+   standalone "Join us!" + "Meet the Board" cards that used to live
+   at the bottom of /initiative. */
+.cta-strip {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
 /* ---------- 404 page ---------------------------------------------------
    The /404.html GitHub Pages auto-serves for any unmatched path. Tries
    to be more useful than the default "Page not found" by surfacing the

--- a/src/initiative.de.njk
+++ b/src/initiative.de.njk
@@ -2,7 +2,7 @@
 layout: base.njk
 permalink: /initiative.de.html
 title: Die Initiative
-description: Die Europäische Initiative für Sicherheitsstudien (EISS) ist ein europaweites multidisziplinäres Netzwerk von Wissenschaftlern zur Konsolidierung der Sicherheitsstudien in Europa.
+description: Die Europäische Initiative für Sicherheitsstudien (EISS) ist ein europaweites multidisziplinäres Netzwerk von Wissenschaftlern, das die Sicherheitsstudien in Europa konsolidiert. Gegründet 2017; Trägerin der COST-Aktion NetSec.
 metaImage: /assets/images/initiative-meta.jpg
 navKey: initiative
 lang: de
@@ -13,6 +13,8 @@ alternates:
   de: /initiative.de.html
 ---
 {% from "icons.njk" import icon %}
+
+{%- set confCount = (conferences.past | length) + (1 if conferences.next else 0) + 2 -%}
 
 <header class="page-header">
   <div class="container">
@@ -25,80 +27,126 @@ alternates:
       <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a> gegründet,
       die ein Dutzend Partnerinstitutionen aus ganz Europa zusammenbringt.
     </p>
+
+    <dl class="stats-row" aria-label="EISS auf einen Blick">
+      <div class="stat">
+        <dt>{{ confCount }}</dt>
+        <dd>Jahreskonferenzen <span class="muted">seit 2017</span></dd>
+      </div>
+      <div class="stat">
+        <dt>{{ boardSorted.counts.peopleTotal }}</dt>
+        <dd>Vorstandsmitglieder und Personal</dd>
+      </div>
+      <div class="stat">
+        <dt>{{ boardSorted.counts.countriesTotal }}</dt>
+        <dd>vertretene Länder</dd>
+      </div>
+      <div class="stat">
+        <dt>1</dt>
+        <dd>COST-Aktion (<a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a>)</dd>
+      </div>
+    </dl>
   </div>
 </header>
 
-<section class="section">
+<section class="section" aria-labelledby="what-we-do-title">
   <div class="container">
-    <article class="prose">
-      <p>Konkret verfolgt EISS zwei Hauptziele:</p>
-    </article>
+    <h2 id="what-we-do-title">Was wir tun</h2>
+    <p class="muted" style="max-width: 44rem;">
+      Konkrete Aktivitäten, die das europäische Feld der Sicherheitsstudien aufbauen — jährliche
+      Konferenzen, die COST-Aktion, Nachwuchsförderung, regelmäßige Umfragen und ein laufender
+      Kalender von Netzwerk-Veranstaltungen.
+    </p>
 
-    <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr)); margin-block: var(--space-7);">
+    <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr)); margin-top: var(--space-5);">
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">{{ icon("users-round") }}</div>
-        <h2>Ein Netzwerk aufbauen</h2>
+        <div class="tile-icon" aria-hidden="true">{{ icon("users") }}</div>
+        <h3>Jahreskonferenz (ESSC)</h3>
         <p>
-          Aufbau und Pflege eines europaweiten Netzwerks im Bereich der Sicherheitsstudien. Dadurch
-          erhalten die individuellen und kollektiven Forschungsprojekte, die derzeit in Europa und
-          darüber hinaus laufen, Sichtbarkeit.
+          {{ confCount }} Ausgaben in ganz Europa seit 2017 — das größte europäische Treffen von
+          Wissenschaftlern und Praktikern zu Sicherheitsfragen.
+        </p>
+        <p style="margin-top: var(--space-3);">
+          <a class="link-arrow" href="/past.de.html">Konferenz-Archiv {{ icon("arrow-right") }}</a>
         </p>
       </article>
+
       <article class="tile">
         <div class="tile-icon" aria-hidden="true">{{ icon("globe") }}</div>
-        <h2>Eine Plattform schaffen</h2>
+        <h3>COST-Aktion NetSec</h3>
         <p>
-          Etablierung eines Forums für den Ideenaustausch, um neue gemeinsame Forschungsprojekte
-          zu fördern und internationale Forschungspartnerschaften aufzubauen.
+          Eine vierjährige COST-Aktion (2025 — 2029), die EISS mit zwölf Partnerinstitutionen ins
+          Leben gerufen hat, um die Fragmentierung der europäischen Basis der Sicherheitsstudien
+          anzugehen.
+        </p>
+        <p style="margin-top: var(--space-3);">
+          <a class="link-arrow" href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec besuchen {{ icon("external-link") }}</a>
+        </p>
+      </article>
+
+      <article class="tile">
+        <div class="tile-icon" aria-hidden="true">{{ icon("graduation-cap") }}</div>
+        <h3>Sommerschule und Ausbildung</h3>
+        <p>
+          Die NetSec-Sommerschule für Nachwuchswissenschaftler und Euro-SWAMOS bilden Doktorierende
+          und Nachwuchsforschende in Sicherheits- und Strategiestudien aus.
+        </p>
+        <p style="margin-top: var(--space-3);">
+          <a class="link-arrow" href="/programmes.de.html">Alle Aktivitäten {{ icon("arrow-right") }}</a>
+        </p>
+      </article>
+
+      <article class="tile">
+        <div class="tile-icon" aria-hidden="true">{{ icon("file-text") }}</div>
+        <h3>Umfragen und Workshops</h3>
+        <p>
+          Die Expertenumfrage Global Risks to the EU, das Programm Coercive Statecraft und
+          fortlaufende Diskussionsrunden zu zentralen Fragen der europäischen Sicherheit.
+        </p>
+        <p style="margin-top: var(--space-3);">
+          <a class="link-arrow" href="/events.de.html">Netzwerk-Veranstaltungen {{ icon("arrow-right") }}</a>
         </p>
       </article>
     </div>
   </div>
 </section>
 
-<section class="section-tight" id="what-makes-us-unique">
+<section class="section-tight" id="how-we-work" aria-labelledby="how-we-work-title">
   <div class="container">
     <article class="card" style="padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8));">
-      <h2>Was uns auszeichnet</h2>
+      <h2 id="how-we-work-title">Wie wir arbeiten</h2>
       <p class="lead">
-        EISS hat drei Hauptmerkmale: (1) thematisch orientiert und offen für alle theoretischen
-        Ansätze, (2) multidisziplinär und interdisziplinär, und (3) geografisch inklusiv.
+        EISS ist thematisch offen, multidisziplinär, geografisch inklusiv und steht allen
+        Hintergründen offen.
       </p>
 
       <dl class="definition-list">
         <div>
           <dt>Offen für alle Ansätze</dt>
           <dd>
-            EISS beschränkt sich nicht auf einen spezifischen theoretischen Ansatz der Sicherheitsstudien,
-            sondern strebt Inklusivität an. Dies spiegelt sich beispielsweise in den Panels der
-            EISS-Konferenz wider, die eine breite Palette von Themen aus dem weiten Feld der
-            Sicherheitsstudien abdecken. EISS begrüßt Beiträge sowohl zu sogenannten „traditionellen"
-            als auch „nicht-traditionellen" Sicherheitsfragen.
+            Keine bestimmte theoretische Schule. Die ESSC-Panels decken das gesamte Spektrum der
+            Sicherheitsstudien ab — traditionelle und nicht-traditionelle gleichermaßen.
           </dd>
         </div>
         <div>
           <dt>Multidisziplinär</dt>
           <dd>
-            EISS ist multidisziplinär und interdisziplinär, da hier unter anderem Historiker,
-            Politikwissenschaftler, Wirtschaftswissenschaftler, Geographen, Anthropologen und
-            Soziologen zusammenkommen, die ein gemeinsames Interesse an der Weiterentwicklung
-            der Sicherheitsstudien in Europa teilen.
+            Historikerinnen, Politik-, Wirtschafts-, Geografie-, Anthropologie- und Sozial­wissen­schaftler —
+            alle mit Interesse an der Entwicklung der Sicherheitsstudien in Europa.
           </dd>
         </div>
         <div>
           <dt>Geografisch inklusiv</dt>
           <dd>
-            EISS strebt geografisch größtmögliche Inklusivität an und integriert Wissenschaftler
-            aus ganz Europa (Süd-, Ost-, Nord- und Westeuropa). Gleichzeitig begrüßt EISS Projekte
-            zu jeder Region der Welt. Jedes Jahr wird die Jahreskonferenz im Rotationsverfahren
-            in einem anderen europäischen Land organisiert.
+            Wissenschaftler aus Süd-, Ost-, Nord- und Westeuropa. Die Jahreskonferenz findet jedes
+            Jahr in einem anderen europäischen Land statt.
           </dd>
         </div>
         <div>
           <dt>Offen für alle Hintergründe</dt>
           <dd>
-            Nachwuchswissenschaftler, Angehörige der Streitkräfte, des diplomatischen Dienstes
-            sowie nationale und internationale Beamte sind alle willkommen.
+            Nachwuchsforschende, Angehörige der Streitkräfte und des diplomatischen Dienstes sowie
+            Verwaltungsbeamte sind neben Akademikerinnen und Akademikern willkommen.
           </dd>
         </div>
       </dl>
@@ -133,56 +181,87 @@ alternates:
   </div>
 </section>
 
-<section class="section">
+<section class="section" id="network" aria-labelledby="network-title">
   <div class="container">
-    <article class="prose">
-      <h2>Unsere Ambition</h2>
-      <ul>
-        <li>
-          Dazu beitragen, die bestehende Fragmentierung in den europäischen Sicherheitsstudien zu
-          überwinden und ein europäisches Feld der Sicherheitsstudien zu fördern und zu konsolidieren.
-        </li>
-        <li>
-          Beitragen zur Förderung akademischer Exzellenz in Europa und zur Entwicklung einer neuen
-          Generation von Wissenschaftlern, die sich mit ihren Pendants weltweit zu internationalen
-          Sicherheitsfragen engagieren.
-        </li>
-        <li>
-          Ein Netzwerk von Akademikern fördern, die durch akademische Forschung und Lehre zu
-          öffentlichen Debatten beitragen und ein informiertes Urteil über Verteidigungs- und
-          Sicherheitsfragen in der Zivilgesellschaft unterstützen können.
-        </li>
-      </ul>
+    <div class="featured-eyebrow">Unser Netzwerk</div>
+    <h2 id="network-title">
+      {{ boardSorted.counts.peopleTotal }} Personen in {{ boardSorted.counts.countriesTotal }} Ländern
+    </h2>
+    <p class="muted" style="max-width: 44rem;">
+      EISS wird von einem Vorstand aus {{ boardSorted.counts.peopleTotal }} Wissenschaftlerinnen und
+      Wissenschaftlern sowie einem kleinen Support-Team geleitet. Die Zusammensetzung spiegelt EISSs
+      geografische Reichweite in Europa und darüber hinaus wider.
+    </p>
+
+    {%- if boardSorted.leadership.length %}
+    <ul class="leadership-strip" aria-label="EISS-Leitung">
+      {%- for person in boardSorted.leadership %}
+      <li>
+        <a href="/board.de.html{% if person.slug %}#{{ person.slug }}{% endif %}">
+          <img src="{{ person.photoOverride or person.photo }}" alt="{{ person.alt or person.name }}" loading="lazy">
+          <span class="leadership-strip-role">{{ person.role }}</span>
+          <span class="leadership-strip-name">{{ person.name }}</span>
+        </a>
+      </li>
+      {%- endfor %}
+    </ul>
+    {%- endif %}
+
+    {%- if boardSorted.countries.length %}
+    <ul class="country-strip" aria-label="Im EISS-Team vertretene Länder">
+      {%- for c in boardSorted.countries %}
+      {%- if c.iso %}
+      <li>
+        <img src="/assets/images/flags/{{ c.iso }}.svg"
+             alt="{{ c.name }}"
+             title="{{ c.name }}"
+             width="28" height="28" loading="lazy">
+      </li>
+      {%- endif %}
+      {%- endfor %}
+    </ul>
+    {%- endif %}
+
+    <p style="margin-top: var(--space-5);">
+      <a class="btn btn-secondary" href="/board.de.html">Das gesamte Team {{ icon("arrow-right") }}</a>
+    </p>
+  </div>
+</section>
+
+<section class="section-tight" id="origin" aria-labelledby="origin-title">
+  <div class="container">
+    <article class="prose" style="max-width: 44rem;">
+      <h2 id="origin-title">Wie EISS entstanden ist</h2>
+      <p>
+        EISS wurde 2017 von Hugo Meijer als europäische Erweiterung der
+        <a href="https://aeges.fr/" target="_blank" rel="noopener">Association pour les Études sur la Guerre et la Stratégie (AEGES)</a>
+        gegründet — einer 2015 ins Leben gerufenen französischen akademischen Vereinigung zur
+        Konsolidierung der Sicherheitsstudien an französischen Universitäten. Die erste
+        Jahreskonferenz fand vom 13. bis 14. Januar 2017 an der Université Panthéon-Assas in Paris
+        statt und versammelte rund 100 Forschende aus 62 Universitäten in 15 europäischen Ländern.
+      </p>
+      <p>
+        Die Initiative wurde von Anfang an als europaweites Netzwerk konzipiert — offen für alle
+        theoretischen Ansätze, alle Disziplinen und Forschende auf jeder Karrierestufe. 2025 hat
+        EISS die COST-Aktion <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a>
+        gestartet und damit die Rolle des Netzwerks als zentrale europäische Plattform der
+        Sicherheitsstudien formalisiert.
+      </p>
     </article>
   </div>
 </section>
 
-<section class="section-tight" aria-labelledby="people-cta-title">
+<section class="section" aria-labelledby="cta-title">
   <div class="container">
-    <article class="card" style="display: grid; gap: var(--space-5); grid-template-columns: 1fr; padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8));">
-      <div>
-        <div class="featured-eyebrow">Wer leitet EISS</div>
-        <h2 id="people-cta-title" style="margin-bottom: var(--space-3);">Lernen Sie den Vorstand und das Team kennen</h2>
-        <p class="muted">
-          Unsere Vorstandsmitglieder beraten und steuern die Organisation, insbesondere durch
-          thematische Arbeitsgruppen. Ein kleines Unterstützungsteam wickelt das Tagesgeschäft ab.
-        </p>
-        <p style="margin-top: var(--space-4);">
-          <a class="btn btn-secondary" href="/board.de.html">Die Personen hinter EISS kennenlernen {{ icon("arrow-right") }}</a>
-        </p>
-      </div>
-    </article>
-  </div>
-</section>
-
-<section class="section">
-  <div class="container">
-    <div class="join">
-      <h2>Werden Sie Mitglied!</h2>
-      <p>Werden Sie Mitglied und schließen Sie sich der Community an.</p>
-      <div class="join-actions">
-        <a class="btn btn-primary" href="/membership.de.html">{{ icon("user-plus") }} Beitreten</a>
-      </div>
+    <h2 id="cta-title" class="sr-only">In Kontakt bleiben</h2>
+    <div class="cta-strip">
+      <a class="btn btn-primary" href="/membership.de.html">{{ icon("user-plus") }} Mitglied werden</a>
+      <a class="btn btn-secondary" href="{{ site.newsletterUrl }}" target="_blank" rel="noopener">
+        {{ icon("mail") }} Newsletter
+      </a>
+      <a class="btn btn-secondary" href="mailto:{{ site.contactEmail }}">
+        {{ icon("mail") }} Kontakt aufnehmen
+      </a>
     </div>
   </div>
 </section>

--- a/src/initiative.fr.njk
+++ b/src/initiative.fr.njk
@@ -2,7 +2,7 @@
 layout: base.njk
 permalink: /initiative.fr.html
 title: L'Initiative
-description: L'Initiative européenne pour les études de sécurité (EISS) est un réseau européen multidisciplinaire de chercheurs visant à consolider les études de sécurité en Europe.
+description: L'Initiative européenne pour les études de sécurité (EISS) est un réseau européen multidisciplinaire de chercheurs consolidant les études de sécurité en Europe. Fondée en 2017 ; organisatrice de l'Action COST NetSec.
 metaImage: /assets/images/initiative-meta.jpg
 navKey: initiative
 lang: fr
@@ -13,6 +13,8 @@ alternates:
   de: /initiative.de.html
 ---
 {% from "icons.njk" import icon %}
+
+{%- set confCount = (conferences.past | length) + (1 if conferences.next else 0) + 2 -%}
 
 <header class="page-header">
   <div class="container">
@@ -25,80 +27,125 @@ alternates:
       <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a>,
       qui rassemble une douzaine d'institutions partenaires à travers le continent.
     </p>
+
+    <dl class="stats-row" aria-label="EISS en bref">
+      <div class="stat">
+        <dt>{{ confCount }}</dt>
+        <dd>conférences annuelles <span class="muted">depuis 2017</span></dd>
+      </div>
+      <div class="stat">
+        <dt>{{ boardSorted.counts.peopleTotal }}</dt>
+        <dd>membres du bureau et personnel</dd>
+      </div>
+      <div class="stat">
+        <dt>{{ boardSorted.counts.countriesTotal }}</dt>
+        <dd>pays représentés</dd>
+      </div>
+      <div class="stat">
+        <dt>1</dt>
+        <dd>Action COST (<a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a>)</dd>
+      </div>
+    </dl>
   </div>
 </header>
 
-<section class="section">
+<section class="section" aria-labelledby="what-we-do-title">
   <div class="container">
-    <article class="prose">
-      <p>Plus précisément, les objectifs de l'EISS sont doubles :</p>
-    </article>
+    <h2 id="what-we-do-title">Nos activités</h2>
+    <p class="muted" style="max-width: 44rem;">
+      Des activités concrètes qui construisent le champ européen des études de sécurité — rencontres
+      annuelles, Action COST, formation de la nouvelle génération, enquêtes périodiques, et un calendrier
+      d'événements du réseau.
+    </p>
 
-    <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr)); margin-block: var(--space-7);">
+    <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr)); margin-top: var(--space-5);">
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">{{ icon("users-round") }}</div>
-        <h2>Créer un réseau</h2>
+        <div class="tile-icon" aria-hidden="true">{{ icon("users") }}</div>
+        <h3>Conférence annuelle (ESSC)</h3>
         <p>
-          Développer et entretenir un réseau européen dans le domaine des études de sécurité. Cela
-          donne de la visibilité à l'ensemble des projets de recherche individuels et collectifs
-          actuellement en cours en Europe et au-delà.
+          {{ confCount }} éditions à travers l'Europe depuis 2017 — le plus grand rassemblement européen
+          de chercheurs et praticiens travaillant sur les questions de sécurité.
+        </p>
+        <p style="margin-top: var(--space-3);">
+          <a class="link-arrow" href="/past.fr.html">Archive des conférences {{ icon("arrow-right") }}</a>
         </p>
       </article>
+
       <article class="tile">
         <div class="tile-icon" aria-hidden="true">{{ icon("globe") }}</div>
-        <h2>Créer une plateforme</h2>
+        <h3>Action COST NetSec</h3>
         <p>
-          Établir un forum d'échange d'idées afin de favoriser de nouveaux projets de recherche
-          conjoints et de développer des partenariats de recherche internationaux.
+          Une Action COST de quatre ans (2025 — 2029) qu'EISS a lancée avec douze institutions
+          partenaires pour s'attaquer à la fragmentation de la base européenne des études de sécurité.
+        </p>
+        <p style="margin-top: var(--space-3);">
+          <a class="link-arrow" href="https://netsec-cost.eu/" target="_blank" rel="noopener">Visiter NetSec {{ icon("external-link") }}</a>
+        </p>
+      </article>
+
+      <article class="tile">
+        <div class="tile-icon" aria-hidden="true">{{ icon("graduation-cap") }}</div>
+        <h3>École d'été et formation</h3>
+        <p>
+          L'École d'été NetSec pour jeunes chercheurs et Euro-SWAMOS forment les doctorants et
+          jeunes chercheurs aux études de sécurité et de stratégie.
+        </p>
+        <p style="margin-top: var(--space-3);">
+          <a class="link-arrow" href="/programmes.fr.html">Toutes les activités {{ icon("arrow-right") }}</a>
+        </p>
+      </article>
+
+      <article class="tile">
+        <div class="tile-icon" aria-hidden="true">{{ icon("file-text") }}</div>
+        <h3>Enquêtes et ateliers</h3>
+        <p>
+          L'enquête d'experts Global Risks to the EU, le programme Coercition étatique, et des tables
+          rondes régulières sur les enjeux critiques de la sécurité européenne.
+        </p>
+        <p style="margin-top: var(--space-3);">
+          <a class="link-arrow" href="/events.fr.html">Événements du réseau {{ icon("arrow-right") }}</a>
         </p>
       </article>
     </div>
   </div>
 </section>
 
-<section class="section-tight" id="what-makes-us-unique">
+<section class="section-tight" id="how-we-work" aria-labelledby="how-we-work-title">
   <div class="container">
     <article class="card" style="padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8));">
-      <h2>Ce qui nous distingue</h2>
+      <h2 id="how-we-work-title">Comment nous travaillons</h2>
       <p class="lead">
-        L'EISS présente trois caractéristiques principales : (1) une approche thématique ouverte à toutes
-        les approches théoriques, (2) une démarche multidisciplinaire et interdisciplinaire,
-        et (3) une inclusion géographique.
+        EISS est thématiquement ouverte, multidisciplinaire, géographiquement inclusive, et accessible
+        à tous les profils.
       </p>
 
       <dl class="definition-list">
         <div>
-          <dt>Ouverte à toutes les approches</dt>
+          <dt>Ouvert à toutes les approches</dt>
           <dd>
-            L'EISS ne se limite pas à une approche théorique spécifique des études de sécurité, mais
-            cherche au contraire à être inclusive. Cela se reflète, par exemple, dans les panels
-            de la conférence EISS, qui couvrent une vaste gamme de thèmes du large champ des études
-            de sécurité. L'EISS accueille les contributions portant aussi bien sur les questions
-            de sécurité dites « traditionnelles » que « non traditionnelles ».
+            Aucune école théorique unique. Les panels de l'ESSC couvrent l'éventail complet des thèmes
+            d'études de sécurité — traditionnels comme non traditionnels.
           </dd>
         </div>
         <div>
           <dt>Multidisciplinaire</dt>
           <dd>
-            L'EISS est multidisciplinaire et interdisciplinaire en ce qu'elle rassemble, entre autres,
-            historiens, politologues, économistes, géographes, anthropologues et sociologues partageant
-            un intérêt pour le développement des études de sécurité en Europe.
+            Historiens, politistes, économistes, géographes, anthropologues, sociologues — tous
+            partageant un intérêt pour le développement des études de sécurité en Europe.
           </dd>
         </div>
         <div>
           <dt>Géographiquement inclusive</dt>
           <dd>
-            L'EISS cherche à être aussi inclusive que possible d'un point de vue géographique, intégrant
-            des chercheurs de toute l'Europe (Sud, Est, Nord et Ouest). Dans le même temps, l'EISS
-            accueille les projets portant sur toute région du monde. Chaque année, la conférence
-            annuelle est organisée par rotation dans un pays européen différent.
+            Chercheurs d'Europe méridionale, orientale, septentrionale et occidentale. La conférence
+            annuelle se tient chaque année dans un pays européen différent.
           </dd>
         </div>
         <div>
-          <dt>Ouverte à tous les profils</dt>
+          <dt>Ouvert à tous les profils</dt>
           <dd>
-            Les chercheurs en début de carrière, les membres des forces armées, des services
-            diplomatiques, ainsi que les fonctionnaires nationaux et internationaux sont tous les bienvenus.
+            Jeunes chercheurs, militaires, diplomates et fonctionnaires sont les bienvenus aux côtés
+            des universitaires.
           </dd>
         </div>
       </dl>
@@ -133,57 +180,86 @@ alternates:
   </div>
 </section>
 
-<section class="section">
+<section class="section" id="network" aria-labelledby="network-title">
   <div class="container">
-    <article class="prose">
-      <h2>Notre ambition</h2>
-      <ul>
-        <li>
-          Contribuer à surmonter la fragmentation existante dans les études européennes de sécurité,
-          et favoriser et consolider un champ européen des études de sécurité.
-        </li>
-        <li>
-          Contribuer à promouvoir l'excellence académique en Europe et à nourrir le développement
-          d'une nouvelle génération de chercheurs qui s'engagent sur les questions de sécurité
-          internationale avec leurs homologues à travers le monde.
-        </li>
-        <li>
-          Favoriser un réseau d'universitaires capables de contribuer aux débats publics à travers
-          la recherche et l'enseignement, et de soutenir un jugement éclairé sur les questions de
-          défense et de sécurité au sein de la société civile.
-        </li>
-      </ul>
+    <div class="featured-eyebrow">Notre réseau</div>
+    <h2 id="network-title">
+      {{ boardSorted.counts.peopleTotal }} personnes dans {{ boardSorted.counts.countriesTotal }} pays
+    </h2>
+    <p class="muted" style="max-width: 44rem;">
+      EISS est dirigée par un bureau de {{ boardSorted.counts.peopleTotal }} chercheurs et une petite
+      équipe de soutien. La composition reflète la portée géographique d'EISS à travers l'Europe et
+      au-delà.
+    </p>
+
+    {%- if boardSorted.leadership.length %}
+    <ul class="leadership-strip" aria-label="Direction d'EISS">
+      {%- for person in boardSorted.leadership %}
+      <li>
+        <a href="/board.fr.html{% if person.slug %}#{{ person.slug }}{% endif %}">
+          <img src="{{ person.photoOverride or person.photo }}" alt="{{ person.alt or person.name }}" loading="lazy">
+          <span class="leadership-strip-role">{{ person.role }}</span>
+          <span class="leadership-strip-name">{{ person.name }}</span>
+        </a>
+      </li>
+      {%- endfor %}
+    </ul>
+    {%- endif %}
+
+    {%- if boardSorted.countries.length %}
+    <ul class="country-strip" aria-label="Pays représentés dans l'équipe EISS">
+      {%- for c in boardSorted.countries %}
+      {%- if c.iso %}
+      <li>
+        <img src="/assets/images/flags/{{ c.iso }}.svg"
+             alt="{{ c.name }}"
+             title="{{ c.name }}"
+             width="28" height="28" loading="lazy">
+      </li>
+      {%- endif %}
+      {%- endfor %}
+    </ul>
+    {%- endif %}
+
+    <p style="margin-top: var(--space-5);">
+      <a class="btn btn-secondary" href="/board.fr.html">Voir toute l'équipe {{ icon("arrow-right") }}</a>
+    </p>
+  </div>
+</section>
+
+<section class="section-tight" id="origin" aria-labelledby="origin-title">
+  <div class="container">
+    <article class="prose" style="max-width: 44rem;">
+      <h2 id="origin-title">Les origines d'EISS</h2>
+      <p>
+        EISS a été fondée en 2017 par Hugo Meijer comme extension européenne de l'
+        <a href="https://aeges.fr/" target="_blank" rel="noopener">Association pour les Études sur la Guerre et la Stratégie (AEGES)</a>,
+        une association universitaire française créée en 2015 pour consolider les études de sécurité
+        dans les universités françaises. La première conférence annuelle s'est tenue les 13 et 14 janvier 2017
+        à l'Université Panthéon-Assas à Paris, rassemblant une centaine de chercheurs de 62 universités
+        dans 15 pays européens.
+      </p>
+      <p>
+        L'initiative a été conçue dès l'origine comme un réseau paneuropéen — ouvert à toutes les approches
+        théoriques, toutes les disciplines, et à tous les profils de chercheurs. En 2025, EISS a lancé
+        l'Action COST <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a>,
+        formalisant le rôle du réseau comme principal lieu de convergence européen des études de sécurité.
+      </p>
     </article>
   </div>
 </section>
 
-<section class="section-tight" aria-labelledby="people-cta-title">
+<section class="section" aria-labelledby="cta-title">
   <div class="container">
-    <article class="card" style="display: grid; gap: var(--space-5); grid-template-columns: 1fr; padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8));">
-      <div>
-        <div class="featured-eyebrow">Qui dirige l'EISS</div>
-        <h2 id="people-cta-title" style="margin-bottom: var(--space-3);">Découvrez le bureau et l'équipe</h2>
-        <p class="muted">
-          Les membres de notre bureau conseillent et orientent l'organisation, notamment à travers
-          des groupes de travail thématiques. Une petite équipe de soutien assure les opérations
-          quotidiennes.
-        </p>
-        <p style="margin-top: var(--space-4);">
-          <a class="btn btn-secondary" href="/board.fr.html">Voir les personnes derrière EISS {{ icon("arrow-right") }}</a>
-        </p>
-      </div>
-    </article>
-  </div>
-</section>
-
-<section class="section">
-  <div class="container">
-    <div class="join">
-      <h2>Rejoignez-nous !</h2>
-      <p>Devenez membre et rejoignez la communauté.</p>
-      <div class="join-actions">
-        <a class="btn btn-primary" href="/membership.fr.html">{{ icon("user-plus") }} Adhérer</a>
-      </div>
+    <h2 id="cta-title" class="sr-only">Restons en contact</h2>
+    <div class="cta-strip">
+      <a class="btn btn-primary" href="/membership.fr.html">{{ icon("user-plus") }} Devenir membre</a>
+      <a class="btn btn-secondary" href="{{ site.newsletterUrl }}" target="_blank" rel="noopener">
+        {{ icon("mail") }} Newsletter
+      </a>
+      <a class="btn btn-secondary" href="mailto:{{ site.contactEmail }}">
+        {{ icon("mail") }} Nous contacter
+      </a>
     </div>
   </div>
 </section>

--- a/src/initiative.njk
+++ b/src/initiative.njk
@@ -2,7 +2,7 @@
 layout: base.njk
 permalink: /initiative.html
 title: The Initiative
-description: The European Initiative for Security Studies (EISS) is a Europe-wide multidisciplinary network of scholars consolidating security studies in Europe.
+description: The European Initiative for Security Studies (EISS) is a Europe-wide multidisciplinary network of scholars consolidating security studies in Europe. Founded 2017; host of the COST Action NetSec.
 metaImage: /assets/images/initiative-meta.jpg
 navKey: initiative
 lang: en
@@ -12,6 +12,11 @@ alternates:
   de: /initiative.de.html
 ---
 {% from "icons.njk" import icon %}
+
+{#- Conference count: data-driven (conferences.js) + the 2 historical
+    editions (2017 + 2018) that pre-date the standalone-page convention.
+    Bump the "+ 2" if more historical editions are added to past.njk. -#}
+{%- set confCount = (conferences.past | length) + (1 if conferences.next else 0) + 2 -%}
 
 <header class="page-header">
   <div class="container">
@@ -23,80 +28,124 @@ alternates:
       Conference (ESSC) and founded the COST Action <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a>,
       which knits together a dozen partner institutions across the continent.
     </p>
+
+    <dl class="stats-row" aria-label="EISS at a glance">
+      <div class="stat">
+        <dt>{{ confCount }}</dt>
+        <dd>annual conferences <span class="muted">since 2017</span></dd>
+      </div>
+      <div class="stat">
+        <dt>{{ boardSorted.counts.peopleTotal }}</dt>
+        <dd>board members &amp; support</dd>
+      </div>
+      <div class="stat">
+        <dt>{{ boardSorted.counts.countriesTotal }}</dt>
+        <dd>countries represented</dd>
+      </div>
+      <div class="stat">
+        <dt>1</dt>
+        <dd>COST Action (<a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a>)</dd>
+      </div>
+    </dl>
   </div>
 </header>
 
-<section class="section">
+<section class="section" aria-labelledby="what-we-do-title">
   <div class="container">
-    <article class="prose">
-      <p>Specifically, the aims of the EISS are two-fold:</p>
-    </article>
+    <h2 id="what-we-do-title">What we do</h2>
+    <p class="muted" style="max-width: 44rem;">
+      Concrete activities that build the European security-studies field — annual gatherings, the COST
+      Action, training the next generation, periodic surveys, and a rolling calendar of network events.
+    </p>
 
-    <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr)); margin-block: var(--space-7);">
+    <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr)); margin-top: var(--space-5);">
       <article class="tile">
-        <div class="tile-icon" aria-hidden="true">{{ icon("users-round") }}</div>
-        <h2>Creating a Network</h2>
+        <div class="tile-icon" aria-hidden="true">{{ icon("users") }}</div>
+        <h3>Annual Conference (ESSC)</h3>
         <p>
-          To develop and sustain a Europe-wide network in the field of security studies. This gives
-          visibility to the range of individual and collective research projects that are currently
-          underway in Europe and beyond.
+          {{ confCount }} editions across Europe since 2017 — the largest European gathering of scholars
+          and practitioners working on security issues.
+        </p>
+        <p style="margin-top: var(--space-3);">
+          <a class="link-arrow" href="/past.html">Conference archive {{ icon("arrow-right") }}</a>
         </p>
       </article>
+
       <article class="tile">
         <div class="tile-icon" aria-hidden="true">{{ icon("globe") }}</div>
-        <h2>Creating a Platform</h2>
+        <h3>NetSec COST Action</h3>
         <p>
-          To establish a forum for the exchange of ideas in order to foster new joint research
-          projects and develop international research partnerships.
+          A four-year COST Action (2025 — 2029) that EISS launched with twelve partner institutions to
+          address the fragmentation of Europe's security-studies base.
+        </p>
+        <p style="margin-top: var(--space-3);">
+          <a class="link-arrow" href="https://netsec-cost.eu/" target="_blank" rel="noopener">Visit NetSec {{ icon("external-link") }}</a>
+        </p>
+      </article>
+
+      <article class="tile">
+        <div class="tile-icon" aria-hidden="true">{{ icon("graduation-cap") }}</div>
+        <h3>Summer School &amp; training</h3>
+        <p>
+          The NetSec Early-Career Scholars Summer School and Euro-SWAMOS train PhD students and early-career
+          researchers in security and strategic studies.
+        </p>
+        <p style="margin-top: var(--space-3);">
+          <a class="link-arrow" href="/programmes.html">All activities {{ icon("arrow-right") }}</a>
+        </p>
+      </article>
+
+      <article class="tile">
+        <div class="tile-icon" aria-hidden="true">{{ icon("file-text") }}</div>
+        <h3>Surveys &amp; workshops</h3>
+        <p>
+          The Global Risks to the EU expert survey, the Coercive Statecraft programme, and rolling
+          roundtables on critical issues in European security.
+        </p>
+        <p style="margin-top: var(--space-3);">
+          <a class="link-arrow" href="/events.html">Network events {{ icon("arrow-right") }}</a>
         </p>
       </article>
     </div>
   </div>
 </section>
 
-<section class="section-tight" id="what-makes-us-unique">
+<section class="section-tight" id="how-we-work" aria-labelledby="how-we-work-title">
   <div class="container">
     <article class="card" style="padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8));">
-      <h2>What makes us unique</h2>
+      <h2 id="how-we-work-title">How we work</h2>
       <p class="lead">
-        The EISS has three main characteristics: it is (1) thematically-driven and open to all
-        theoretical approaches, (2) multidisciplinary and interdisciplinary, and (3) geographically
-        inclusive.
+        EISS is thematically driven, multidisciplinary, geographically inclusive, and open to all
+        backgrounds.
       </p>
 
       <dl class="definition-list">
         <div>
           <dt>Open to all approaches</dt>
           <dd>
-            The EISS is not limited to one specific theoretical approach to security studies, but
-            instead seeks to be inclusive. This is reflected, for instance, in the EISS Conference's
-            panels, which cover a large range of themes in the broad field of security studies.
-            The EISS welcomes contributions on both so-called "traditional" and "non-traditional"
-            security issues.
+            No single theoretical school. The ESSC's panels cover the full range of security-studies
+            themes — traditional and non-traditional alike.
           </dd>
         </div>
         <div>
           <dt>Multidisciplinary</dt>
           <dd>
-            The EISS is multidisciplinary and interdisciplinary in that it gathers, among others,
-            historians, political scientists, economists, geographers, anthropologists and
-            sociologists sharing an interest in developing security studies in Europe.
+            Historians, political scientists, economists, geographers, anthropologists, sociologists —
+            all sharing an interest in developing security studies in Europe.
           </dd>
         </div>
         <div>
           <dt>Geographically inclusive</dt>
           <dd>
-            The EISS seeks to be as inclusive as possible from a geographical perspective, including
-            scholars from all of Europe (Southern, Eastern, Northern and Western Europe). At the
-            same time, the EISS welcomes projects focusing on any region of the world. Each year,
-            the Annual Conference is organised on a rotational basis in a different European country.
+            Scholars from Southern, Eastern, Northern, and Western Europe. The Annual Conference rotates
+            through a different European country each year.
           </dd>
         </div>
         <div>
           <dt>Open to all backgrounds</dt>
           <dd>
-            Early-career scholars, members of the armed forces, of diplomatic services, as well as
-            national and international civil servants are all welcome.
+            Early-career scholars, armed forces and diplomatic-service members, and civil servants are
+            all welcome alongside academics.
           </dd>
         </div>
       </dl>
@@ -131,56 +180,84 @@ alternates:
   </div>
 </section>
 
-<section class="section">
+<section class="section" id="network" aria-labelledby="network-title">
   <div class="container">
-    <article class="prose">
-      <h2>Our ambition</h2>
-      <ul>
-        <li>
-          To help overcome the existing fragmentation in European security studies, and to foster
-          and consolidate a European field of security studies.
-        </li>
-        <li>
-          To contribute to promoting academic excellence in Europe and to nurture the development of
-          a new generation of scholars that engage on international security issues with their
-          counterparts across the globe.
-        </li>
-        <li>
-          To foster a network of academics who can contribute to public debates through academic
-          research and instruction, and support informed judgment on defence and security issues
-          within the civil society.
-        </li>
-      </ul>
+    <div class="featured-eyebrow">Our network</div>
+    <h2 id="network-title">
+      {{ boardSorted.counts.peopleTotal }} people across {{ boardSorted.counts.countriesTotal }} countries
+    </h2>
+    <p class="muted" style="max-width: 44rem;">
+      EISS is run by a board of {{ boardSorted.counts.peopleTotal }} scholars and a small support team.
+      The composition reflects EISS's geographical reach across Europe and beyond.
+    </p>
+
+    {%- if boardSorted.leadership.length %}
+    <ul class="leadership-strip" aria-label="EISS leadership">
+      {%- for person in boardSorted.leadership %}
+      <li>
+        <a href="/board.html{% if person.slug %}#{{ person.slug }}{% endif %}">
+          <img src="{{ person.photoOverride or person.photo }}" alt="{{ person.alt or person.name }}" loading="lazy">
+          <span class="leadership-strip-role">{{ person.role }}</span>
+          <span class="leadership-strip-name">{{ person.name }}</span>
+        </a>
+      </li>
+      {%- endfor %}
+    </ul>
+    {%- endif %}
+
+    {%- if boardSorted.countries.length %}
+    <ul class="country-strip" aria-label="Countries represented on the EISS team">
+      {%- for c in boardSorted.countries %}
+      {%- if c.iso %}
+      <li>
+        <img src="/assets/images/flags/{{ c.iso }}.svg"
+             alt="{{ c.name }}"
+             title="{{ c.name }}"
+             width="28" height="28" loading="lazy">
+      </li>
+      {%- endif %}
+      {%- endfor %}
+    </ul>
+    {%- endif %}
+
+    <p style="margin-top: var(--space-5);">
+      <a class="btn btn-secondary" href="/board.html">See the full team {{ icon("arrow-right") }}</a>
+    </p>
+  </div>
+</section>
+
+<section class="section-tight" id="origin" aria-labelledby="origin-title">
+  <div class="container">
+    <article class="prose" style="max-width: 44rem;">
+      <h2 id="origin-title">How EISS started</h2>
+      <p>
+        EISS was founded in 2017 by Hugo Meijer as a European extension of the
+        <a href="https://aeges.fr/" target="_blank" rel="noopener">Association pour les Études sur la Guerre et la Stratégie (AEGES)</a> —
+        a French academic association created in 2015 to consolidate security studies in French universities.
+        The first Annual Conference took place on 13 — 14 January 2017 at Université Panthéon-Assas in Paris,
+        gathering about 100 researchers from 62 universities across 15 European countries.
+      </p>
+      <p>
+        The initiative was conceived from the outset as a Europe-wide network — open to all theoretical
+        approaches, all disciplines, and scholars at every career stage. In 2025, EISS launched the COST
+        Action <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a>,
+        formalising the network's role as Europe's main convening body in security studies.
+      </p>
     </article>
   </div>
 </section>
 
-<section class="section-tight" aria-labelledby="people-cta-title">
+<section class="section" aria-labelledby="cta-title">
   <div class="container">
-    <article class="card" style="display: grid; gap: var(--space-5); grid-template-columns: 1fr; padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8));">
-      <div>
-        <div class="featured-eyebrow">Who runs EISS</div>
-        <h2 id="people-cta-title" style="margin-bottom: var(--space-3);">Meet the Board &amp; team</h2>
-        <p class="muted">
-          Our Board members advise and steer the organisation, notably through thematic Working
-          Groups. A small support team handles day-to-day operations.
-        </p>
-        <p style="margin-top: var(--space-4);">
-          <a class="btn btn-secondary" href="/board.html">See the people behind EISS {{ icon("arrow-right") }}</a>
-        </p>
-      </div>
-    </article>
-  </div>
-</section>
-
-<section class="section">
-  <div class="container">
-    <div class="join">
-      <h2>Join us!</h2>
-      <p>Become a member and join the community.</p>
-      <div class="join-actions">
-        <a class="btn btn-primary" href="/membership.html">{{ icon("user-plus") }} Join</a>
-      </div>
+    <h2 id="cta-title" class="sr-only">Stay in touch</h2>
+    <div class="cta-strip">
+      <a class="btn btn-primary" href="/membership.html">{{ icon("user-plus") }} Become a member</a>
+      <a class="btn btn-secondary" href="{{ site.newsletterUrl }}" target="_blank" rel="noopener">
+        {{ icon("mail") }} Newsletter
+      </a>
+      <a class="btn btn-secondary" href="mailto:{{ site.contactEmail }}">
+        {{ icon("mail") }} Get in touch
+      </a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary

The old /initiative repeated *"multidisciplinary inclusive European network"* three times (two-fold aims, what makes us unique, our ambition) without ever showing concrete proof. Six text-heavy blocks at equal weight; no imagery, no data, no faces.

The redesign tells the same story but **shows** instead of asserts:

| Section | What's there |
|---|---|
| Hero | Lead + **stats row**: 10 / 22 / 12 / 1 — conferences / people / countries / COST Action |
| **What we do** | 4 activity tiles linking to ESSC archive, NetSec, programmes, network events |
| How we work | Existing "what makes us unique" card, copy trimmed ~30% |
| NetSec | Existing COST Action card |
| **Our network** | "22 people across 12 countries" + 3 leadership headshots + every country as a flag |
| **How EISS started** | New 2-paragraph origin from the Cairn article: founded 2017 by Hugo Meijer as a European extension of AEGES, first conference Jan 13-14 2017 at Université Panthéon-Assas, ~100 researchers from 62 universities in 15 countries |
| Stay in touch | Compact 3-pill CTA (member / newsletter / contact) replacing the standalone "Join us!" + "Meet the Board" cards |

## Data layer

`src/_data/boardSorted.js` now also exposes:
- `countries[]` — sorted unique list of {name, iso} for the flag strip
- `counts.peopleTotal`, `counts.countriesTotal` — for the stats row + section headlines

The stats numbers + flag strip are fully data-driven — no hardcoded numbers to drift out of date when board membership changes.

## CSS additions (no removals)

- `.stats-row` — responsive 4-up; big accent-coloured number + small caption
- `.link-arrow` — "Learn more →" lockup with hover-shift arrow, used in each activity tile
- `.leadership-strip` — round portraits with role + name underneath
- `.country-strip` — flags inline
- `.cta-strip` — three-pill row at the bottom

## i18n

EN / FR / DE all in lockstep. FR copy: high confidence (you're native). DE copy: best-effort, marked beta and ready for native-speaker review whenever you find one.

## Test plan

- [ ] `/initiative.html` — stats row shows 10 / 22 / 12 / 1
- [ ] 4 activity tiles each have a "Learn more →" link
- [ ] "Our network" section shows 3 leadership faces + 12 country flags
- [ ] "How EISS started" paragraph reads correctly + links to aeges.fr + netsec-cost.eu
- [ ] CTA strip at the bottom: Become a member · Newsletter · Get in touch
- [ ] FR + DE pages render with localised copy

Milestone: **NetSec & shared infra** (the NetSec card + activity surfacing reframe the page around the COST Action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)