### PR TITLE
release.sh: accept r-suffixed tags in compare-link regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **`scripts/release.sh` compare-link regex** now accepts letters and dashes after the dotted numerics, so `v2.13.0r` and any future suffixed tags update cleanly. Previous regex `v([0-9.]+)` silently failed to bind on `v2.13.0r`, leaving `[Unreleased]: …/compare/v2.13.0r...HEAD` stale across v2.22.0. Same PR repoints the live compare link at v2.22.0. (#121)
 
 ## [2.22.0] · 2026-05-24 — Live board pipeline and Initiative refresh
 
@@ -677,4 +679,5 @@ Preview MCP screenshots of `/index.fr.html`, `/index.de.html`, `/initiative.de.h
 
 *Originally tagged as **v2.0.0**; renumbered to **v2.0.0r** in the v2.13.0r retroactive cleanup so the SemVer signal matches the actual scope of the change.*
 
-[Unreleased]: https://github.com/EISSeuropa/EISSeuropa.github.io/compare/v2.13.0r...HEAD
+[Unreleased]: https://github.com/EISSeuropa/EISSeuropa.github.io/compare/v2.22.0...HEAD
+[2.22.0]: https://github.com/EISSeuropa/EISSeuropa.github.io/compare/v2.13.0r...v2.22.0

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -252,8 +252,13 @@ if n != 1:
     raise SystemExit("Could not find a unique [Unreleased] heading.")
 
 # 2. Update the compare-link block at the bottom.
+# The tag-name group allows letters and dashes after the dotted
+# numerics so "r"-suffixed renumbered tags (v2.13.0r) match too.
+# Earlier the regex was v([0-9.]+), which silently failed to update
+# the link past a v2.13.0r baseline and left
+# "[Unreleased]: …/compare/v2.13.0r...HEAD" stale through v2.22.0.
 m = re.search(
-    r"^\[Unreleased\]:\s*(https://github\.com/[^/]+/[^/]+)/compare/v([0-9.]+)\.\.\.HEAD\s*$",
+    r"^\[Unreleased\]:\s*(https://github\.com/[^/]+/[^/]+)/compare/v([0-9A-Za-z.\-]+?)\.\.\.HEAD\s*$",
     src,
     flags=re.M,
 )


### PR DESCRIPTION
## Summary

Closes #121.

The compare-link regex in `scripts/release.sh` only matched `v[0-9.]+`, so the `r`-suffixed tags from the retroactive renumber (notably `v2.13.0r`) silently failed to bind. The result: every release cut from a `v2.13.0r` baseline left `[Unreleased]: …/compare/v2.13.0r...HEAD` stale on the next iteration. Confirmed on v2.22.0 — the link was never updated.

## Changes

- **`scripts/release.sh`** — tag-name group broadened to `[0-9A-Za-z.-]+?` so `r`-suffixes (and any future tag-name oddities) match. Added a comment explaining the rationale + history.
- **`CHANGELOG.md`** — repoints the live `[Unreleased]: …/compare/...HEAD` link at v2.22.0, seeds a `[2.22.0]: …/compare/v2.13.0r...v2.22.0` link, and adds the corresponding `[Unreleased] → Fixed` entry.

## Verified

Python sanity check confirms the new regex binds correctly against both `v2.22.0` and `v2.13.0r`:

```
matched: True
 repo: https://github.com/EISSeuropa/EISSeuropa.github.io
 tag: 2.22.0
r-suffix tag: 2.13.0r
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)