### PR TITLE
initiative: lift Our network section above What we do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ## [Unreleased]
 
+### Changed
+
+- **`/initiative` — Our network section moved up** above *What we do*, so the leadership headshots + country flags appear immediately after the hero stats row instead of below the NetSec card. Visualises the **N people across M countries** stat right where the reader sees it.
+
 ### Fixed
 
 - **`scripts/release.sh` compare-link regex** now accepts letters and dashes after the dotted numerics, so `v2.13.0r` and any future suffixed tags update cleanly. Previous regex `v([0-9.]+)` silently failed to bind on `v2.13.0r`, leaving `[Unreleased]: …/compare/v2.13.0r...HEAD` stale across v2.22.0. Same PR repoints the live compare link at v2.22.0. (#121)

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -18,13 +18,13 @@
     "src/initiative.njk": {
       "fr": {
         "file": "src/initiative.fr.njk",
-        "source_sha1": "aba65af134341f16b0f4d2bd69220c672b6a804f",
+        "source_sha1": "6a94586f1e2d5e0a6381b6ef7d7bebb43b1907a4",
         "translated_on": "2026-05-24",
         "status": "beta"
       },
       "de": {
         "file": "src/initiative.de.njk",
-        "source_sha1": "aba65af134341f16b0f4d2bd69220c672b6a804f",
+        "source_sha1": "6a94586f1e2d5e0a6381b6ef7d7bebb43b1907a4",
         "translated_on": "2026-05-24",
         "status": "beta"
       }

--- a/src/initiative.de.njk
+++ b/src/initiative.de.njk
@@ -49,6 +49,53 @@ alternates:
   </div>
 </header>
 
+<section class="section" id="network" aria-labelledby="network-title">
+  <div class="container">
+    <div class="featured-eyebrow">Unser Netzwerk</div>
+    <h2 id="network-title">
+      {{ boardSorted.counts.peopleTotal }} Personen in {{ boardSorted.counts.countriesTotal }} Ländern
+    </h2>
+    <p class="muted" style="max-width: 44rem;">
+      EISS wird von einem Vorstand aus {{ boardSorted.counts.peopleTotal }} Wissenschaftlerinnen und
+      Wissenschaftlern sowie einem kleinen Support-Team geleitet. Die Zusammensetzung spiegelt EISSs
+      geografische Reichweite in Europa und darüber hinaus wider.
+    </p>
+
+    {%- if boardSorted.leadership.length %}
+    <ul class="leadership-strip" aria-label="EISS-Leitung">
+      {%- for person in boardSorted.leadership %}
+      <li>
+        <a href="/board.de.html{% if person.slug %}#{{ person.slug }}{% endif %}">
+          <img src="{{ person.photoOverride or person.photo }}" alt="{{ person.alt or person.name }}" loading="lazy">
+          <span class="leadership-strip-role">{{ person.role }}</span>
+          <span class="leadership-strip-name">{{ person.name }}</span>
+        </a>
+      </li>
+      {%- endfor %}
+    </ul>
+    {%- endif %}
+
+    {%- if boardSorted.countries.length %}
+    <ul class="country-strip" aria-label="Im EISS-Team vertretene Länder">
+      {%- for c in boardSorted.countries %}
+      {%- if c.iso %}
+      <li>
+        <img src="/assets/images/flags/{{ c.iso }}.svg"
+             alt="{{ c.name }}"
+             title="{{ c.name }}"
+             width="28" height="28" loading="lazy">
+      </li>
+      {%- endif %}
+      {%- endfor %}
+    </ul>
+    {%- endif %}
+
+    <p style="margin-top: var(--space-5);">
+      <a class="btn btn-secondary" href="/board.de.html">Das gesamte Team {{ icon("arrow-right") }}</a>
+    </p>
+  </div>
+</section>
+
 <section class="section" aria-labelledby="what-we-do-title">
   <div class="container">
     <h2 id="what-we-do-title">Was wir tun</h2>
@@ -178,53 +225,6 @@ alternates:
         </a>
       </p>
     </article>
-  </div>
-</section>
-
-<section class="section" id="network" aria-labelledby="network-title">
-  <div class="container">
-    <div class="featured-eyebrow">Unser Netzwerk</div>
-    <h2 id="network-title">
-      {{ boardSorted.counts.peopleTotal }} Personen in {{ boardSorted.counts.countriesTotal }} Ländern
-    </h2>
-    <p class="muted" style="max-width: 44rem;">
-      EISS wird von einem Vorstand aus {{ boardSorted.counts.peopleTotal }} Wissenschaftlerinnen und
-      Wissenschaftlern sowie einem kleinen Support-Team geleitet. Die Zusammensetzung spiegelt EISSs
-      geografische Reichweite in Europa und darüber hinaus wider.
-    </p>
-
-    {%- if boardSorted.leadership.length %}
-    <ul class="leadership-strip" aria-label="EISS-Leitung">
-      {%- for person in boardSorted.leadership %}
-      <li>
-        <a href="/board.de.html{% if person.slug %}#{{ person.slug }}{% endif %}">
-          <img src="{{ person.photoOverride or person.photo }}" alt="{{ person.alt or person.name }}" loading="lazy">
-          <span class="leadership-strip-role">{{ person.role }}</span>
-          <span class="leadership-strip-name">{{ person.name }}</span>
-        </a>
-      </li>
-      {%- endfor %}
-    </ul>
-    {%- endif %}
-
-    {%- if boardSorted.countries.length %}
-    <ul class="country-strip" aria-label="Im EISS-Team vertretene Länder">
-      {%- for c in boardSorted.countries %}
-      {%- if c.iso %}
-      <li>
-        <img src="/assets/images/flags/{{ c.iso }}.svg"
-             alt="{{ c.name }}"
-             title="{{ c.name }}"
-             width="28" height="28" loading="lazy">
-      </li>
-      {%- endif %}
-      {%- endfor %}
-    </ul>
-    {%- endif %}
-
-    <p style="margin-top: var(--space-5);">
-      <a class="btn btn-secondary" href="/board.de.html">Das gesamte Team {{ icon("arrow-right") }}</a>
-    </p>
   </div>
 </section>
 

--- a/src/initiative.fr.njk
+++ b/src/initiative.fr.njk
@@ -49,6 +49,53 @@ alternates:
   </div>
 </header>
 
+<section class="section" id="network" aria-labelledby="network-title">
+  <div class="container">
+    <div class="featured-eyebrow">Notre réseau</div>
+    <h2 id="network-title">
+      {{ boardSorted.counts.peopleTotal }} personnes dans {{ boardSorted.counts.countriesTotal }} pays
+    </h2>
+    <p class="muted" style="max-width: 44rem;">
+      EISS est dirigée par un bureau de {{ boardSorted.counts.peopleTotal }} chercheurs et une petite
+      équipe de soutien. La composition reflète la portée géographique d'EISS à travers l'Europe et
+      au-delà.
+    </p>
+
+    {%- if boardSorted.leadership.length %}
+    <ul class="leadership-strip" aria-label="Direction d'EISS">
+      {%- for person in boardSorted.leadership %}
+      <li>
+        <a href="/board.fr.html{% if person.slug %}#{{ person.slug }}{% endif %}">
+          <img src="{{ person.photoOverride or person.photo }}" alt="{{ person.alt or person.name }}" loading="lazy">
+          <span class="leadership-strip-role">{{ person.role }}</span>
+          <span class="leadership-strip-name">{{ person.name }}</span>
+        </a>
+      </li>
+      {%- endfor %}
+    </ul>
+    {%- endif %}
+
+    {%- if boardSorted.countries.length %}
+    <ul class="country-strip" aria-label="Pays représentés dans l'équipe EISS">
+      {%- for c in boardSorted.countries %}
+      {%- if c.iso %}
+      <li>
+        <img src="/assets/images/flags/{{ c.iso }}.svg"
+             alt="{{ c.name }}"
+             title="{{ c.name }}"
+             width="28" height="28" loading="lazy">
+      </li>
+      {%- endif %}
+      {%- endfor %}
+    </ul>
+    {%- endif %}
+
+    <p style="margin-top: var(--space-5);">
+      <a class="btn btn-secondary" href="/board.fr.html">Voir toute l'équipe {{ icon("arrow-right") }}</a>
+    </p>
+  </div>
+</section>
+
 <section class="section" aria-labelledby="what-we-do-title">
   <div class="container">
     <h2 id="what-we-do-title">Nos activités</h2>
@@ -177,53 +224,6 @@ alternates:
         </a>
       </p>
     </article>
-  </div>
-</section>
-
-<section class="section" id="network" aria-labelledby="network-title">
-  <div class="container">
-    <div class="featured-eyebrow">Notre réseau</div>
-    <h2 id="network-title">
-      {{ boardSorted.counts.peopleTotal }} personnes dans {{ boardSorted.counts.countriesTotal }} pays
-    </h2>
-    <p class="muted" style="max-width: 44rem;">
-      EISS est dirigée par un bureau de {{ boardSorted.counts.peopleTotal }} chercheurs et une petite
-      équipe de soutien. La composition reflète la portée géographique d'EISS à travers l'Europe et
-      au-delà.
-    </p>
-
-    {%- if boardSorted.leadership.length %}
-    <ul class="leadership-strip" aria-label="Direction d'EISS">
-      {%- for person in boardSorted.leadership %}
-      <li>
-        <a href="/board.fr.html{% if person.slug %}#{{ person.slug }}{% endif %}">
-          <img src="{{ person.photoOverride or person.photo }}" alt="{{ person.alt or person.name }}" loading="lazy">
-          <span class="leadership-strip-role">{{ person.role }}</span>
-          <span class="leadership-strip-name">{{ person.name }}</span>
-        </a>
-      </li>
-      {%- endfor %}
-    </ul>
-    {%- endif %}
-
-    {%- if boardSorted.countries.length %}
-    <ul class="country-strip" aria-label="Pays représentés dans l'équipe EISS">
-      {%- for c in boardSorted.countries %}
-      {%- if c.iso %}
-      <li>
-        <img src="/assets/images/flags/{{ c.iso }}.svg"
-             alt="{{ c.name }}"
-             title="{{ c.name }}"
-             width="28" height="28" loading="lazy">
-      </li>
-      {%- endif %}
-      {%- endfor %}
-    </ul>
-    {%- endif %}
-
-    <p style="margin-top: var(--space-5);">
-      <a class="btn btn-secondary" href="/board.fr.html">Voir toute l'équipe {{ icon("arrow-right") }}</a>
-    </p>
   </div>
 </section>
 

--- a/src/initiative.njk
+++ b/src/initiative.njk
@@ -50,6 +50,52 @@ alternates:
   </div>
 </header>
 
+<section class="section" id="network" aria-labelledby="network-title">
+  <div class="container">
+    <div class="featured-eyebrow">Our network</div>
+    <h2 id="network-title">
+      {{ boardSorted.counts.peopleTotal }} people across {{ boardSorted.counts.countriesTotal }} countries
+    </h2>
+    <p class="muted" style="max-width: 44rem;">
+      EISS is run by a board of {{ boardSorted.counts.peopleTotal }} scholars and a small support team.
+      The composition reflects EISS's geographical reach across Europe and beyond.
+    </p>
+
+    {%- if boardSorted.leadership.length %}
+    <ul class="leadership-strip" aria-label="EISS leadership">
+      {%- for person in boardSorted.leadership %}
+      <li>
+        <a href="/board.html{% if person.slug %}#{{ person.slug }}{% endif %}">
+          <img src="{{ person.photoOverride or person.photo }}" alt="{{ person.alt or person.name }}" loading="lazy">
+          <span class="leadership-strip-role">{{ person.role }}</span>
+          <span class="leadership-strip-name">{{ person.name }}</span>
+        </a>
+      </li>
+      {%- endfor %}
+    </ul>
+    {%- endif %}
+
+    {%- if boardSorted.countries.length %}
+    <ul class="country-strip" aria-label="Countries represented on the EISS team">
+      {%- for c in boardSorted.countries %}
+      {%- if c.iso %}
+      <li>
+        <img src="/assets/images/flags/{{ c.iso }}.svg"
+             alt="{{ c.name }}"
+             title="{{ c.name }}"
+             width="28" height="28" loading="lazy">
+      </li>
+      {%- endif %}
+      {%- endfor %}
+    </ul>
+    {%- endif %}
+
+    <p style="margin-top: var(--space-5);">
+      <a class="btn btn-secondary" href="/board.html">See the full team {{ icon("arrow-right") }}</a>
+    </p>
+  </div>
+</section>
+
 <section class="section" aria-labelledby="what-we-do-title">
   <div class="container">
     <h2 id="what-we-do-title">What we do</h2>
@@ -177,52 +223,6 @@ alternates:
         </a>
       </p>
     </article>
-  </div>
-</section>
-
-<section class="section" id="network" aria-labelledby="network-title">
-  <div class="container">
-    <div class="featured-eyebrow">Our network</div>
-    <h2 id="network-title">
-      {{ boardSorted.counts.peopleTotal }} people across {{ boardSorted.counts.countriesTotal }} countries
-    </h2>
-    <p class="muted" style="max-width: 44rem;">
-      EISS is run by a board of {{ boardSorted.counts.peopleTotal }} scholars and a small support team.
-      The composition reflects EISS's geographical reach across Europe and beyond.
-    </p>
-
-    {%- if boardSorted.leadership.length %}
-    <ul class="leadership-strip" aria-label="EISS leadership">
-      {%- for person in boardSorted.leadership %}
-      <li>
-        <a href="/board.html{% if person.slug %}#{{ person.slug }}{% endif %}">
-          <img src="{{ person.photoOverride or person.photo }}" alt="{{ person.alt or person.name }}" loading="lazy">
-          <span class="leadership-strip-role">{{ person.role }}</span>
-          <span class="leadership-strip-name">{{ person.name }}</span>
-        </a>
-      </li>
-      {%- endfor %}
-    </ul>
-    {%- endif %}
-
-    {%- if boardSorted.countries.length %}
-    <ul class="country-strip" aria-label="Countries represented on the EISS team">
-      {%- for c in boardSorted.countries %}
-      {%- if c.iso %}
-      <li>
-        <img src="/assets/images/flags/{{ c.iso }}.svg"
-             alt="{{ c.name }}"
-             title="{{ c.name }}"
-             width="28" height="28" loading="lazy">
-      </li>
-      {%- endif %}
-      {%- endfor %}
-    </ul>
-    {%- endif %}
-
-    <p style="margin-top: var(--space-5);">
-      <a class="btn btn-secondary" href="/board.html">See the full team {{ icon("arrow-right") }}</a>
-    </p>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary

Moves the *Our network* strip (leadership headshots + country flags) from below the NetSec card to right after the hero stats row, across EN / FR / DE. The stats row already cites *N people across M countries*; placing the visualised version immediately below makes the abstract numbers tangible before the reader scrolls into the activity tiles.

## New section order

`Hero + stats → Our network → What we do → How we work → NetSec → Origins → CTA strip`

## Stats provenance (sanity check requested in chat)

- `boardSorted.counts.peopleTotal` — sum of `leadership.length + boardMembers.length + support.length` in `src/_data/boardSorted.js`. **Fully dynamic**: every Form-driven board.json change updates it on the next build.
- `boardSorted.counts.countriesTotal` — `countries.length` of the distinct-country list in the same file. **Fully dynamic**.
- `boardSorted.counts.leadershipTotal` — `leadership.length`. **Fully dynamic**.
- `confCount` — `(conferences.past | length) + (1 if conferences.next else 0) + 2`. **Semi-dynamic**: tracks `conferences.js` automatically; the `+ 2` is a hand-coded baseline for the 2017 + 2018 editions, which pre-date the data array (`/2019` is the earliest entry). Comment in the template explains the bump rule.

So yes — add or remove a board member through the Google Form and both the *N · M · …* row in the hero and the leadership strip + country flags below auto-refresh on the next CI build.

## i18n

- Drift markers refreshed for `src/initiative.fr.njk` and `src/initiative.de.njk`.
- Translations were unchanged in content — only the section position moved, so no native-speaker review needed.

## CHANGELOG

`[Unreleased]` carries a one-line entry under *Changed*.

## Test plan

- [x] Local: section order grep confirms `network → what-we-do → how-we-work → netsec → origin → cta` across all three locales.
- [x] `python3 scripts/check-i18n-drift.py` returns clean.
- [ ] Visual: confirm via build preview that the leadership strip + flags appear directly under the hero across EN / FR / DE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)