### PR TITLE
CHANGELOG: renumber v2.15.0 → v2.22.0 (whole range tombstoned)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 _Nothing yet._
 
-## [2.15.0] · 2026-05-24 — Live board pipeline and Initiative refresh
+## [2.22.0] · 2026-05-24 — Live board pipeline and Initiative refresh
 
 > The Google Form board pipeline goes live, the `/board` page is rebuilt around it, and `/initiative` is redesigned to read as concrete activities + numbers + people. Same scope-cycle also tightens the programme grid (per-slot rooms, Google Maps embed) and the sync workflow itself (descriptive PR titles, honest reporting, country flags).
 
@@ -79,7 +79,7 @@ The programme grid carries colour-coded room pills (blue / purple / amber for th
 - **ESSC-speaker tooltip clipped** by the card's `overflow: hidden`. Moved the corner-clipping responsibility onto `.person-photo` via `border-top-{left,right}-radius`; the card becomes `overflow: visible` so the tooltip can escape. Tooltip max-width raised + z-index bumped to clear neighbouring cards. (#103)
 - **Country flag wrapping alone on narrow cards** — on 4K-ish viewports the institution wrapped to multiple lines and the flag, sitting as a separate flex item, got pushed onto a fresh flex line. Switched the institution line to plain inline flow with a non-breaking space gluing the last word to the flag — flag never lands alone now. (#112)
 
-*Version number jumps from v2.13.0r straight to v2.15.0: GitHub's **immutable-releases** feature permanently reserves any tag name that was once attached to a release, and `v2.14.0` had been used by the original "live programme grid on /2026" release (since renumbered to v2.10.0r in the v2.13.0r retroactive cleanup). The tag is therefore unrecoverable; we skip the number rather than work around it.*
+*Version number jumps from v2.13.0r straight to v2.22.0: GitHub's **immutable-releases** feature permanently reserves any tag name that was once attached to a release, and every number from `v2.14.0` through `v2.21.0` had been used by the **original** (now-renumbered) releases — `v2.14.0` was "live programme grid on /2026" (now v2.10.0r), `v2.15.0` was "visual polish ported from NetSec" (now v2.10.3), and so on. Their tags are unrecoverable; we skip the whole burned range rather than try to work around individual tombstones. From this point onward releases follow the v2.22.0-line cleanly.*
 
 ## [2.13.0r] · 2026-05-23 — Adopt NetSec versioning and release tooling
 


### PR DESCRIPTION
## Summary

PR #116 renumbered to v2.15.0, but pushing that tag failed with the **same** GH013 error: v2.15.0 was also historically used (originally the "visual polish ported from NetSec" release, now v2.10.3). Probing all the way up shows every number from **v2.14.0 through v2.21.0** is tombstoned by GitHub's immutable-releases feature — these are exactly the originals from the v2.13.0r retroactive renumber.

Probes at **v2.22.0, v2.30.0, v3.0.0** all pushed cleanly and were cleaned up. Picking the smallest safe forward-going MINOR: **v2.22.0**.

- Renames `## [2.15.0]` → `## [2.22.0]`.
- Updates the footer note to explain the wider skip and lists why (with two concrete examples: v2.14.0 = old programme grid, v2.15.0 = old visual polish).

Body and themes unchanged.

## Test plan

- [x] Probes confirm v2.22.0 pushes cleanly
- [ ] After merge: `scripts/release.sh 2.22.0 "Live board pipeline and Initiative refresh"` cuts the release for real

🤖 Generated with [Claude Code](https://claude.com/claude-code)