### PR TITLE
board: auto-expire time-bound role cards with 7-day grace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,15 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ## [Unreleased]
 
+### Added
+
+- **Auto-expiring board cards for time-bound roles** — interns, visiting fellows, and fixed-term contracts. A new optional `roleEndDate` field on each board entry (Form question 18, Date type) carries the role end-date. `src/_data/boardSorted.js` applies a **7-day grace** after that date, then moves the entry from the active sections into a new `pastMembers` array. The daily-rebuild workflow re-evaluates each build so the transition is automatic, no manual gardening required. (#126)
+- **"Past board members and interns" folded footer** on `/board` — a `<details>`-based collapsed footer rendering all expired entries with a compact people-grid. Closed by default, opens to a quieter grid (smaller min column, slightly muted). Copy in EN / FR / DE reinforces the "they remain part of the broader European security-studies family" framing. (#126)
+- **Date-shape tolerance in `scripts/sync-board.py`** — accepts `YYYY-MM-DD` (Forms default), `DD/MM/YYYY`, `DD.MM.YYYY`, `YYYY/MM/DD`, and `MM/DD/YYYY`; normalises everything to ISO. Unparseable values log a warning and leave the entry permanent (no silent expiry on garbage input). (#126)
+
 ### Changed
 
+- **`boardSorted.counts.peopleTotal` / `countriesTotal` now count active members only** — past members no longer show up in the `/initiative` stats row, so the **N people across M countries** headline reflects the present team rather than the cumulative roster. `counts.pastTotal` exposes the alumni count for any future template that wants it. (#126)
 - **`/initiative` — Our network section moved up** above *What we do*, so the leadership headshots + country flags appear immediately after the hero stats row instead of below the NetSec card. Visualises the **N people across M countries** stat right where the reader sees it.
 
 ### Fixed

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -46,13 +46,13 @@
     "src/board.njk": {
       "fr": {
         "file": "src/board.fr.njk",
-        "source_sha1": "a53f45ad90eea41e7438d1cc0140c6d37a5b12db",
+        "source_sha1": "a373681b0f8a72207afb5052bef1dd7bab943d4a",
         "translated_on": "2026-05-24",
         "status": "beta"
       },
       "de": {
         "file": "src/board.de.njk",
-        "source_sha1": "a53f45ad90eea41e7438d1cc0140c6d37a5b12db",
+        "source_sha1": "a373681b0f8a72207afb5052bef1dd7bab943d4a",
         "translated_on": "2026-05-24",
         "status": "beta"
       }

--- a/docs/board-bios-setup.md
+++ b/docs/board-bios-setup.md
@@ -62,7 +62,8 @@ just don't merge.
 | 15 | **Bluesky URL (optional)** | Short answer | ⬜ |
 | 16 | **Mastodon URL (optional)** | Short answer | ⬜ |
 | 17 | **Headshot photo (optional)** | File upload — image only — max 5 MB | ⬜ |
-| 18 | **I consent to publication of my bio on eiss-europa.com** | Checkboxes — single option | ✅ |
+| 18 | **End date for time-bound roles (optional)** | Date | ⬜ |
+| 19 | **I consent to publication of my bio on eiss-europa.com** | Checkboxes — single option | ✅ |
 
 **Q2 options** — must match exactly the `label` values in
 `scripts/board-source.json` → `roles` table:
@@ -122,6 +123,26 @@ And on the **Headshot photo (optional)** question, set its
 > Already submitted once and want to change your photo? Don't edit
 > — submit a fresh response. The file-upload field is locked by
 > Google Forms after the first submission.
+
+### End-date question — time-bound roles
+
+Q18 (**End date for time-bound roles (optional)**, Date) lets interns,
+visiting fellows, and anyone on a fixed-term contract record when
+their role ends. Set the question **Description** to:
+
+> Leave blank if your EISS role is open-ended. Fill in only if you're
+> on a fixed-term role (internship, visiting fellow, contract). Your
+> card will stay on the board for ~1 week after this date, then move
+> to a folded *"Past board members and interns"* footer — you remain
+> part of the broader European security studies family.
+
+The sync writes whatever the respondent picks straight through to
+`board.json` as `roleEndDate` (ISO `YYYY-MM-DD`).
+`src/_data/boardSorted.js` applies a 7-day grace at build time and
+moves expired entries into `pastMembers` for the folded footer on
+`/board`. The daily-rebuild workflow re-evaluates this with each
+build, so the transition is automatic. Empty / unparseable values
+leave the entry permanent — no silent surprises.
 
 ## Step 2 · Link the Form to a Sheet
 

--- a/scripts/board-source.json
+++ b/scripts/board-source.json
@@ -28,6 +28,7 @@
     "bluesky": "Bluesky URL (optional)",
     "mastodon": "Mastodon URL (optional)",
     "photo": "Headshot photo (optional)",
+    "roleEndDate": "End date for time-bound roles (optional)",
     "consent": "I consent to publication of my bio on eiss-europa.com"
   },
 

--- a/scripts/sync-board.py
+++ b/scripts/sync-board.py
@@ -286,6 +286,41 @@ def _cell(row: dict, cols: dict, key: str) -> str:
     return (row.get(col_name, "") or "").strip()
 
 
+# Google Forms' Date question writes values as YYYY-MM-DD by default in
+# the linked Sheet, but the respondent can also type free-text into a
+# Short-answer question. _normalize_date() accepts the common shapes
+# we've actually seen (YYYY-MM-DD, DD/MM/YYYY, DD.MM.YYYY, MM/DD/YYYY)
+# and emits a canonical ISO `YYYY-MM-DD` string. Anything it can't parse
+# returns "" so boardSorted.js leaves the entry permanent rather than
+# silently expiring it on garbage input.
+_DATE_PATTERNS = [
+    "%Y-%m-%d",       # 2026-06-30 (Google Forms default)
+    "%d/%m/%Y",       # 30/06/2026 (FR/UK)
+    "%d.%m.%Y",       # 30.06.2026 (DE)
+    "%Y/%m/%d",       # 2026/06/30
+    "%m/%d/%Y",       # 06/30/2026 (US — accept last because it's most
+                      # ambiguous with the FR form)
+]
+
+
+def _normalize_date(raw: str) -> str:
+    s = (raw or "").strip()
+    if not s:
+        return ""
+    from datetime import datetime
+    for fmt in _DATE_PATTERNS:
+        try:
+            d = datetime.strptime(s, fmt)
+            return d.strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+    print(
+        f"  ⚠ unparseable roleEndDate {s!r} — leaving entry permanent.",
+        file=sys.stderr,
+    )
+    return ""
+
+
 ## (No-op kept for git-history clarity.)
 ##
 ## _join_affiliation() used to merge the Form's separate Position +
@@ -396,6 +431,19 @@ def build_from_row(row: dict, cols: dict, role_info: dict, prior: dict | None) -
     working_groups = _cell(row, cols, "workingGroups") or (prior or {}).get("workingGroups", "")
     if working_groups:
         person["workingGroups"] = working_groups
+
+    # Role end-date for time-bound roles (interns, visiting fellows,
+    # fixed-term contracts). Normalised to ISO `YYYY-MM-DD` if the
+    # respondent typed a recognisable date; left out of the entry if
+    # the field is blank or unparseable. boardSorted.js applies a
+    # 7-day grace then moves the entry to the folded "Past board
+    # members and interns" footer.
+    role_end_raw = _cell(row, cols, "roleEndDate")
+    role_end = _normalize_date(role_end_raw) if role_end_raw else ""
+    if not role_end:
+        role_end = (prior or {}).get("roleEndDate", "")
+    if role_end:
+        person["roleEndDate"] = role_end
 
     # Slug + alt are preserved across syncs if the prior entry has them
     # (a hand-set slug for deep linking, or a custom alt for a11y).
@@ -665,6 +713,7 @@ FIELD_LABELS: dict[str, str] = {
     "photo": "headshot path",
     "alt": "alt text",
     "workingGroups": "working groups",
+    "roleEndDate": "role end-date",
 }
 LINK_LABELS: dict[str, str] = {
     "publicEmail": "public email",

--- a/src/_data/boardSorted.js
+++ b/src/_data/boardSorted.js
@@ -102,9 +102,32 @@ function buildTierMap() {
 // can't expand into anything new.
 const BIO_LONG_THRESHOLD = 180;
 
+// Time-bound roles (interns, visiting fellows, fixed-term contracts)
+// carry a `roleEndDate` (ISO `YYYY-MM-DD`). We hide a person from the
+// active sections one week after that date — the grace period keeps
+// the card visible for ~7 days past departure so anyone bookmarking
+// the page just after the end date still finds them. Entries without
+// `roleEndDate` are permanent and never filtered.
+//
+// Past entries move to `pastMembers` so the template can render them
+// as a folded "Past board members and interns" footer — they remain
+// part of the broader European security studies family, just not the
+// active team.
+const GRACE_PERIOD_DAYS = 7;
+function isExpired(person, todayMs) {
+  if (!person || !person.roleEndDate) return false;
+  // Treat the end-date as end-of-day UTC so a same-day check returns
+  // false (the person is still active on their last day).
+  const endMs = Date.parse(person.roleEndDate + "T23:59:59Z");
+  if (Number.isNaN(endMs)) return false; // malformed → never expire
+  const cutoffMs = endMs + GRACE_PERIOD_DAYS * 24 * 60 * 60 * 1000;
+  return todayMs > cutoffMs;
+}
+
 module.exports = function () {
   const esscNames = collectEsscNames();
   const tierByRole = buildTierMap();
+  const todayMs = Date.now();
 
   function annotate(person) {
     const bio = (person.bio || "").trim();
@@ -130,25 +153,39 @@ module.exports = function () {
     });
   }
 
-  const annotated = (board.members || []).map(annotate);
-  const leadership = sortMembers(annotated.filter((m) => m.tier < 100));
-  const boardMembers = sortMembers(annotated.filter((m) => m.tier >= 100));
-  const support = (board.support || []).map(annotate); // ordering preserved
+  // Annotate everyone (board members + support), then split into
+  // active vs. past based on `roleEndDate` + 7-day grace.
+  const allMembersAnnotated = (board.members || []).map(annotate);
+  const allSupportAnnotated = (board.support || []).map(annotate);
+
+  const activeMembers = allMembersAnnotated.filter((m) => !isExpired(m, todayMs));
+  const activeSupport = allSupportAnnotated.filter((m) => !isExpired(m, todayMs));
+
+  const leadership = sortMembers(activeMembers.filter((m) => m.tier < 100));
+  const boardMembers = sortMembers(activeMembers.filter((m) => m.tier >= 100));
+  const support = activeSupport; // ordering preserved
+
+  // Past members: union of expired entries from both sources, sorted
+  // by surname for the folded footer. Tier is preserved so the
+  // template can show their last role.
+  const pastMembers = [...allMembersAnnotated, ...allSupportAnnotated]
+    .filter((m) => isExpired(m, todayMs))
+    .sort(bySurname);
 
   // Exposed for the page footer link ("Update your bio"). Sourced
   // from scripts/board-source.json so the URL stays in sync with the
   // Form configuration the sync workflow uses.
   const formUrl = (boardSource.form_url || "").trim();
 
-  // Distinct countries across the whole team, alphabetised. Each
-  // entry includes the iso code so the /initiative page's flag strip
-  // can render them without re-doing the countryFlags lookup at
-  // template time. Skips empty country fields.
+  // Distinct countries across the whole active team, alphabetised.
+  // Each entry includes the iso code so the /initiative page's flag
+  // strip can render them without re-doing the countryFlags lookup at
+  // template time. Skips empty country fields. Past members are
+  // excluded so the stats row reflects only the active team.
   const countryFlags = require("./countryFlags.js");
   const seen = new Set();
   const countries = [];
-  const allAnnotated = [...annotated, ...(board.support || []).map(annotate)];
-  for (const p of allAnnotated) {
+  for (const p of [...activeMembers, ...activeSupport]) {
     if (!p.country) continue;
     const key = p.country.toLowerCase().trim();
     if (seen.has(key)) continue;
@@ -159,13 +196,24 @@ module.exports = function () {
   countries.sort((a, b) => a.name.localeCompare(b.name));
 
   // Top-line counts the /initiative page uses in the stats row.
-  // peopleTotal includes everyone (board + support); countriesTotal
-  // is the distinct count above.
+  // peopleTotal includes everyone *active* (board + support);
+  // countriesTotal is the distinct count above. Past members are not
+  // counted — the "N people across M countries" headline reflects the
+  // present team, not the cumulative roster.
   const counts = {
     peopleTotal: leadership.length + boardMembers.length + support.length,
     countriesTotal: countries.length,
     leadershipTotal: leadership.length,
+    pastTotal: pastMembers.length,
   };
 
-  return { leadership, boardMembers, support, formUrl, countries, counts };
+  return {
+    leadership,
+    boardMembers,
+    support,
+    pastMembers,
+    formUrl,
+    countries,
+    counts,
+  };
 };

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -3009,6 +3009,87 @@ h4 { font-size: var(--fs-lg); }
   margin: 0;
 }
 
+/* ---------- /board — past members folded footer ------------------------
+   Renders alumni (interns / visiting fellows / fixed-term contracts
+   whose `roleEndDate` has passed by more than the 7-day grace) as a
+   collapsed <details> at the bottom of /board. Closed by default.
+   When expanded the people-grid stays narrow (compact variant) so the
+   alumni section reads as a footer rather than competing with the
+   active team. */
+.past-members {
+  border-top: 1px solid var(--border);
+  padding-top: var(--space-5);
+}
+
+.past-members > summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-4);
+  align-items: baseline;
+  padding: var(--space-2) 0;
+  transition: color var(--motion-base) var(--ease-out);
+}
+
+.past-members > summary::-webkit-details-marker {
+  display: none;
+}
+
+.past-members > summary::before {
+  content: "▸";
+  display: inline-block;
+  margin-inline-end: var(--space-2);
+  color: var(--text-muted);
+  transition: transform var(--motion-base) var(--ease-out);
+}
+
+.past-members[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.past-members > summary:hover,
+.past-members > summary:focus-visible {
+  color: var(--accent);
+  outline: none;
+}
+
+.past-members-label {
+  font-weight: 600;
+  font-size: var(--fs-lg);
+  color: var(--text);
+}
+
+.past-members-count {
+  display: inline-block;
+  margin-inline-start: var(--space-2);
+  padding: 0.1em 0.55em;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  color: var(--text-muted);
+  background: var(--surface);
+}
+
+.past-members-hint {
+  flex: 1;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.past-members[open] .people-grid {
+  margin-top: var(--space-5);
+}
+
+.people-grid--compact {
+  /* Slightly smaller min column so alumni cards pack denser than the
+     active grid — visual signal that this is a quieter section. */
+  grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
+  opacity: 0.92;
+}
+
 /* ---------- print stylesheet -------------------------------------------
    Optimised for attendees printing the conference programme. Forces a
    light theme regardless of OS / toggle, strips chrome (nav, footer,

--- a/src/board.de.njk
+++ b/src/board.de.njk
@@ -69,3 +69,26 @@ alternates:
     {%- endif %}
   </div>
 </section>
+
+{%- if boardSorted.pastMembers and boardSorted.pastMembers.length %}
+<section class="section-tight">
+  <div class="container">
+    <details class="past-members">
+      <summary>
+        <span class="past-members-label">
+          Ehemalige Vorstandsmitglieder und Praktikanten
+          <span class="past-members-count">{{ boardSorted.pastMembers.length }}</span>
+        </span>
+        <span class="past-members-hint">
+          Sie bleiben Teil der weiteren europäischen Forschungsgemeinschaft für Sicherheitsstudien.
+        </span>
+      </summary>
+      <div class="people-grid people-grid--compact">
+        {%- for person in boardSorted.pastMembers %}
+          {%- include "person-card.njk" %}
+        {%- endfor %}
+      </div>
+    </details>
+  </div>
+</section>
+{%- endif %}

--- a/src/board.fr.njk
+++ b/src/board.fr.njk
@@ -70,3 +70,26 @@ alternates:
     {%- endif %}
   </div>
 </section>
+
+{%- if boardSorted.pastMembers and boardSorted.pastMembers.length %}
+<section class="section-tight">
+  <div class="container">
+    <details class="past-members">
+      <summary>
+        <span class="past-members-label">
+          Anciens membres et stagiaires
+          <span class="past-members-count">{{ boardSorted.pastMembers.length }}</span>
+        </span>
+        <span class="past-members-hint">
+          Ils font toujours partie de la communauté européenne des études de sécurité.
+        </span>
+      </summary>
+      <div class="people-grid people-grid--compact">
+        {%- for person in boardSorted.pastMembers %}
+          {%- include "person-card.njk" %}
+        {%- endfor %}
+      </div>
+    </details>
+  </div>
+</section>
+{%- endif %}

--- a/src/board.njk
+++ b/src/board.njk
@@ -71,3 +71,30 @@ alternates:
     {%- endif %}
   </div>
 </section>
+
+{# Past board members + interns whose `roleEndDate` is more than a week
+   in the past. Rendered as a folded <details> footer — they remain
+   part of the broader European security studies family, just not the
+   active team. Hidden entirely when nobody has expired. #}
+{%- if boardSorted.pastMembers and boardSorted.pastMembers.length %}
+<section class="section-tight">
+  <div class="container">
+    <details class="past-members">
+      <summary>
+        <span class="past-members-label">
+          Past board members and interns
+          <span class="past-members-count">{{ boardSorted.pastMembers.length }}</span>
+        </span>
+        <span class="past-members-hint">
+          They remain part of the broader European security studies family.
+        </span>
+      </summary>
+      <div class="people-grid people-grid--compact">
+        {%- for person in boardSorted.pastMembers %}
+          {%- include "person-card.njk" %}
+        {%- endfor %}
+      </div>
+    </details>
+  </div>
+</section>
+{%- endif %}


### PR DESCRIPTION
## Summary

Closes #126.

Adds a `roleEndDate` field to the board pipeline so interns, visiting fellows, and fixed-term contracts disappear from the active `/board` sections one week after their end date — and **reappear in a folded "Past board members and interns" footer** that frames them as part of the broader European security studies family rather than vanishing them outright. Daily rebuild keeps the transition automatic; no human gardening required.

## Design decisions (per #126 conversation)

- **Past members → folded footer**, not vanish. Copy reinforces the "they remain part of the broader European security studies family" framing in EN / FR / DE.
- **7-day grace period** after the role end-date. A card stays visible for ~1 week past departure so anyone bookmarking just after the end-date still finds them.
- **Generic field name** `roleEndDate` — covers interns, visiting fellows, fixed-term contracts. Empty field = no expiry (permanent role).
- **Filter at render**, not at sync. Expired entries stay in `board.json` for posterity; only the display is filtered. Daily rebuild auto-refreshes within ~24h of expiry.
- **`/initiative` stats reflect *active* team only**. `counts.peopleTotal` and `countriesTotal` recompute from the filtered list; new `counts.pastTotal` exposes the alumni count if any template wants it later.

## Pieces

- **`scripts/board-source.json`** — `roleEndDate` entry in the `columns` map → Form question "End date for time-bound roles (optional)" (Q18, Date).
- **`scripts/sync-board.py`**:
  - New `_normalize_date()` helper accepts `YYYY-MM-DD` (Forms default) plus `DD/MM/YYYY`, `DD.MM.YYYY`, `YYYY/MM/DD`, `MM/DD/YYYY`. Bad input logs a warning + leaves the entry permanent.
  - `build_from_row()` reads + writes the field through.
  - `FIELD_LABELS` grows a `"role end-date"` label so auto-PR-body diffs report changes by name.
- **`src/_data/boardSorted.js`**:
  - `isExpired(person, todayMs)` returns true when `roleEndDate` is set AND today is past `roleEndDate` end-of-day + 7 days.
  - Three active arrays (`leadership` / `boardMembers` / `support`) filter expired entries; new `pastMembers` carries the filtered-out entries sorted by surname.
  - `counts.peopleTotal` + `countriesTotal` reflect active team only; new `counts.pastTotal`.
- **`src/board.{njk,fr.njk,de.njk}`** — new `<details class="past-members">` folded footer rendering pastMembers in a compact people-grid. Hidden entirely when nobody has expired (current state for everyone).
- **`src/assets/css/site.css`** — `.past-members` / `.past-members-{label,count,hint}` / `.people-grid--compact`. Native `<details>` with rotating-caret marker, accent on hover/focus, count chip, italic hint line, opacity 0.92 on the alumni grid.
- **`docs/board-bios-setup.md`** — Q18 added to the question grid; new "End-date question — time-bound roles" subsection covers Form configuration + grace period + folded-footer behaviour.

## Operator action (manual, post-merge)

The Form question itself still has to be created by hand in the Google Form — the doc walks through it. The repo is ready to consume the field as soon as the column appears in the linked Sheet.

## Test plan

- [x] `python3 -c "import json; ...; assert 'roleEndDate' in board-source.json columns"` — column wired
- [x] `boardSorted.js` syntactically OK; `isExpired()` logic walked through by inspection (end-of-day UTC + 7 days, malformed → never expire)
- [x] `python3 scripts/check-i18n-drift.py` clean
- [ ] After merge + Form question add: insert a test entry with `roleEndDate` 10 days in the past, confirm it lands in the folded footer; another with date 3 days in the past, confirm it's still active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)