### PR TITLE
initiative: deepen page with founding-document content + research themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ## [Unreleased]
 
+### Added
+
+- **`/initiative` — founder pull-quote, two founding objectives, and "Filling a gap" framing** in a new *"What EISS was founded to do"* card that replaces the generic *"How we work"* block. Quote attribution links to Meijer's 2017 *Champs de Mars* article on Cairn — the page now signposts its own founding document.
+- **`/initiative` — research-themes pill grid** listing the nine permanent thematic sections from the 2017 inaugural conference. Renders as a wrapped row of accented pills below NetSec. Localised EN / FR / DE.
+- **`/initiative` — *First conference* facts aside** on the *How EISS started* section: a side card with the 13–14 January 2017 date, Panthéon-Assas venue, attendance figures, Sir Hew Strachan keynote, AEGES · Centre Thucydide · CERSA co-organisers, and a footer citation to the Cairn article.
+- **`/initiative` — expanded origins prose** names Jean-Vincent Holeindre (AEGES president, Univ. Poitiers), the CNRS Éditions + Armand Colin book series, the planned English-language series, and the **Prix Bastien Irondelle** PhD thesis prize. Adds *legal scholars / juristes* to the multidisciplinary list.
+- **`.theme-pills` + `.origin-layout` + `.inaugural-facts` styles** in `src/assets/css/site.css` — pill row, two-column prose-plus-aside grid that collapses on narrow viewports, and a compact two-column definition list for the facts aside.
+
 ### Changed
 
 - **`/initiative` — Our network section moved up** above *What we do*, so the leadership headshots + country flags appear immediately after the hero stats row instead of below the NetSec card. Visualises the **N people across M countries** stat right where the reader sees it.

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -18,13 +18,13 @@
     "src/initiative.njk": {
       "fr": {
         "file": "src/initiative.fr.njk",
-        "source_sha1": "6a94586f1e2d5e0a6381b6ef7d7bebb43b1907a4",
+        "source_sha1": "7d37ba2180f7463bd2f0a5676dec30b09db9db01",
         "translated_on": "2026-05-24",
         "status": "beta"
       },
       "de": {
         "file": "src/initiative.de.njk",
-        "source_sha1": "6a94586f1e2d5e0a6381b6ef7d7bebb43b1907a4",
+        "source_sha1": "7d37ba2180f7463bd2f0a5676dec30b09db9db01",
         "translated_on": "2026-05-24",
         "status": "beta"
       }

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -3009,6 +3009,72 @@ h4 { font-size: var(--fs-lg); }
   margin: 0;
 }
 
+/* ---------- /initiative — research-themes pill grid + origins layout ----
+   The themes-pills list renders the nine permanent thematic sections
+   (anchored in the 2017 inaugural conference) as a wrapped row of
+   accented pills. The origin-layout splits the prose paragraph from
+   the inaugural-conference factoid card on wide viewports and stacks
+   them on narrow. */
+.theme-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  list-style: none;
+  padding: 0;
+  margin: var(--space-4) 0 0;
+}
+
+.theme-pills > li {
+  margin: 0;
+  padding: 0.4rem 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  font-size: var(--fs-sm);
+  color: var(--text);
+  line-height: 1.3;
+}
+
+.origin-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(18rem, 1fr);
+  gap: var(--space-6);
+  align-items: start;
+}
+
+@media (max-width: 56rem) {
+  .origin-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.inaugural-facts dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: var(--space-4);
+  row-gap: var(--space-2);
+  margin: var(--space-3) 0 var(--space-4);
+}
+
+.inaugural-facts dt {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.inaugural-facts dd {
+  margin: 0;
+  font-size: var(--fs-sm);
+}
+
+.inaugural-facts .citation {
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  margin: 0;
+}
+
 /* ---------- print stylesheet -------------------------------------------
    Optimised for attendees printing the conference programme. Forces a
    light theme regardless of OS / toggle, strips chrome (nav, footer,

--- a/src/initiative.de.njk
+++ b/src/initiative.de.njk
@@ -158,46 +158,90 @@ alternates:
   </div>
 </section>
 
-<section class="section-tight" id="how-we-work" aria-labelledby="how-we-work-title">
+<section class="section-tight" id="founded-to-do" aria-labelledby="founded-to-do-title">
   <div class="container">
-    <article class="card" style="padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8));">
-      <h2 id="how-we-work-title">Wie wir arbeiten</h2>
-      <p class="lead">
-        EISS ist thematisch offen, multidisziplinär, geografisch inklusiv und steht allen
-        Hintergründen offen.
+    <article class="card prose" style="padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8)); max-width: none;">
+      <h2 id="founded-to-do-title" style="margin-top: 0;">Wofür EISS gegründet wurde</h2>
+
+      <blockquote>
+        EISS will diese Lücke schließen, indem sie zur Bildung einer europäischen Gemeinschaft von
+        Forschenden im Bereich der Sicherheitsstudien beiträgt.
+        <footer style="margin-top: var(--space-2); font-style: normal; font-size: var(--fs-sm); color: var(--text-muted);">
+          — Hugo Meijer, Gründer ·
+          <cite><a href="https://shs.cairn.info/annuaire-francais-de-relations--9791090429956-page-95?lang=fr"
+                  target="_blank" rel="noopener">Champs de Mars, 2017</a></cite>
+        </footer>
+      </blockquote>
+
+      <p>
+        Die Initiative wurde 2017 mit zwei Gründungszielen ins Leben gerufen, beide explizit in den
+        Akten der Eröffnungskonferenz: ein europäisches akademisches Netzwerk für Sicherheitsstudien
+        aufzubauen, und ein Forum für gemeinsame Forschungsprojekte zwischen Institutionen zu schaffen.
       </p>
 
-      <dl class="definition-list">
-        <div>
-          <dt>Offen für alle Ansätze</dt>
-          <dd>
-            Keine bestimmte theoretische Schule. Die ESSC-Panels decken das gesamte Spektrum der
-            Sicherheitsstudien ab — traditionelle und nicht-traditionelle gleichermaßen.
-          </dd>
-        </div>
-        <div>
-          <dt>Multidisziplinär</dt>
-          <dd>
-            Historikerinnen, Politik-, Wirtschafts-, Geografie-, Anthropologie- und Sozial­wissen­schaftler —
-            alle mit Interesse an der Entwicklung der Sicherheitsstudien in Europa.
-          </dd>
-        </div>
-        <div>
-          <dt>Geografisch inklusiv</dt>
-          <dd>
-            Wissenschaftler aus Süd-, Ost-, Nord- und Westeuropa. Die Jahreskonferenz findet jedes
-            Jahr in einem anderen europäischen Land statt.
-          </dd>
-        </div>
-        <div>
-          <dt>Offen für alle Hintergründe</dt>
-          <dd>
-            Nachwuchsforschende, Angehörige der Streitkräfte und des diplomatischen Dienstes sowie
-            Verwaltungsbeamte sind neben Akademikerinnen und Akademikern willkommen.
-          </dd>
-        </div>
-      </dl>
+      <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr)); margin-top: var(--space-5);">
+        <article class="tile">
+          <div class="tile-icon" aria-hidden="true">{{ icon("users") }}</div>
+          <h3>Das europäische akademische Netzwerk aufbauen</h3>
+          <p>
+            Über die Jahreskonferenz ESSC und ständige thematische Sektionen, in denen Forschende
+            <em>laufende</em> Arbeiten vorstellen — keine fertigen Aufsätze — um das Feld in seiner
+            Entstehung zu entwickeln.
+          </p>
+        </article>
+
+        <article class="tile">
+          <div class="tile-icon" aria-hidden="true">{{ icon("globe") }}</div>
+          <h3>Ein Forum für gemeinsame Projekte</h3>
+          <p>
+            Bewusst das Gegenteil einer klassischen Vortragskonferenz: Die ESSC bringt neue Ideen hervor
+            und stiftet institutionsübergreifende Forschungspartnerschaften, anstatt fertige Ergebnisse
+            zu verbreiten.
+          </p>
+        </article>
+      </div>
+
+      <h3 style="margin-top: var(--space-6);">Eine Lücke in den europäischen Sicherheitsstudien schließen</h3>
+      <p>
+        Mehrere europäische Vereinigungen decken bereits die Internationalen Beziehungen im weiteren Sinne
+        ab — die European International Studies Association (EISA), die Standing Group on International
+        Relations des ECPR, die Nordic International Studies Association (NISA), die Central and Eastern
+        European International Studies Association (CEEISA). <strong>Keine ist speziell den
+        Sicherheitsstudien gewidmet.</strong> EISS existiert, um diese Lücke zu schließen und eine
+        europäische Forschungsgemeinschaft im Feld zu konsolidieren.
+      </p>
+
+      <p class="muted" style="margin-top: var(--space-5); font-size: var(--fs-sm);">
+        Multidisziplinär konzipiert — Historikerinnen, Politik-, Wirtschafts-, Geografie-, Anthropologie-
+        und Sozialwissenschaftler sowie Juristinnen und Juristen — und offen für Nachwuchsforschende,
+        Angehörige der Streitkräfte und des diplomatischen Dienstes sowie Verwaltungsbeamte neben
+        Akademikerinnen und Akademikern. Die Jahreskonferenz findet jedes Jahr in einem anderen
+        europäischen Land statt.
+      </p>
     </article>
+  </div>
+</section>
+
+<section class="section" id="research-themes" aria-labelledby="research-themes-title">
+  <div class="container">
+    <span class="eyebrow">Thematische Sektionen</span>
+    <h2 id="research-themes-title">Neun ständige thematische Sektionen</h2>
+    <p class="muted" style="max-width: 44rem;">
+      Die Eröffnungskonferenz von EISS organisierte die Beiträge um neun ständige thematische Sektionen,
+      die bis heute durch das ESSC-Programm verfolgt werden. Die Liste erweitert sich, wenn teilnehmende
+      Universitäten neue Querschnittsthemen vorschlagen.
+    </p>
+    <ul class="theme-pills" aria-label="Thematische Sektionen von EISS">
+      <li>Transformationen des Krieges und der Konfliktualität</li>
+      <li>Aufkommende Domänen (Cybersicherheit)</li>
+      <li>Rüstungsbeschaffung und Rüstungstransfer</li>
+      <li>Private militärische Akteure</li>
+      <li>Verteidigungskooperation und militärische Unterstützung</li>
+      <li>Militärische Interventionen</li>
+      <li>Nichtverbreitung und Rüstungskontrolle</li>
+      <li>Terrorismus und Terrorismusbekämpfung</li>
+      <li>Theoretische Entwicklungen in den Sicherheitsstudien</li>
+    </ul>
   </div>
 </section>
 
@@ -230,24 +274,47 @@ alternates:
 
 <section class="section-tight" id="origin" aria-labelledby="origin-title">
   <div class="container">
-    <article class="prose" style="max-width: 44rem;">
-      <h2 id="origin-title">Wie EISS entstanden ist</h2>
-      <p>
-        EISS wurde 2017 von Hugo Meijer als europäische Erweiterung der
-        <a href="https://aeges.fr/" target="_blank" rel="noopener">Association pour les Études sur la Guerre et la Stratégie (AEGES)</a>
-        gegründet — einer 2015 ins Leben gerufenen französischen akademischen Vereinigung zur
-        Konsolidierung der Sicherheitsstudien an französischen Universitäten. Die erste
-        Jahreskonferenz fand vom 13. bis 14. Januar 2017 an der Université Panthéon-Assas in Paris
-        statt und versammelte rund 100 Forschende aus 62 Universitäten in 15 europäischen Ländern.
-      </p>
-      <p>
-        Die Initiative wurde von Anfang an als europaweites Netzwerk konzipiert — offen für alle
-        theoretischen Ansätze, alle Disziplinen und Forschende auf jeder Karrierestufe. 2025 hat
-        EISS die COST-Aktion <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a>
-        gestartet und damit die Rolle des Netzwerks als zentrale europäische Plattform der
-        Sicherheitsstudien formalisiert.
-      </p>
-    </article>
+    <h2 id="origin-title" style="margin-bottom: var(--space-5);">Wie EISS entstanden ist</h2>
+    <div class="origin-layout">
+      <article class="prose" style="max-width: none;">
+        <p>
+          EISS wurde 2017 von Hugo Meijer als europäische Erweiterung der
+          <a href="https://aeges.fr/" target="_blank" rel="noopener">Association pour les Études sur la Guerre et la Stratégie (AEGES)</a>
+          gegründet — einer 2015 unter dem Vorsitz von Jean-Vincent Holeindre (Université de Poitiers)
+          ins Leben gerufenen französischen akademischen Vereinigung, die die nach langer
+          Marginalisierung geschwächten Sicherheitsstudien an französischen Universitäten neu aufbauen
+          sollte. Die AEGES verankert die französische Seite des Netzwerks über zwei Buchreihen — bei
+          <strong>CNRS Éditions</strong> und <strong>Armand Colin</strong> — eine geplante
+          englischsprachige Reihe sowie den seit 2017 jährlich vergebenen <strong>Prix Bastien
+          Irondelle</strong> für die beste Dissertation in den strategischen Studien.
+        </p>
+        <p>
+          Hugo Meijer leitete die internationalen Forschungspartnerschaften der AEGES und gründete EISS,
+          um das Projekt auf die europäische Ebene auszuweiten. Die Initiative wurde von Anfang an als
+          europaweites Netzwerk konzipiert — offen für alle theoretischen Ansätze, alle Disziplinen und
+          Forschende auf jeder Karrierestufe. 2025 hat EISS die COST-Aktion
+          <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a> gestartet und damit
+          die Rolle des Netzwerks als zentrale europäische Plattform der Sicherheitsstudien formalisiert.
+        </p>
+      </article>
+
+      <aside class="card inaugural-facts" style="padding: var(--space-5);">
+        <div class="featured-eyebrow">Erste Konferenz</div>
+        <dl>
+          <dt>Datum</dt>     <dd>13. — 14. Januar 2017</dd>
+          <dt>Ort</dt>       <dd>Université Panthéon-Assas (Paris II)</dd>
+          <dt>Teilnahme</dt> <dd>~100 Forschende · 62 Universitäten · 15 europäische Länder</dd>
+          <dt>Eröffnungsvortrag</dt> <dd>Sir Hew Strachan</dd>
+          <dt>Veranstalter</dt> <dd>AEGES · Centre Thucydide · CERSA</dd>
+        </dl>
+        <p class="citation">
+          Ausführlicher Bericht:
+          <a href="https://shs.cairn.info/annuaire-francais-de-relations--9791090429956-page-95?lang=fr"
+             target="_blank" rel="noopener">Meijer, <em>Die Europäische Initiative für
+            Sicherheitsstudien</em>, Champs de Mars, 2017</a>.
+        </p>
+      </aside>
+    </div>
   </div>
 </section>
 

--- a/src/initiative.fr.njk
+++ b/src/initiative.fr.njk
@@ -157,46 +157,90 @@ alternates:
   </div>
 </section>
 
-<section class="section-tight" id="how-we-work" aria-labelledby="how-we-work-title">
+<section class="section-tight" id="founded-to-do" aria-labelledby="founded-to-do-title">
   <div class="container">
-    <article class="card" style="padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8));">
-      <h2 id="how-we-work-title">Comment nous travaillons</h2>
-      <p class="lead">
-        EISS est thématiquement ouverte, multidisciplinaire, géographiquement inclusive, et accessible
-        à tous les profils.
+    <article class="card prose" style="padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8)); max-width: none;">
+      <h2 id="founded-to-do-title" style="margin-top: 0;">Pourquoi EISS a été fondée</h2>
+
+      <blockquote>
+        L'EISS vise à combler cette lacune en contribuant à la constitution d'une communauté européenne
+        de chercheurs dans le domaine des études de sécurité.
+        <footer style="margin-top: var(--space-2); font-style: normal; font-size: var(--fs-sm); color: var(--text-muted);">
+          — Hugo Meijer, fondateur ·
+          <cite><a href="https://shs.cairn.info/annuaire-francais-de-relations--9791090429956-page-95?lang=fr"
+                  target="_blank" rel="noopener">Champs de Mars, 2017</a></cite>
+        </footer>
+      </blockquote>
+
+      <p>
+        L'Initiative a été créée en 2017 avec deux objectifs fondateurs, tous deux explicites dans les
+        actes de la conférence inaugurale : constituer un réseau académique européen sur les études de
+        sécurité, et créer un forum permettant de monter des projets de recherche conjoints entre
+        institutions.
       </p>
 
-      <dl class="definition-list">
-        <div>
-          <dt>Ouvert à toutes les approches</dt>
-          <dd>
-            Aucune école théorique unique. Les panels de l'ESSC couvrent l'éventail complet des thèmes
-            d'études de sécurité — traditionnels comme non traditionnels.
-          </dd>
-        </div>
-        <div>
-          <dt>Multidisciplinaire</dt>
-          <dd>
-            Historiens, politistes, économistes, géographes, anthropologues, sociologues — tous
-            partageant un intérêt pour le développement des études de sécurité en Europe.
-          </dd>
-        </div>
-        <div>
-          <dt>Géographiquement inclusive</dt>
-          <dd>
-            Chercheurs d'Europe méridionale, orientale, septentrionale et occidentale. La conférence
-            annuelle se tient chaque année dans un pays européen différent.
-          </dd>
-        </div>
-        <div>
-          <dt>Ouvert à tous les profils</dt>
-          <dd>
-            Jeunes chercheurs, militaires, diplomates et fonctionnaires sont les bienvenus aux côtés
-            des universitaires.
-          </dd>
-        </div>
-      </dl>
+      <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr)); margin-top: var(--space-5);">
+        <article class="tile">
+          <div class="tile-icon" aria-hidden="true">{{ icon("users") }}</div>
+          <h3>Constituer le réseau européen</h3>
+          <p>
+            Par la conférence annuelle ESSC et des sections thématiques permanentes où les
+            chercheurs-enseignants présentent leurs projets <em>en cours</em> — pas des articles finis —
+            pour développer le champ tel qu'il se construit.
+          </p>
+        </article>
+
+        <article class="tile">
+          <div class="tile-icon" aria-hidden="true">{{ icon("globe") }}</div>
+          <h3>Un forum pour des projets conjoints</h3>
+          <p>
+            Délibérément l'inverse d'une conférence classique de présentations d'articles : l'ESSC fait
+            émerger de nouvelles idées et amorce des partenariats de recherche transinstitutionnels plutôt
+            que de diffuser des résultats finalisés.
+          </p>
+        </article>
+      </div>
+
+      <h3 style="margin-top: var(--space-6);">Combler une lacune en études de sécurité européennes</h3>
+      <p>
+        Plusieurs associations européennes couvrent déjà les relations internationales au sens large —
+        l'European International Studies Association (EISA), le Standing Group on International Relations
+        de l'ECPR, la Nordic International Studies Association (NISA), la Central and Eastern European
+        International Studies Association (CEEISA). <strong>Aucune n'est dédiée spécifiquement aux études
+        de sécurité.</strong> L'EISS existe pour combler cette lacune et consolider une communauté
+        européenne de chercheurs dans le domaine.
+      </p>
+
+      <p class="muted" style="margin-top: var(--space-5); font-size: var(--fs-sm);">
+        Multidisciplinaire par construction — historiens, politistes, économistes, géographes,
+        anthropologues, sociologues et juristes — et ouverte aux jeunes chercheurs, militaires,
+        diplomates et fonctionnaires aux côtés des universitaires. La conférence annuelle se tient
+        chaque année dans un pays européen différent.
+      </p>
     </article>
+  </div>
+</section>
+
+<section class="section" id="research-themes" aria-labelledby="research-themes-title">
+  <div class="container">
+    <span class="eyebrow">Sections thématiques</span>
+    <h2 id="research-themes-title">Neuf sections thématiques permanentes</h2>
+    <p class="muted" style="max-width: 44rem;">
+      La conférence inaugurale d'EISS organisait les communications autour de neuf sections thématiques
+      permanentes, toujours suivies aujourd'hui à travers la programmation ESSC. La liste s'élargit au gré
+      des thèmes transversaux proposés par les universités participantes.
+    </p>
+    <ul class="theme-pills" aria-label="Sections thématiques d'EISS">
+      <li>Transformations du phénomène guerrier et de la conflictualité</li>
+      <li>Domaines émergents (cyber-sécurité)</li>
+      <li>Acquisition et transfert d'armement</li>
+      <li>Acteurs militaires privés</li>
+      <li>Coopération de défense et assistance militaire</li>
+      <li>Interventions militaires</li>
+      <li>Non-prolifération et maîtrise des armements</li>
+      <li>Terrorisme et contre-terrorisme</li>
+      <li>Développements théoriques dans les études de sécurité</li>
+    </ul>
   </div>
 </section>
 
@@ -229,23 +273,46 @@ alternates:
 
 <section class="section-tight" id="origin" aria-labelledby="origin-title">
   <div class="container">
-    <article class="prose" style="max-width: 44rem;">
-      <h2 id="origin-title">Les origines d'EISS</h2>
-      <p>
-        EISS a été fondée en 2017 par Hugo Meijer comme extension européenne de l'
-        <a href="https://aeges.fr/" target="_blank" rel="noopener">Association pour les Études sur la Guerre et la Stratégie (AEGES)</a>,
-        une association universitaire française créée en 2015 pour consolider les études de sécurité
-        dans les universités françaises. La première conférence annuelle s'est tenue les 13 et 14 janvier 2017
-        à l'Université Panthéon-Assas à Paris, rassemblant une centaine de chercheurs de 62 universités
-        dans 15 pays européens.
-      </p>
-      <p>
-        L'initiative a été conçue dès l'origine comme un réseau paneuropéen — ouvert à toutes les approches
-        théoriques, toutes les disciplines, et à tous les profils de chercheurs. En 2025, EISS a lancé
-        l'Action COST <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a>,
-        formalisant le rôle du réseau comme principal lieu de convergence européen des études de sécurité.
-      </p>
-    </article>
+    <h2 id="origin-title" style="margin-bottom: var(--space-5);">Les origines d'EISS</h2>
+    <div class="origin-layout">
+      <article class="prose" style="max-width: none;">
+        <p>
+          EISS a été fondée en 2017 par Hugo Meijer comme extension européenne de l'
+          <a href="https://aeges.fr/" target="_blank" rel="noopener">Association pour les Études sur la Guerre et la Stratégie (AEGES)</a>,
+          association universitaire française créée en 2015 sous la présidence de Jean-Vincent Holeindre
+          (Université de Poitiers) pour reconstruire les études de sécurité dans les universités françaises
+          après une longue marginalisation. L'AEGES ancre le versant français du réseau à travers deux
+          collections — chez <strong>CNRS Éditions</strong> et <strong>Armand Colin</strong> — une
+          collection anglophone en projet, et le <strong>Prix Bastien Irondelle</strong> de la meilleure
+          thèse en études stratégiques, décerné chaque année depuis 2017.
+        </p>
+        <p>
+          Hugo Meijer dirigeait les partenariats de recherche internationaux de l'AEGES et a fondé EISS
+          pour étendre le projet à l'échelle européenne. L'initiative a été conçue dès l'origine comme un
+          réseau paneuropéen — ouvert à toutes les approches théoriques, toutes les disciplines, et à
+          tous les profils de chercheurs. En 2025, EISS a lancé l'Action COST
+          <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a>, formalisant le rôle
+          du réseau comme principal lieu de convergence européen des études de sécurité.
+        </p>
+      </article>
+
+      <aside class="card inaugural-facts" style="padding: var(--space-5);">
+        <div class="featured-eyebrow">Première conférence</div>
+        <dl>
+          <dt>Date</dt>          <dd>13 — 14 janvier 2017</dd>
+          <dt>Lieu</dt>          <dd>Université Panthéon-Assas (Paris II)</dd>
+          <dt>Participation</dt> <dd>~100 chercheurs · 62 universités · 15 pays européens</dd>
+          <dt>Conférencier</dt>  <dd>Sir Hew Strachan</dd>
+          <dt>Organisateurs</dt> <dd>AEGES · Centre Thucydide · CERSA</dd>
+        </dl>
+        <p class="citation">
+          Compte-rendu complet :
+          <a href="https://shs.cairn.info/annuaire-francais-de-relations--9791090429956-page-95?lang=fr"
+             target="_blank" rel="noopener">Meijer, <em>L'Initiative européenne pour les études de sécurité</em>,
+            Champs de Mars, 2017</a>.
+        </p>
+      </aside>
+    </div>
   </div>
 </section>
 

--- a/src/initiative.njk
+++ b/src/initiative.njk
@@ -156,46 +156,86 @@ alternates:
   </div>
 </section>
 
-<section class="section-tight" id="how-we-work" aria-labelledby="how-we-work-title">
+<section class="section-tight" id="founded-to-do" aria-labelledby="founded-to-do-title">
   <div class="container">
-    <article class="card" style="padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8));">
-      <h2 id="how-we-work-title">How we work</h2>
-      <p class="lead">
-        EISS is thematically driven, multidisciplinary, geographically inclusive, and open to all
-        backgrounds.
+    <article class="card prose" style="padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8)); max-width: none;">
+      <h2 id="founded-to-do-title" style="margin-top: 0;">What EISS was founded to do</h2>
+
+      <blockquote>
+        EISS aims to fill this gap by contributing to the formation of a European community of researchers
+        in security studies.
+        <footer style="margin-top: var(--space-2); font-style: normal; font-size: var(--fs-sm); color: var(--text-muted);">
+          — Hugo Meijer, founder ·
+          <cite><a href="https://shs.cairn.info/annuaire-francais-de-relations--9791090429956-page-95?lang=fr"
+                  target="_blank" rel="noopener">Champs de Mars, 2017</a></cite>
+        </footer>
+      </blockquote>
+
+      <p>
+        The Initiative was created in 2017 with two founding objectives, both explicit in the inaugural-conference
+        proceedings: build the European academic network in security studies, and create a forum for joint
+        research projects across institutions.
       </p>
 
-      <dl class="definition-list">
-        <div>
-          <dt>Open to all approaches</dt>
-          <dd>
-            No single theoretical school. The ESSC's panels cover the full range of security-studies
-            themes — traditional and non-traditional alike.
-          </dd>
-        </div>
-        <div>
-          <dt>Multidisciplinary</dt>
-          <dd>
-            Historians, political scientists, economists, geographers, anthropologists, sociologists —
-            all sharing an interest in developing security studies in Europe.
-          </dd>
-        </div>
-        <div>
-          <dt>Geographically inclusive</dt>
-          <dd>
-            Scholars from Southern, Eastern, Northern, and Western Europe. The Annual Conference rotates
-            through a different European country each year.
-          </dd>
-        </div>
-        <div>
-          <dt>Open to all backgrounds</dt>
-          <dd>
-            Early-career scholars, armed forces and diplomatic-service members, and civil servants are
-            all welcome alongside academics.
-          </dd>
-        </div>
-      </dl>
+      <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr)); margin-top: var(--space-5);">
+        <article class="tile">
+          <div class="tile-icon" aria-hidden="true">{{ icon("users") }}</div>
+          <h3>Build the European academic network</h3>
+          <p>
+            Through the Annual ESSC and standing thematic sections where scholars present
+            <em>in-progress</em> work — not finished papers — to develop the field as it forms.
+          </p>
+        </article>
+
+        <article class="tile">
+          <div class="tile-icon" aria-hidden="true">{{ icon("globe") }}</div>
+          <h3>Create a forum for joint projects</h3>
+          <p>
+            Deliberately the opposite of a traditional paper-reading conference: the ESSC surfaces new ideas
+            and seeds cross-institutional research partnerships rather than broadcasting finished results.
+          </p>
+        </article>
+      </div>
+
+      <h3 style="margin-top: var(--space-6);">Filling a gap in European security studies</h3>
+      <p>
+        Several European associations already cover International Relations broadly — the European
+        International Studies Association (EISA), the ECPR's Standing Group on International Relations,
+        the Nordic International Studies Association (NISA), the Central and Eastern European International
+        Studies Association (CEEISA). <strong>None are dedicated specifically to security studies.</strong>
+        EISS exists to fill that gap and to consolidate a European community of scholars in the field.
+      </p>
+
+      <p class="muted" style="margin-top: var(--space-5); font-size: var(--fs-sm);">
+        Multidisciplinary by design — historians, political scientists, economists, geographers,
+        anthropologists, sociologists, and legal scholars — and open to early-career researchers,
+        armed-forces and diplomatic-service members, and civil servants alongside academics.
+        The Annual Conference rotates through a different European country each year.
+      </p>
     </article>
+  </div>
+</section>
+
+<section class="section" id="research-themes" aria-labelledby="research-themes-title">
+  <div class="container">
+    <span class="eyebrow">Research themes</span>
+    <h2 id="research-themes-title">Nine permanent thematic sections</h2>
+    <p class="muted" style="max-width: 44rem;">
+      The inaugural EISS conference organised papers around nine permanent thematic sections, still tracked
+      today through the ESSC programme. The list expands as participating universities propose cross-cutting
+      themes.
+    </p>
+    <ul class="theme-pills" aria-label="EISS research themes">
+      <li>Transformations of warfare and conflict</li>
+      <li>Emerging domains (cybersecurity)</li>
+      <li>Arms acquisition and transfer</li>
+      <li>Private military actors</li>
+      <li>Defence cooperation and military assistance</li>
+      <li>Military interventions</li>
+      <li>Non-proliferation and arms control</li>
+      <li>Terrorism and counter-terrorism</li>
+      <li>Theoretical developments in security studies</li>
+    </ul>
   </div>
 </section>
 
@@ -228,22 +268,46 @@ alternates:
 
 <section class="section-tight" id="origin" aria-labelledby="origin-title">
   <div class="container">
-    <article class="prose" style="max-width: 44rem;">
-      <h2 id="origin-title">How EISS started</h2>
-      <p>
-        EISS was founded in 2017 by Hugo Meijer as a European extension of the
-        <a href="https://aeges.fr/" target="_blank" rel="noopener">Association pour les Études sur la Guerre et la Stratégie (AEGES)</a> —
-        a French academic association created in 2015 to consolidate security studies in French universities.
-        The first Annual Conference took place on 13 — 14 January 2017 at Université Panthéon-Assas in Paris,
-        gathering about 100 researchers from 62 universities across 15 European countries.
-      </p>
-      <p>
-        The initiative was conceived from the outset as a Europe-wide network — open to all theoretical
-        approaches, all disciplines, and scholars at every career stage. In 2025, EISS launched the COST
-        Action <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a>,
-        formalising the network's role as Europe's main convening body in security studies.
-      </p>
-    </article>
+    <h2 id="origin-title" style="margin-bottom: var(--space-5);">How EISS started</h2>
+    <div class="origin-layout">
+      <article class="prose" style="max-width: none;">
+        <p>
+          EISS was founded in 2017 by Hugo Meijer as a European extension of the
+          <a href="https://aeges.fr/" target="_blank" rel="noopener">Association pour les Études sur la Guerre et la Stratégie (AEGES)</a>,
+          a French academic association created in 2015 under the presidency of Jean-Vincent Holeindre
+          (Univ. Poitiers) to rebuild security studies in French universities after long marginalisation.
+          AEGES anchors the French side of the network through two book series — at
+          <strong>CNRS Éditions</strong> and <strong>Armand Colin</strong> — a planned English-language
+          series, and the annual <strong>Prix Bastien Irondelle</strong> PhD thesis prize in strategic
+          studies, awarded since 2017.
+        </p>
+        <p>
+          Hugo Meijer led AEGES's international research partnerships and founded EISS to extend the
+          project to a European scale. The initiative was conceived from the outset as a Europe-wide
+          network — open to all theoretical approaches, all disciplines, and scholars at every career
+          stage. In 2025, EISS launched the COST Action
+          <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a>, formalising the
+          network's role as Europe's main convening body in security studies.
+        </p>
+      </article>
+
+      <aside class="card inaugural-facts" style="padding: var(--space-5);">
+        <div class="featured-eyebrow">First conference</div>
+        <dl>
+          <dt>When</dt>      <dd>13 – 14 January 2017</dd>
+          <dt>Venue</dt>     <dd>Université Panthéon-Assas (Paris II)</dd>
+          <dt>Attendance</dt><dd>~100 scholars · 62 universities · 15 European countries</dd>
+          <dt>Keynote</dt>   <dd>Sir Hew Strachan</dd>
+          <dt>Hosts</dt>     <dd>AEGES · Centre Thucydide · CERSA</dd>
+        </dl>
+        <p class="citation">
+          Full account:
+          <a href="https://shs.cairn.info/annuaire-francais-de-relations--9791090429956-page-95?lang=fr"
+             target="_blank" rel="noopener">Meijer, <em>European Initiative for Security Studies</em>,
+            Champs de Mars, 2017</a>.
+        </p>
+      </aside>
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary

Big content lift on `/initiative` drawing from Hugo Meijer's 2017 founding account in *Champs de Mars* ([Cairn link](https://shs.cairn.info/annuaire-francais-de-relations--9791090429956-page-95?lang=fr)). The page now reads like a short founding pamphlet rather than abstract positioning.

## New page structure (EN / FR / DE, identical)

`Hero + stats → Our network → What we do → **What EISS was founded to do** → **Research themes** → NetSec → **How EISS started** (expanded) → CTA`

## What changed

- **Replaces** *"How we work"* with **"What EISS was founded to do"** — a single card carrying:
  - Founder pull-quote attributed to Hugo Meijer with a Cairn-article citation link
  - Two original founding objectives in a 2-card grid (*build the European academic network · create a forum for joint projects*) framed against the inaugural-conference proceedings
  - Explicit "filling a gap" paragraph contrasting EISS with EISA / ECPR Standing Group / NISA / CEEISA
  - A compact one-liner that absorbs the inclusivity bullets (multidisciplinary, open to all career stages and backgrounds, rotating venue)
- **Adds** a **Research themes** pill-grid of the nine permanent thematic sections from the 2017 inaugural conference
- **Expands** *"How EISS started"* into a two-column layout:
  - Prose now names Jean-Vincent Holeindre (AEGES president, Univ. Poitiers), the CNRS Éditions + Armand Colin book series, planned English-language series, and the **Prix Bastien Irondelle** PhD thesis prize
  - Side **facts card** with the 13–14 January 2017 date, Panthéon-Assas venue, *~100 scholars · 62 universities · 15 countries*, Sir Hew Strachan keynote, AEGES · Centre Thucydide · CERSA co-organisers
  - Footer citation to the Cairn article
- **Adds** *legal scholars / juristes / Juristinnen und Juristen* to the multidisciplinary list (was missing)
- **CSS additions** in `src/assets/css/site.css`:
  - `.theme-pills` — wrapping flex row of accented pills
  - `.origin-layout` — 2fr / 1fr grid collapsing to single column below 56 rem
  - `.inaugural-facts` — compact two-column dt/dd list + small citation footer style

## i18n

- Drift markers refreshed; `python3 scripts/check-i18n-drift.py` returns clean.
- French wording draws on the user's own French summary of the Cairn article for accuracy.
- German is a careful translation from English; minor refinement may be wanted at the next native-speaker review.

## CHANGELOG

`[Unreleased] → Added` carries five concrete entries documenting each piece; the section reorder from PR #125 stays under *Changed*.

## Test plan

- [x] `grep` confirms section order across all three locales.
- [x] `python3 scripts/check-i18n-drift.py` clean.
- [x] Visual: confirm via build preview that the founder pull-quote, pill grid, and side facts card render correctly across EN / FR / DE on wide + narrow viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)