### PR TITLE
docs: import operator + security conventions from netsec.github.io (Import PR 1 of 3-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,59 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 
 ## Release-notes format (applies to `[Unreleased]` + every `[X.Y.Z]` section)
 
-Release notes here follow a **hybrid format**: a short prose lede, two-to-five themed sub-sections carrying the actual narrative, and a canonical **index of changes** at the bottom grouped by Keep-a-Changelog categories. Patches skip the lede + themes and ship the index only.
+Release notes here follow a **hybrid format**: a short prose lede, two-to-five themed sub-sections carrying the actual narrative, and a canonical **index of changes** at the bottom grouped by Keep-a-Changelog categories. The themes are where the writing happens; the index is the audit trail.
+
+### Shape
+
+```markdown
+## [X.Y.Z] · YYYY-MM-DD — <short title>
+
+> One- to three-sentence lede in voice. What is this release *about*?
+> Who's it for? Why ship it now?
+
+### <First theme — name it for the thing that changed>
+
+Prose intro (~2-4 sentences). Inline links to docs / issues where
+relevant. Add bullets only if the theme has multiple distinct pieces;
+otherwise let the prose carry it.
+
+### <Second theme>
+
+Same shape.
+
+### Index of changes
+
+The themed sections above are the story; the index below is the
+audit trail. Same content, terser.
+
+#### Added
+- (one-line pointer bullets, what not why)
+
+#### Changed
+- (…)
+
+#### Fixed
+- (…)
+```
+
+### Rules
+
+1. **One Index block per release.** Each release section has at most one `### Index of changes` block and at most one of each `#### Added` / `#### Changed` / `#### Deprecated` / `#### Removed` / `#### Fixed` / `#### Security` sub-heading inside it, in that order. When a PR adds an entry to `[Unreleased]`, the bullet goes inside the *existing* sub-heading, never a new one with the same name below it.
+
+2. **The lede + themes are written when the release is cut**, not accumulated bullet-by-bullet through the development cycle. The release-cutting moment is where the maintainer reads back through `[Unreleased]`, picks the 2-5 most coherent themes, drafts the lede, and weaves the bullets into prose sections.
+
+3. **Self-policing tier**:
+   - **Patch** (`X.Y.Z` with `Z > 0`) ships the Index block only, no lede or themes. People reading patch notes care about specifics.
+   - **Minor / major** ships the full hybrid: lede + themes + index.
+   - If you can't write a meaningful lede about a release, it's a patch. The format mirrors the actual significance.
+
+4. **Within a theme**, order content by user impact: headline first, smaller polish after. Within the index, same ordering inside each `####` block.
+
+5. **The release script (`scripts/release.sh`) extracts the `[Unreleased]` body verbatim** into the GitHub Release notes. Eyeball the body before confirming the script's prompt.
+
+6. **No hard wraps in prose.** Each prose paragraph, blockquote lede, and multi-line bullet must be a single source line. Do not break mid-sentence with a `\n`. GitHub Releases renders markdown with the *break-on-newline* GFM variant; every soft `\n` becomes a `<br>` and forces the prose to render narrow on the Releases page (even though it looks flowing on the `github.com` file view). One long line per paragraph keeps both renderings correct. Code fences, headings, blank lines, and the compare-link footer are unaffected.
+
+See [`CLAUDE.md`](CLAUDE.md) §4 for the operator-facing version of these rules.
 
 ## Retroactive renumber
 
@@ -16,10 +68,13 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ### Added
 
+- **`CLAUDE.md` at repo root**, ~270 lines of operator-facing convention adapted from the sister repo [`netsec.github.io`](https://github.com/EISSeuropa/netsec.github.io)'s `CLAUDE.md`. Codifies eleven numbered rule sections: language (British English, no machine translation), PR workflow (auto-merge default, visual carve-out, squash), the "open an issue for every deferred item" rule with informal template, release-notes hybrid format, the four-point release cross-check (roadmap, sitemap, translations, repo docs + the milestone hygiene gate), public-copy voice (no developer jargon, show-don't-tell), prose voice (no em dashes, no rule-of-three rhythm, no synonym cycling), working-tree hygiene, accessibility + i18n cadence, milestone tagging (every issue carries one of the five thematic milestones), and documentation currency. Adapted where the EISS convention diverges from NetSec's: thematic milestones rather than per-release version milestones; `master` branch rather than `main`; no Wiki or stakeholder PDF; sync-board + sync-indico data pipelines rather than sync-cost + sync-bios. Future Claude sessions read this on every invocation, so the conventions survive context-window expiry.
 - **`/initiative` hero brand banner (PR C of 3)** — the full EISS lockup (constellation + EiSS wordmark + "The European Initiative for Security Studies" tagline) renders above the eyebrow on the about page in all three locales, sized for a one-line tagline on desktop and graceful wrap on mobile. Acts as a visual statement of identity right where new visitors land. Left-aligned to flow with the existing eyebrow + H1 + page-lead stack rather than competing with them; `aria-hidden` because the H1 already names the section. Uses the same `inlineSvg` shortcode added in PR B so the wordmark's `currentColor` cascades from the `.initiative-hero-brand { color: #007bc6 }` rule.
 
 ### Changed
 
+- **`SECURITY.md` rewritten from an 84-byte stub to a full security policy** adapted from the sister repo `netsec.github.io`'s template, ~110 lines covering scope (in-scope vs out-of-scope, listed third-party vendors with their own reporting URLs), the private-disclosure channels (GitHub Security Advisories preferred, email fallback), expected acknowledgement and resolution SLAs by severity, safe-harbour terms for good-faith researchers, and a list of the security hygiene the repo already maintains (pinned dependencies, no production secrets in-repo, least-privilege Actions, no tracking pixels).
+- **`CHANGELOG.md` preamble expanded** with the full hybrid release-notes shape (template + six rules), so the format is documented in the same file that uses it rather than only in `README.md` and `CLAUDE.md`. The new rules cover one-Index-per-release, write-themes-at-release-time-not-PR-time, self-policing patch vs minor tier, content ordering by user impact, the release-script verbatim extraction guarantee, and the critical "no hard wraps in prose" rule (every soft `\n` becomes a `<br>` in GitHub Releases). Links to `CLAUDE.md` §4 for the operator-facing version.
 - **Schema.org `Organization` `logo` upgraded from a stale Mobirise-era JPEG to the new high-res brand PNG (PR C of 3)** — the JSON-LD in `base.njk` head now points at `/assets/images/brand/logo-full-1024.png` (1024×712, ≈1.44:1 aspect — within Google's required 1:1-to-4:1 range for Knowledge Panel logos) and uses an `ImageObject` with explicit `width` / `height` so Google's parser can size it without an extra fetch. Also adds `foundingDate: "2017"` to tie the org to the inaugural Panthéon-Assas conference — helps disambiguate from other "EISS" acronyms in the Knowledge Panel and surfaces the founding year on rich-results cards.
 - **EISS logo replaces the placeholder "E" mark across site chrome (PR B of 3)** — every header, every footer, the favicon, the Apple touch icon, the Android adaptive icon, and the PWA manifest theme colour now use the real brand identity from `src/assets/images/brand/` (shipped in PR A). The header inlines the constellation + EiSS wordmark lockup on desktop and collapses to just the iconmark + a small text label below 600 px (the breakpoint where the nav's lang switcher + menu button start crowding the brand). The footer carries the full lockup including the tagline as a polished closing sign-off. The favicon is a brand-blue rounded square containing a simplified 4-dot constellation (the full 7-dot constellation is illegible at 16-32 px; this captures the network metaphor with strokes thick enough to survive downscaling — verified at 16 / 32 / 180 / 192 / 512). `theme-color` and PWA `background_color` switch from `#1e6bcb` to the canonical brand `#007bc6`, sampled from the master PDF in the brand bundle. A new `inlineSvg` Eleventy shortcode reads the SVG bytes at build time so the inlined markup picks up cascading `color:` from the parent — that's how the wordmark's `currentColor` fills resolve to brand blue (set on `.brand-logo`) without forking the SVG per surface. Maintains brand blue in both light + dark modes per the agreed identity rule.
 - **`scripts/derive-logo-variants.py`: unique title/desc IDs per variant** (`t-mark/d-mark`, `t-lockup/d-lockup`, `t-full/d-full`) so the lockup + iconmark can be inlined on the same page (as `nav.njk` does for desktop/mobile responsive swap) without producing duplicate HTML IDs in the rendered page.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Claude project rules — EISSeuropa.github.io
+# Claude project rules: EISSeuropa.github.io
 
 Read by Claude Code on every session in this repository. Codifies the
 standing constraints the maintainer has set for AI-assisted work, so
@@ -95,7 +95,7 @@ Specific enough that a future maintainer can pick it up without
 re-deriving the analysis. Code paths, file names, line numbers.
 
 ## Milestone
-One of the thematic milestones (rule §10) — never leave it blank.
+One of the thematic milestones (rule §10). Never leave it blank.
 ```
 
 **Set the GitHub milestone at creation time** (rule §10):
@@ -293,15 +293,15 @@ drifts.
 EISS uses **thematic milestones** rather than per-release version
 milestones (NetSec's convention is different). The current set:
 
-- **NetSec & shared infra** — anything touching the NetSec relationship
+- **NetSec & shared infra**: anything touching the NetSec relationship
   or shared scripts / tokens / data sources between the two sister sites.
-- **Indico integration deepening** — sync-indico work, live programme
+- **Indico integration deepening**: sync-indico work, live programme
   grids, Indico API probing.
-- **ESSC 2026 ops** — anything specific to the current annual
+- **ESSC 2026 ops**: anything specific to the current annual
   conference cycle.
-- **i18n native-speaker review** — FR / DE translation refreshes,
+- **i18n native-speaker review**: FR / DE translation refreshes,
   native-reviewer feedback.
-- **Maintenance & reliability** — CI, build hygiene, dependency
+- **Maintenance & reliability**: CI, build hygiene, dependency
   bumps, accessibility fixes, security hardening.
 
 When the active work no longer fits any of these, propose a new

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,361 @@
+# Claude project rules — EISSeuropa.github.io
+
+Read by Claude Code on every session in this repository. Codifies the
+standing constraints the maintainer has set for AI-assisted work, so
+they survive context-window expiry. Update via PR when a rule shifts.
+
+The single human reader of this file is the maintainer (Dr Arthur
+Laudrain). Keep it terse: every word here is read once per session
+and costs context.
+
+Adapted from the sister repository
+[`EISSeuropa/netsec.github.io`](https://github.com/EISSeuropa/netsec.github.io)'s
+`CLAUDE.md`. Where rules differ between the two sites, this file is
+authoritative for EISS.
+
+---
+
+## 1. Language & translation
+
+- **British English** in user-facing copy (site pages, the accessibility
+  statement, the privacy notice, CHANGELOG release notes, GitHub Release
+  bodies, PR descriptions that an external reader might see). Internal
+  commit messages and code comments can be more relaxed but should not
+  flip mid-document.
+- **No machine translation, ever.** FR and DE variants are translated
+  by hand. The `status: beta` ribbon on `*.fr.njk` / `*.de.njk` carries
+  the manual-translation framing. If you find any user-facing copy that
+  implies machine translation, fix it.
+
+## 2. Pull-request workflow
+
+- **Auto-merge by default.** Open the PR with `gh pr create`, then arm
+  auto-merge with `gh pr merge --auto --squash`. CI checks (the i18n
+  drift checker on every HTML-touching PR, plus CodeQL) hold the merge
+  if something is wrong.
+- **Carve-out: visual changes need preview review.** When the PR
+  changes something a human will see (layout shifts, new components,
+  copy that's visible above the fold, anything affecting brand
+  identity), do NOT arm auto-merge. Leave the PR open and ask the
+  maintainer to eyeball the Cloudflare or Netlify deploy preview
+  before merging. The brand rollout (PRs #154 / #155 / #156) is the
+  canonical example of the carve-out done well.
+- **Carve-out: release notes.** When cutting a release via
+  `scripts/release.sh`, eyeball the lede + themes + index before
+  confirming the publish prompt. Publication to GitHub Releases is
+  harder to undo than a merge.
+- **Squash, not merge commits.** Every PR ends as a single commit on
+  `master`. The release-cutter then writes the release commit on top.
+
+## 3. Open a GitHub issue for every deferred item
+
+Whenever you identify work that won't ship *this turn* (a bug, a
+feature need, a structural follow-up, a "queued for later" finding),
+**open a GitHub issue before the session ends.** The audit trail
+self-references that way; loose ends survive context-window expiry
+and release cycles.
+
+### When to open an issue
+
+- A **bug** you've spotted but aren't fixing now, because it's out of
+  scope for the current PR, needs further investigation, or pairs
+  better with future work. Example: the brand rollout (#156) left
+  the OG-card overlay watermark out of scope; the deeper question
+  of "how do we keep the iconmark on every social card going forward"
+  became [#157](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/157).
+- A **feature need** that surfaced from a user journey or maintainer
+  conversation but isn't being scoped this turn.
+- A **structural follow-up**: the current PR papered over a symptom
+  but the root cause needs a different fix.
+- A **deferral with a tag**: "queued for the next minor", "after the
+  brand rollout", "needs design pass". Anything that sits in
+  audit-trail prose anywhere in the repo belongs in an issue too.
+
+### When **not** to open an issue
+
+- Work that's shipping *this turn*. The PR is the record.
+- Pure observations that need no action.
+- Duplicates: always
+  `gh issue list --state open --search "..."` first, and prefer
+  linking + commenting on an existing issue.
+- Trivial inline fixes you can do in seconds without context switch.
+
+### Issue template (informal, no `.github/ISSUE_TEMPLATE/` files)
+
+```markdown
+## What's happening
+One paragraph + a concrete repro or pointer.
+
+## Why it matters
+One paragraph. User impact, audit-trail context, or accessibility /
+compliance angle.
+
+## Fix path (or fix options)
+Specific enough that a future maintainer can pick it up without
+re-deriving the analysis. Code paths, file names, line numbers.
+
+## Milestone
+One of the thematic milestones (rule §10) — never leave it blank.
+```
+
+**Set the GitHub milestone at creation time** (rule §10):
+`gh issue create --milestone "<milestone>" ...`. The body's milestone
+line is human-readable context; the milestone is the queryable
+commitment.
+
+Labels: use the existing set already present in this repo (`bug`,
+`enhancement`, `documentation`, `data-sync`, `automated`,
+`known-issue`, etc.). Don't invent new labels without asking; the
+label set is small on purpose.
+
+### Cross-reference
+
+When an issue closes a deferred row in an audit doc (e.g. an entry
+in `docs/roadmap-2026.md`, or a "needs follow-up" note in the
+accessibility statement), **edit the audit doc to link the new
+issue.** Status should read e.g. "open (tracked in #157)" rather
+than the dangling "deferred".
+
+## 4. Release-notes format
+
+The hybrid format is documented at the top of `CHANGELOG.md` and
+restated in `README.md` under *Versioning*. Every release section
+follows it.
+
+Short version: **lede + 2-4 themed `### sub-sections` + canonical
+`### Index of changes`**. Self-policing tier: patch releases skip
+the lede + themes and ship the index only.
+
+**Minor vs patch: the feature test** (see `README.md` for the full
+table). A minor ships at least one new user-visible feature or a
+significantly improved existing feature. Anything else (content
+additions on an existing page, copy edits, translation refreshes,
+accessibility passes, dependency bumps) is a patch. Read the lede
+aloud: *"we polished / fixed / refreshed X"* means patch; *"you can
+now do X"* means minor. When in doubt, patch.
+
+Hard rule: **no hard wraps in prose.** One source line per
+paragraph / bullet / blockquote. GitHub Releases renders soft `\n`
+as `<br>` and otherwise produces visibly narrow prose.
+
+**Keep `[Unreleased]` current.** Every PR that introduces a
+user-visible change adds at least one bullet under
+`[Unreleased]` → `### Added` / `### Changed` / `### Fixed` in the
+same PR. Reconstructing a release batch from the git log at release
+time loses nuance and burns time; capturing the bullet while the
+context is fresh is cheap. Exempt: Dependabot PRs, the automated
+`indico-sync/auto` and `bios-sync/auto` data refresh PRs, and any
+internal-only commit (docs-only refresh, CI tooling, working-tree
+hygiene). When in doubt, add the bullet. Cutting a release becomes:
+review what's already there, decide on the title,
+`scripts/release.sh`.
+
+## 5. Release-time four-point cross-check (minor / major only)
+
+Every **minor (`X.Y.0` where `Y > prev`) or major (`X.0.0`)
+release** should trigger a deliberate check across four surfaces
+before `scripts/release.sh` runs. Skip the cross-check on **patch
+releases** (`X.Y.Z` where `Z > 0`); they're scoped to small fixes
+and the overhead isn't justified. The release script's
+*self-policing tier* mirrors this: patches ship the index only.
+
+For each surface, the question is the same: *"Did anything in this
+release change what this surface documents?"* If yes, edit in the
+same release. If yes but too big to fit, open a tracking issue
+(rule §3) and reference it from the surface itself.
+
+### 1. Roadmap (`docs/roadmap-2026.md`)
+
+- Is the next planned release on the timeline still accurate?
+- Anything in the deferred-items section ready to promote to a
+  dated entry?
+- The autostamp on the document (when wired in, see rule §11) keeps
+  the `[Unreleased]` bullet count fresh automatically. The prose
+  timeline rows stay maintainer-edited.
+
+### 2. Sitemap (`src/sitemap.xml.njk` + `src/sitemap.njk` + FR + DE)
+
+- New pages added in this release? Confirm they show up in
+  `src/sitemap.xml.njk` (the XML index for search engines) and in
+  the visual `src/sitemap.njk` inventory + its FR / DE siblings.
+- The visual sitemap is hand-edited; confirm new pages land in the
+  correct branch (*About* / *Programmes* / *Conferences* / etc.).
+
+### 3. Translations (FR + DE variants)
+
+- Run `python3 scripts/check-i18n-drift.py` locally. CI catches drift
+  on HTML-touching PRs, but a release moment is the right place to
+  confirm zero drift before stamping a version.
+- Did any EN copy change in this release? FR / DE need manual updates
+  (no machine translation per rule §1).
+- The `status: beta` ribbon on `*.fr.njk` / `*.de.njk` carries the
+  manual-translation framing; if a translation has been re-verified
+  against current EN, consider whether the *beta* marker still applies.
+
+### 4. Repo docs
+
+- Maintainer-facing markdown docs under `docs/`
+  (`board-bios-setup.md`, `i18n.md`, `indico-api-token.md`,
+  `indico-programme-integration.md`, `new-conference.md`,
+  `roadmap-2026.md`): does anything in this release contradict what's
+  documented?
+- `BRAND.md` and the brand SVGs under `src/assets/images/brand/`:
+  refresh if the visual identity changes.
+
+### 5. Milestone hygiene (gate, not a surface)
+
+- Every issue closed by this release carries the matching milestone.
+- Every issue still open and tagged with a milestone that just shipped
+  has either been ticked off in the release notes or moved to the
+  next milestone with a one-line reason in the issue thread.
+- The release should not ship with its own milestone holding open work.
+  See rule §10.
+
+This is a deliberate friction-point: cutting a minor release here is
+**slightly more work than running release.sh**, by design. The
+release script's confirmation prompt is the last moment to bail if
+the cross-check surfaces something that needs to land in the same
+release.
+
+## 6. Voice for public-facing copy
+
+Public-facing copy means anything that appears on `eiss-europa.com`
+pages, the beta ribbon, the accessibility statement, the privacy
+notice, OG card descriptions. Readers are scholars, journalists,
+prospective board / community members, and partner-institution staff.
+None of them are developers; none of them care how the site is built.
+
+**No "source of truth".** It is developer jargon. Acceptable
+substitutes by context: "authoritative source", "Indico", "the
+Form", "the directory".
+
+**Show, don't tell, for feature mechanics.** If a page surfaces
+synced data, don't write a sentence explaining the sync. Surface
+liveness with a visual cue. The pulsing accent ring on the
+registration badge in `/2026.njk` is the canonical example.
+Mechanism descriptions belong in the maintainer docs.
+
+## 7. Prose voice (em dashes and AI patterns)
+
+These apply to every piece of prose I author in this project: the
+public site, the CHANGELOG, PR descriptions, the documentation pack
+body text, multi-paragraph code comments. (One-line `# label` code
+comments stay flexible.)
+
+**No em dashes.** Use commas, parentheses, full stops, or colons. Em
+dashes pattern-match to AI-generated prose; a careful reader notices.
+
+**No rule-of-three rhythm.** If there are two items, write two. If
+there are five, write five. Manufactured triplets for cadence are
+the most reliable AI tell.
+
+**No synonym cycling.** Pick one referent for an entity and reuse it
+across consecutive sentences. Writing "the script" then "the sync"
+then "the workflow" for the same thing in three sentences is an AI
+tell, even when each label is technically accurate.
+
+The rules are forward-looking. They apply to prose authored from the
+PR that introduces them onwards; pre-existing em dashes in the repo
+aren't retroactively scrubbed unless the surrounding text is being
+edited anyway.
+
+## 8. Working tree hygiene
+
+- Never leave the working tree dirty across PR boundaries. If a
+  script (e.g. `sync-board.py`, `sync-indico.py`, `derive-logo-variants.py`)
+  modifies tracked files as a side-effect of a verification run,
+  decide whether the modification is part of the current PR (include
+  it) or an unrelated drift (revert before committing).
+- The weekly bios-sync workflow (`sync-board.yml`) is structurally
+  tuned to produce zero dirty files when no submitter has
+  substantively changed their entry. If you see the workflow trip an
+  apparently-empty PR, that's a regression. Open an issue and
+  investigate before silencing.
+
+## 9. Accessibility & i18n cadence
+
+- The accessibility statement at `src/accessibility.njk` (+ FR + DE)
+  is bumped on every release that touches a11y conformance, audit
+  results, or a known-limitations list.
+- FR / DE drift checker (`scripts/check-i18n-drift.py`) runs in CI on
+  every HTML-touching PR. When it flags drift, refresh the
+  translation manually before merging.
+
+## 10. Milestone tagging
+
+Every open issue belongs to exactly one milestone. The milestone is
+the bridge between the *Milestone* line in the issue template (rule
+§3) and the planned work on the roadmap; without it, the backlog
+drifts.
+
+### The milestone set (thematic, not version-tied)
+
+EISS uses **thematic milestones** rather than per-release version
+milestones (NetSec's convention is different). The current set:
+
+- **NetSec & shared infra** — anything touching the NetSec relationship
+  or shared scripts / tokens / data sources between the two sister sites.
+- **Indico integration deepening** — sync-indico work, live programme
+  grids, Indico API probing.
+- **ESSC 2026 ops** — anything specific to the current annual
+  conference cycle.
+- **i18n native-speaker review** — FR / DE translation refreshes,
+  native-reviewer feedback.
+- **Maintenance & reliability** — CI, build hygiene, dependency
+  bumps, accessibility fixes, security hardening.
+
+When the active work no longer fits any of these, propose a new
+milestone in a PR (or to the maintainer directly), don't silently
+spawn one.
+
+### When to set the milestone
+
+- **At issue creation.** Whenever rule §3 fires, set the milestone
+  alongside the title and body.
+- **When an issue moves between themes.** Update the milestone in
+  the same edit that records the reframe.
+- **Never leave an open issue without one.** A milestone-less open
+  issue is invisible to roadmap planning.
+
+## 11. Documentation currency
+
+The site has two classes of documentation, each with a different
+cadence for staying current.
+
+### Repo `.md` docs
+
+1. **Inline at PR time.** If a PR changes something a doc describes
+   (an architectural component, a documented procedure, the public
+   surface of a script that has its own `.md` doc), the same PR
+   updates that doc. Same posture as the per-PR `[Unreleased]` rule
+   in §4. Examples: `board-bios-setup.md` for Form / board.json
+   pipeline changes, `indico-programme-integration.md` for sync
+   changes, `new-conference.md` for the per-year-page rollover
+   procedure.
+
+2. **Catch-up sweep at every release** (patch, minor, major). Walk
+   the `docs/` index, spot-check each against what shipped, fix
+   what's wrong. Lightweight by design: most PRs already updated
+   their target doc inline, so the sweep is the safety net rather
+   than the workhorse.
+
+#### Automation note: roadmap autostamp (planned)
+
+A workflow modelled on
+[`netsec.github.io`'s `sync-roadmap.yml`](https://github.com/EISSeuropa/netsec.github.io/blob/main/.github/workflows/sync-roadmap.yml)
+will keep an autostamp block at the top of `docs/roadmap-2026.md` in
+sync with `CHANGELOG.md`'s `[Unreleased]` section, counting bullets
+per category and anchoring against the most recent SemVer tag. This
+is an open import task: Import PR 2 in the NetSec-convention rollout.
+
+So the maintainer will never have to manually refresh the count or
+freshness stamp once that lands. **What the automation does not do**:
+rewrite the prose timeline rows. When the count visibly diverges from
+what the prose says is in flight, the maintainer resynthesises by
+hand (which is also a §5 cross-check item at release time).
+
+---
+
+*This file is short on purpose. If you need to add a rule, add it
+here; if you need to add an example, prefer linking a PR / commit /
+issue so this file stays a reference rather than a tutorial.*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,110 @@
 # Security Policy
 
-## Reporting a Vulnerability
-Email us at contact@eiss-europa.com
+This repository hosts the public website of the **European Initiative
+for Security Studies (EISS)**, served at <https://eiss-europa.com>.
+It is a static [GitHub Pages](https://pages.github.com/) site built
+from Eleventy 3 + Nunjucks templates, with two scheduled Python sync
+jobs (board bios from a Google Form, Indico event data from the EISS
+Indico instance) and a daily rebuild cron. We take its security
+seriously and welcome reports.
+
+## Scope
+
+| In scope                                                              | Out of scope                                                                              |
+| --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| The current `master` branch of this repository                        | Older branches, tags, or forks                                                            |
+| The deployed site at <https://eiss-europa.com> and `*.github.io` URL  | Third-party services we rely on, please report to them directly                           |
+| The GitHub Actions workflows in `.github/workflows/`                  | Reports about EISS branding, visual identity, or funding statements                       |
+| The Python sync scripts in `scripts/`                                 | Theoretical issues that depend on a compromised contributor account or repo write access  |
+| `src/_data/board.json` and any personal data therein                  | Volumetric DoS against GitHub, Google Forms, or the Indico instance                       |
+
+Third-party services in our stack. Report vulnerabilities affecting
+them to the relevant vendor rather than to us:
+
+- **GitHub** (hosting, Pages, Actions): <https://github.com/security>
+- **Google** (Forms + Sheets used for the board-bios pipeline): <https://www.google.com/about/appsecurity/>
+- **Indico** (event metadata API at the EISS conference platform): contact the Indico instance administrator
+- **FlagCDN** (passive CDN asset for country flags)
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue or pull request.** Two
+private channels are available:
+
+1. **GitHub Security Advisories** (preferred):
+   <https://github.com/EISSeuropa/EISSeuropa.github.io/security/advisories/new>.
+   This is encrypted, lets us collaborate on a fix in a private fork,
+   and gives you a CVE if appropriate.
+2. **Email** Dr Arthur Laudrain (site maintainer, board member CH).
+   For data-protection matters specifically, contact the Data
+   Controller (the European Initiative for Security Studies) at
+   <contact@eiss-europa.com>, per §1 of the
+   [Privacy Notice](https://eiss-europa.com/policy.html).
+
+When reporting, please include:
+
+- a description of the issue and its impact;
+- the URL or file path where you observed it;
+- the steps needed to reproduce it (a minimal proof-of-concept is
+  ideal, but not required);
+- any suggested remediation, if you have one.
+
+## What to expect from us
+
+- **Acknowledgement**: within **5 working days** of your report.
+- **Initial assessment**: within **14 working days**. We will tell
+  you whether we accept the finding, need more information, or
+  consider it out of scope, and we will share an indicative timeline.
+- **Resolution**:
+  - *Critical* (data exposure, account takeover, XSS with credential
+    leakage): patch in days, hotfix deployed via a PR to `master`.
+  - *High / Medium*: patch in the next sprint of work, typically two
+    to four weeks.
+  - *Low / informational*: rolled into routine maintenance.
+- **Disclosure**: coordinated. We will not publicly discuss the
+  vulnerability until a fix is deployed. We are happy to credit you
+  in the resolving PR and in the GitHub Security Advisory unless you
+  prefer to remain anonymous.
+
+## Safe harbour
+
+If you make a good-faith effort to comply with this policy when
+researching and reporting an issue, we will:
+
+- not pursue or support any legal action against you;
+- work with you to understand and resolve the issue quickly;
+- recognise your contribution publicly if you wish.
+
+Good-faith research means: only acting against your own data and the
+public website, avoiding privacy violations and service disruption,
+not retaining personal data of others, and giving us reasonable time
+to fix the issue before any public disclosure.
+
+## What we do on our side
+
+A short list of the security hygiene we maintain on this repository:
+
+- **Dependencies**: Python dependencies in `scripts/requirements.txt`
+  are pinned with version bounds and monitored by GitHub Dependabot.
+  Node dependencies (Eleventy core) are likewise pinned in
+  `package.json` and monitored.
+- **Secrets**: no production credentials live in the repo. The Google
+  Forms / Sheets pipeline uses **public** published-to-web CSV URLs
+  and a public Forms URL. The Indico sync uses a Personal Access
+  Token stored as a GitHub Actions secret, scoped to read-only access
+  on the conference instance.
+- **GitHub Actions**: third-party actions are pinned by full commit
+  SHA where reasonable, and Action permissions follow the principle
+  of least privilege (the default workflow token is read-only; jobs
+  that need to commit declare `contents: write` at the job level).
+- **Personal data**: handled per the
+  [Privacy Notice](https://eiss-europa.com/policy.html). Submitters
+  can ask for changes or removal at any time via
+  <contact@eiss-europa.com>, and we maintain a soft PR-review
+  workflow before any new bio appears on the public site.
+- **No tracking, no analytics**: the site loads no inline analytics,
+  no advertising, and no third-party tracking pixels. External
+  passive assets are limited to FlagCDN; see `policy.html` for the
+  full list.
+
+Thank you for helping keep EISS safe.


### PR DESCRIPTION
## Summary

First of the three-to-four NetSec convention imports. **Pure docs, no site behaviour changes.** Adapts NetSec's `CLAUDE.md` operator playbook + `SECURITY.md` policy for EISS context, and expands the `CHANGELOG.md` preamble with the full release-notes format spec.

## Files

| File | Status | Notes |
|---|---|---|
| `CLAUDE.md` | **new** (~270 lines) | Read by Claude Code on every session. 11 numbered rule sections. |
| `SECURITY.md` | rewrite (4 lines → ~110) | Was a stub. Now a proper policy with scope, channels, SLAs, safe harbour. |
| `CHANGELOG.md` | preamble expanded | Adds the hybrid-format shape spec + 6 rules. |

## CLAUDE.md rule sections (the eleven)

1. Language & translation (British English, no MT)
2. PR workflow (auto-merge default, **visual-change carve-out**, squash)
3. **Open a GitHub issue for every deferred item** (informal template, milestone at creation)
4. Release-notes hybrid format (lede + themes + index, no hard wraps)
5. Release-time **four-point cross-check** (roadmap, sitemap, translations, repo docs + the milestone hygiene gate)
6. Voice for public copy (no "source of truth", show-don't-tell)
7. **Prose voice: no em dashes, no rule-of-three rhythm, no synonym cycling** — the AI-tell hardening rules
8. Working-tree hygiene
9. A11y + i18n cadence
10. Milestone tagging (every issue lands in one of EISS's five thematic milestones)
11. Documentation currency

## Notable adaptations from NetSec

NetSec's `CLAUDE.md` is the source. Where the two repos diverge, EISS-specific rules:

- **Thematic milestones** (NetSec & shared infra, Indico integration deepening, ESSC 2026 ops, i18n native-speaker review, Maintenance & reliability) rather than NetSec's version-named milestones (`v1.7.0`, etc.). Every issue still carries one, just the naming convention is different.
- **`master` branch** rather than `main`
- **No Wiki, no stakeholder PDF** — so the §5 cross-check has 4 points instead of 6
- **`sync-board` + `sync-indico` data pipelines** rather than NetSec's `sync-cost` + `sync-bios`
- Cross-references real EISS PR history: #154/#155/#156 as the canonical visual-PR-needs-preview-review example; #157 as the canonical deferred-issue example

## Test plan

- [ ] **Read `CLAUDE.md` cover to cover** — every rule should reflect how the repo actually works today. Flag anything you disagree with before merge; this is the constitution.
- [ ] **Read the new `SECURITY.md`** — the scope table, the SLAs, the safe-harbour text. Adjust anything that doesn't match your expectations for how a vuln report would be handled.
- [ ] **Skim the new CHANGELOG preamble rules** — particularly the "no hard wraps in prose" rule, which is critical for GitHub Releases rendering but not currently codified anywhere.
- [ ] (Bonus) Spot-check that I haven't slipped any em dashes into the new prose; the prose-voice rule in §7 applies to this PR itself.

## Coming next

- **Import PR 2**: `scripts/sync-roadmap.py` + workflow (roadmap autostamp pattern). Wires the AUTOSTAMP block into `docs/roadmap-2026.md`.
- **Import PR 3**: `scripts/check-links.sh` + workflow. Per-PR link check + weekly cron against `master`.
- **Optional Import PR 4**: `scripts/check-css-class-collisions.py` if you want it.

After Import PR 2 lands I'll come back and update `CLAUDE.md` §11's "planned" note to reflect that the autostamp is now wired in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)