### PR TITLE
mobile nav: right-align utility cluster + restore lang switcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ### Fixed
 
+- **Mobile nav: utility icons + lang switcher restored to the right edge** — at the `880 px` drawer breakpoint, `.nav-links` becomes a fixed-position dropdown which stopped taking flex space, so its previous `margin-left: auto` no longer pushed `.nav-actions` right. The lang switcher + theme toggle + burger menu were ending up squeezed against the brand, looking centered-ish. Added `margin-inline-start: auto` on `.nav-actions` inside the drawer breakpoint so the utility cluster aligns to the right edge of the bar. Same PR drops the `@media (max-width: 480px) { .lang-switcher { display: none; } }` rule that was hiding the EN/FR/DE switcher on phones — FR and DE speakers couldn't switch locales without going to desktop or editing the URL. The switcher now compacts (smaller padding + 10 px chips) at very narrow widths but stays visible. Closes #137. (#138)
 - **`scripts/release.sh` compare-link regex** now accepts letters and dashes after the dotted numerics, so `v2.13.0r` and any future suffixed tags update cleanly. Previous regex `v([0-9.]+)` silently failed to bind on `v2.13.0r`, leaving `[Unreleased]: …/compare/v2.13.0r...HEAD` stale across v2.22.0. Same PR repoints the live compare link at v2.22.0. (#121)
 
 ## [2.22.0] · 2026-05-24 — Live board pipeline and Initiative refresh

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -348,11 +348,21 @@ h4 { font-size: var(--fs-lg); }
   background: var(--accent);
 }
 
-/* On narrow viewports the chips can wrap below the nav.
-   Hidden on the smallest mobile widths to keep the top bar tidy —
-   users can still switch via the footer or by editing the URL. */
+/* On narrow viewports the chips compact — language switching is a
+   primary action and dropping it on mobile (the previous behaviour,
+   `display: none` below 480px) stranded FR/DE speakers on whichever
+   locale they landed on. Closes #137. */
 @media (max-width: 480px) {
-  .lang-switcher { display: none; }
+  .lang-switcher {
+    /* Drop the right margin so the switcher hugs the theme toggle
+       (the nav-actions container has its own gap). */
+    margin-right: 0;
+    padding: 2px;
+  }
+  .lang-chip {
+    padding: 3px 7px;
+    font-size: 10px;
+  }
 }
 
 /* ---------- beta-translation ribbon ---------- */
@@ -625,6 +635,18 @@ h4 { font-size: var(--fs-lg); }
 
   .nav-menu-toggle {
     display: grid;
+  }
+
+  /* At this breakpoint .nav-links becomes a fixed drawer below the
+     header bar, so it stops taking flex space and its previous
+     `margin-left: auto` no longer pushes .nav-actions to the right.
+     The actions cluster (lang switcher + theme toggle + burger) was
+     ending up squeezed against the brand, looking like it was
+     "floating in the middle" of the bar. Pushing nav-actions itself
+     right restores the right-aligned utility cluster the desktop
+     bar has. Closes #137. */
+  .nav-actions {
+    margin-inline-start: auto;
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #137. Two sitewide mobile nav fixes, both CSS-only:

### 1. Utility icons aligned right (was: floating mid-bar)

At the `880 px` drawer breakpoint, `.nav-links` becomes `position: fixed` (the drop-down drawer), which takes it out of the flex flow. Its previous `margin-left: auto` no longer pushed anything after it to the right. Result: `.nav-actions` (lang switcher + theme toggle + burger menu) sat at default `flex-start` position right after the brand — looking off-center on phones.

**Fix**: added `margin-inline-start: auto` on `.nav-actions` inside the drawer media query. Cluster now aligns to the right edge of the bar, matching the desktop layout's right-aligned utility area.

### 2. Translation switcher restored on mobile

There was a `@media (max-width: 480px) { .lang-switcher { display: none; } }` rule hiding the EN / FR / DE chips on phones. FR and DE speakers landing on the EN site couldn't switch locales without going desktop or hand-editing the URL.

**Fix**: dropped the `display: none`. Replaced with a compact-on-mobile variant — smaller padding (2 px outer, 3 × 7 chips), 10 px font, no right margin (the nav-actions container has its own gap). The switcher now fits the bar comfortably at ~360–414 px viewports.

## Files

- `src/assets/css/site.css` — CSS-only changes (`.lang-switcher` mobile rules + `.nav-actions` inside the 880 px breakpoint)
- `CHANGELOG.md` — `[Unreleased] → Fixed` entry referencing #137

No template changes, no i18n drift, no accessibility regressions (the lang switcher gains visibility, not loses it). Light + dark modes inherit; reduced-motion unaffected.

## Test plan

- [ ] **Phone (~360–414 px)**: brand on left, utility cluster (EN/FR/DE switcher + theme toggle + burger) hugs the right edge
- [ ] **Phone**: tapping a chip switches locale; the active chip stays highlighted
- [ ] **Tablet (~768 px)**: drawer breakpoint, same right-aligned layout
- [ ] **Desktop**: unchanged from before (the rules only fire below 880 px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)