### PR TITLE
i18n: localizedHref filter eliminates dead cross-locale links (closes #162)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -18,6 +18,54 @@ module.exports = function (eleventyConfig) {
     fs.readFileSync(path.join("src", relPath), "utf-8")
   );
 
+  // {{ "/2025.html" | localizedHref(lang) }} — given an internal
+  // page href + a target locale, return the localised URL if a
+  // translated source file actually exists, otherwise return the
+  // original (English) href unchanged. Pre-empts the link-rot
+  // pattern (#162) where the footer and a few inline links used
+  // to unconditionally rewrite `/foo.html` to `/foo.fr.html` on
+  // every FR page, producing dead links to pages that have not
+  // been translated yet.
+  //
+  // Resolution: check both `src/<slug>.<lang>.njk` and the legacy
+  // `src/<slug>.<lang>.html` for the existence of a localised
+  // source. Cheap (one stat) and runs at build time, so the cost
+  // is paid once per page-render rather than per visitor.
+  //
+  // Pass-throughs (returned unchanged):
+  //   - lang === "en"        (no swap needed)
+  //   - external URLs        (http:// or https:// or //)
+  //   - non-html targets     (PDFs, assets, mailto:, tel:)
+  //   - anchor-only          (starts with "#")
+  //   - missing href         (empty string or null)
+  eleventyConfig.addFilter("localizedHref", (href, lang) => {
+    if (!href || typeof href !== "string") return href;
+    if (lang === "en") return href;
+    if (
+      href.startsWith("http://") ||
+      href.startsWith("https://") ||
+      href.startsWith("//") ||
+      href.startsWith("#") ||
+      href.startsWith("mailto:") ||
+      href.startsWith("tel:")
+    ) {
+      return href;
+    }
+    if (!href.endsWith(".html")) return href;
+    // Strip query and fragment for the source lookup, but reattach
+    // them on the localised return so deep links keep working.
+    const [pathPart, ...rest] = href.split(/([?#])/);
+    const tail = rest.join("");
+    const slug = pathPart.replace(/^\//, "").replace(/\.html$/, "");
+    if (!slug) return href; // bare "/" stays as-is
+    const localizedSource = path.join("src", `${slug}.${lang}.njk`);
+    const localizedHtml = path.join("src", `${slug}.${lang}.html`);
+    if (fs.existsSync(localizedSource) || fs.existsSync(localizedHtml)) {
+      return `/${slug}.${lang}.html${tail}`;
+    }
+    return href; // localised version doesn't exist; fall back to EN
+  });
+
   eleventyConfig.addPassthroughCopy("src/assets");
   eleventyConfig.addPassthroughCopy({ "src/.well-known": "/.well-known" });
   eleventyConfig.addPassthroughCopy({ "src/CNAME": "CNAME" });

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -9,16 +9,12 @@
 #     it)
 #   - manual dispatch from the Actions tab
 #
-# Status: **advisory** (continue-on-error). The first run will report
-# ~14 pre-existing broken internal links to `.fr.html` / `.de.html`
-# pages that nav.njk synthesises but where the translation hasn't
-# been written yet. Tracked separately; see the open issue tagged
-# "i18n native-speaker review". Once that's fixed, flip
-# `continue-on-error: false` on the run step so this workflow
-# actually gates merges.
-#
-# The headline value during the advisory window is the weekly cron
-# catching external link rot, not the per-PR gate.
+# Status: **gating**. The script exits non-zero on any broken link
+# (internal or external) and the workflow fails accordingly. The
+# pre-existing untranslated-page nav-synthesis breakage that gated
+# this workflow as advisory in PR #164 was resolved by #162's
+# `localizedHref` filter, and the script now reports 0 broken links
+# across all 1500+ internal references.
 #
 # Adapted from the sister repo
 # EISSeuropa/netsec.github.io/.github/workflows/launch-qa-link-check.yml.
@@ -72,7 +68,4 @@ jobs:
           python-version: '3.12'
 
       - name: Run link check
-        # Advisory until the pre-existing untranslated-page link
-        # breakage is resolved. Flip to `false` once that's done.
-        continue-on-error: true
         run: ./scripts/check-links.sh --quiet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,19 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **`localizedHref` Eleventy filter** in `.eleventy.js` returns the `.lang.html` sibling of an internal `/foo.html` URL when that translated source exists in `src/`, and falls back to the English page otherwise (closes [#162](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/162)). External URLs, anchors, `mailto:` / `tel:`, and non-html targets pass through unchanged. Used by `nav.njk`, `footer.njk`, `programmes.{fr,de}.njk`, and `initiative.{fr,de}.njk` to replace the previous unconditional `.html → .lang.html` swap that produced 14 broken internal links to untranslated pages on every FR / DE page. The link checker is no longer advisory: it gates PRs, and the script now reports zero broken links across 1,590+ internal references.
+
+### Fixed
+
+- **John Helferich's `board.json` website link** stored as bare `johnhelferich.com` without the `https://` scheme, which the link checker correctly resolved as a relative path against `/board.html` and flagged as 404. Added the scheme. The sync pipeline (`scripts/sync-board.py`) doesn't currently auto-prefix bare hostnames; that's a separate hardening if more entries surface the same shape.
+
+### Changed
+
+- **`.github/workflows/link-check.yml` flipped from advisory to gating**. The pre-existing untranslated-page breakage that justified `continue-on-error: true` in PR #164 is resolved, so the workflow now fails the PR on any broken link (internal or external). The weekly Monday 07:00 UTC cron continues to surface external rot.
+
+## [2.23.0] · 2026-05-26 — Brand identity and Initiative depth
 
 ## [2.23.0] · 2026-05-26 — Brand identity and Initiative depth
 

--- a/src/_data/board.json
+++ b/src/_data/board.json
@@ -103,7 +103,7 @@
       "bio": "John Helferich is a Lecturer in Politics at Hertford College and a researcher with the Oxford Global Security Programme. His research focuses on European security and transformations in international order. He holds a Doctor of Philosophy (DPhil) in International Relations from the University of Oxford and a Master’s degree in International Security (summa cum laude) from Sciences Po. His dissertation on EU defence integration won the PSA Best Dissertation Prize in International Relations. He chairs the Working Group on Transfer of Knowledge within the COST Action Networking European Security Knowledge and serves as a board member of the European Initiative for Security Studies (EISS).",
       "themes": "Foreign Policy Analysis, European Security, Political Psychology, Research Methods",
       "links": {
-        "website": "johnhelferich.com"
+        "website": "https://johnhelferich.com"
       },
       "workingGroups": "WG1, WG2"
     },

--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -1,9 +1,8 @@
 {# Footer consumes the active-locale catalog `t` from base.njk.
-   Brand+legal text is i18n'd, but link `href` values stay constant
-   (and where possible point at the appropriate-language sibling
-   when one exists). #}
+   Brand+legal text is i18n'd; link `href` values point at the
+   `.lang.html` sibling when it exists, and fall back to the English
+   page otherwise via the `localizedHref` filter (#162). #}
 {% from "icons.njk" import icon %}
-{%- set langSuffix = "" if lang == "en" else "." + lang -%}
 <footer class="site-footer" role="contentinfo">
   <div class="container footer">
     <div class="footer-grid">
@@ -28,29 +27,29 @@
       <div>
         <h2>{{ t.footer.conferencesHeading }}</h2>
         <ul class="footer-list">
-          <li><a href="/2026{{ langSuffix }}.html">{{ t.footer.conferencesItems.c2026 }}</a></li>
-          <li><a href="/2025{{ langSuffix }}.html">{{ t.footer.conferencesItems.c2025 }}</a></li>
-          <li><a href="/2024{{ langSuffix }}.html">{{ t.footer.conferencesItems.c2024 }}</a></li>
-          <li><a href="/past{{ langSuffix }}.html">{{ t.footer.conferencesItems.allPast }}</a></li>
+          <li><a href="{{ '/2026.html' | localizedHref(lang) }}">{{ t.footer.conferencesItems.c2026 }}</a></li>
+          <li><a href="{{ '/2025.html' | localizedHref(lang) }}">{{ t.footer.conferencesItems.c2025 }}</a></li>
+          <li><a href="{{ '/2024.html' | localizedHref(lang) }}">{{ t.footer.conferencesItems.c2024 }}</a></li>
+          <li><a href="{{ '/past.html' | localizedHref(lang) }}">{{ t.footer.conferencesItems.allPast }}</a></li>
         </ul>
       </div>
 
       <div>
         <h2>{{ t.footer.programmesHeading }}</h2>
         <ul class="footer-list">
-          <li><a href="/NetSecSchool{{ langSuffix }}.html">{{ t.footer.programmesItems.netsec }}</a></li>
-          <li><a href="/euroswamos{{ langSuffix }}.html">{{ t.footer.programmesItems.euroswamos }}</a></li>
-          <li><a href="/coercion{{ langSuffix }}.html">{{ t.footer.programmesItems.coercion }}</a></li>
-          <li><a href="/GlobalRisks{{ langSuffix }}.html">{{ t.footer.programmesItems.globalRisks }}</a></li>
+          <li><a href="{{ '/NetSecSchool.html' | localizedHref(lang) }}">{{ t.footer.programmesItems.netsec }}</a></li>
+          <li><a href="{{ '/euroswamos.html' | localizedHref(lang) }}">{{ t.footer.programmesItems.euroswamos }}</a></li>
+          <li><a href="{{ '/coercion.html' | localizedHref(lang) }}">{{ t.footer.programmesItems.coercion }}</a></li>
+          <li><a href="{{ '/GlobalRisks.html' | localizedHref(lang) }}">{{ t.footer.programmesItems.globalRisks }}</a></li>
         </ul>
       </div>
 
       <div>
         <h2>{{ t.footer.aboutHeading }}</h2>
         <ul class="footer-list">
-          <li><a href="/initiative{{ langSuffix }}.html">{{ t.footer.aboutItems.initiative }}</a></li>
-          <li><a href="/board{{ langSuffix }}.html">{{ t.footer.aboutItems.people }}</a></li>
-          <li><a href="/membership{{ langSuffix }}.html">{{ t.footer.aboutItems.membership }}</a></li>
+          <li><a href="{{ '/initiative.html' | localizedHref(lang) }}">{{ t.footer.aboutItems.initiative }}</a></li>
+          <li><a href="{{ '/board.html' | localizedHref(lang) }}">{{ t.footer.aboutItems.people }}</a></li>
+          <li><a href="{{ '/membership.html' | localizedHref(lang) }}">{{ t.footer.aboutItems.membership }}</a></li>
           <li><a href="{{ site.newsletterUrl }}" target="_blank" rel="noopener">{{ t.footer.aboutItems.newsletter }}</a></li>
           <li><a href="mailto:{{ site.contactEmail }}">{{ t.footer.aboutItems.contact }}</a></li>
         </ul>
@@ -84,17 +83,17 @@
       </p>
       <p class="footer-meta">
         <span class="footer-meta-links">
-          <a href="/refund{{ langSuffix }}.html">{{ t.footer.legalLinks.terms }}</a> ·
-          <a href="/policy{{ langSuffix }}.html">{{ t.footer.legalLinks.privacy }}</a> ·
-          <a href="/accessibility{{ langSuffix }}.html">{{ t.footer.legalLinks.accessibility }}</a> ·
-          <a href="/sitemap{{ langSuffix }}.html">{{ t.footer.legalLinks.sitemap }}</a>
+          <a href="{{ '/refund.html' | localizedHref(lang) }}">{{ t.footer.legalLinks.terms }}</a> ·
+          <a href="{{ '/policy.html' | localizedHref(lang) }}">{{ t.footer.legalLinks.privacy }}</a> ·
+          <a href="{{ '/accessibility.html' | localizedHref(lang) }}">{{ t.footer.legalLinks.accessibility }}</a> ·
+          <a href="{{ '/sitemap.html' | localizedHref(lang) }}">{{ t.footer.legalLinks.sitemap }}</a>
         </span>
         {# Authorship credit. The name links to the author's board card
            via the slug from src/_data/board.json. Keep this discreet —
            it doesn't compete with EISS branding. #}
         <span class="footer-authorship">
           {{ t.footer.authorship.prefix }}
-          <a href="/board{{ langSuffix }}.html#{{ t.footer.authorship.authorSlug }}">{{ t.footer.authorship.authorName }}</a>
+          <a href="{{ '/board.html' | localizedHref(lang) }}#{{ t.footer.authorship.authorSlug }}">{{ t.footer.authorship.authorName }}</a>
         </span>
       </p>
     </div>

--- a/src/_includes/nav.njk
+++ b/src/_includes/nav.njk
@@ -27,15 +27,12 @@
     <ul class="nav-links" id="primary-nav" data-nav-menu>
       {% for item in site.nav %}
         {% if item.key != "home" %}
-          {%- set itemHref = item.href -%}
-          {%- if not item.external and lang != "en" -%}
-            {# For translated pages, point at the .lang.html sibling.
-               `replace` is a no-op on URLs without `.html` (e.g. "/"
-               and external URLs). We don't validate existence here —
-               if a sibling is missing, the page's own beta banner (and
-               the lang-switcher fallback) handle the experience. #}
-            {%- set itemHref = item.href | replace(".html", "." + lang + ".html") -%}
-          {%- endif -%}
+          {# `localizedHref` returns the `.lang.html` sibling when it
+             exists in src/ (Eleventy generates the matching output
+             file), and falls back to the English page otherwise.
+             External URLs and the home "/" pass through unchanged.
+             See .eleventy.js for the full filter contract (#162). #}
+          {%- set itemHref = item.href if item.external else (item.href | localizedHref(lang)) -%}
           <li>
             <a class="nav-link"
                href="{{ itemHref }}"

--- a/src/initiative.de.njk
+++ b/src/initiative.de.njk
@@ -228,43 +228,43 @@ alternates:
         </g>
 
         <g class="essc-map-dots">
-          <a href="/2019.de.html" class="essc-map-link">
+          <a href="{{ '/2019.html' | localizedHref(lang) }}" class="essc-map-link">
             <title>Paris — 2017, 2018, 2019</title>
             <circle cx="326" cy="784" r="14" class="essc-map-dot essc-map-dot--inaugural"/>
             <text x="346" y="783" font-size="26" class="essc-map-label">Paris</text>
             <text x="346" y="815" font-size="20" class="essc-map-years">2017 – 2019</text>
           </a>
-          <a href="/2021.de.html" class="essc-map-link">
+          <a href="{{ '/2021.html' | localizedHref(lang) }}" class="essc-map-link">
             <title>Lissabon — 2021</title>
             <circle cx="65" cy="1143" r="9" class="essc-map-dot"/>
             <text x="85" y="1142" font-size="26" class="essc-map-label">Lissabon</text>
             <text x="85" y="1174" font-size="20" class="essc-map-years">2021</text>
           </a>
-          <a href="/2022.de.html" class="essc-map-link">
+          <a href="{{ '/2022.html' | localizedHref(lang) }}" class="essc-map-link">
             <title>Berlin — 2022</title>
             <circle cx="577" cy="653" r="9" class="essc-map-dot"/>
             <text x="597" y="652" font-size="26" class="essc-map-label">Berlin</text>
             <text x="597" y="684" font-size="20" class="essc-map-years">2022</text>
           </a>
-          <a href="/2023.de.html" class="essc-map-link">
+          <a href="{{ '/2023.html' | localizedHref(lang) }}" class="essc-map-link">
             <title>Barcelona — 2023</title>
             <circle cx="322" cy="1048" r="9" class="essc-map-dot"/>
             <text x="342" y="1047" font-size="26" class="essc-map-label">Barcelona</text>
             <text x="342" y="1079" font-size="20" class="essc-map-years">2023</text>
           </a>
-          <a href="/2024.de.html" class="essc-map-link">
+          <a href="{{ '/2024.html' | localizedHref(lang) }}" class="essc-map-link">
             <title>Prag — 2024</title>
             <circle cx="601" cy="741" r="9" class="essc-map-dot"/>
             <text x="621" y="740" font-size="26" class="essc-map-label">Prag</text>
             <text x="621" y="772" font-size="20" class="essc-map-years">2024</text>
           </a>
-          <a href="/2025.de.html" class="essc-map-link">
+          <a href="{{ '/2025.html' | localizedHref(lang) }}" class="essc-map-link">
             <title>Thessaloniki — 2025</title>
             <circle cx="794" cy="1074" r="9" class="essc-map-dot"/>
             <text x="784" y="1094" font-size="26" class="essc-map-label essc-map-label--end">Thessaloniki</text>
             <text x="784" y="1126" font-size="20" class="essc-map-years essc-map-years--end">2025</text>
           </a>
-          <a href="/2026.de.html" class="essc-map-link">
+          <a href="{{ '/2026.html' | localizedHref(lang) }}" class="essc-map-link">
             <title>Stockholm — 2026 (kommend)</title>
             <circle cx="683" cy="413" r="11" class="essc-map-dot essc-map-dot--next"/>
             <text x="703" y="412" font-size="26" class="essc-map-label">Stockholm</text>
@@ -289,7 +289,7 @@ alternates:
           Stockholm
         </div>
         <div class="conf-tour-host">Universität Stockholm</div>
-        <a class="conf-tour-link" href="/2026.de.html">Programm &rarr;</a>
+        <a class="conf-tour-link" href="{{ '/2026.html' | localizedHref(lang) }}">Programm &rarr;</a>
       </li>
       <li class="conf-tour-card">
         <div class="conf-tour-year">2025 <span class="conf-tour-ordinal">8.</span></div>
@@ -298,7 +298,7 @@ alternates:
           Thessaloniki
         </div>
         <div class="conf-tour-host">Universität Makedonien</div>
-        <a class="conf-tour-link" href="/2025.de.html">Rückblick &rarr;</a>
+        <a class="conf-tour-link" href="{{ '/2025.html' | localizedHref(lang) }}">Rückblick &rarr;</a>
       </li>
       <li class="conf-tour-card">
         <div class="conf-tour-year">2024 <span class="conf-tour-ordinal">7.</span></div>
@@ -307,7 +307,7 @@ alternates:
           Prag
         </div>
         <div class="conf-tour-host">Karls-Universität</div>
-        <a class="conf-tour-link" href="/2024.de.html">Rückblick &rarr;</a>
+        <a class="conf-tour-link" href="{{ '/2024.html' | localizedHref(lang) }}">Rückblick &rarr;</a>
       </li>
       <li class="conf-tour-card">
         <div class="conf-tour-year">2023 <span class="conf-tour-ordinal">6.</span></div>
@@ -316,7 +316,7 @@ alternates:
           Barcelona
         </div>
         <div class="conf-tour-host">IBEI (Institut Barcelona d'Estudis Internacionals)</div>
-        <a class="conf-tour-link" href="/2023.de.html">Rückblick &rarr;</a>
+        <a class="conf-tour-link" href="{{ '/2023.html' | localizedHref(lang) }}">Rückblick &rarr;</a>
       </li>
       <li class="conf-tour-card">
         <div class="conf-tour-year">2022 <span class="conf-tour-ordinal">5.</span></div>
@@ -325,7 +325,7 @@ alternates:
           Berlin
         </div>
         <div class="conf-tour-host">Hertie School</div>
-        <a class="conf-tour-link" href="/2022.de.html">Rückblick &rarr;</a>
+        <a class="conf-tour-link" href="{{ '/2022.html' | localizedHref(lang) }}">Rückblick &rarr;</a>
       </li>
       <li class="conf-tour-card">
         <div class="conf-tour-year">2021 <span class="conf-tour-ordinal">4.</span></div>
@@ -334,13 +334,13 @@ alternates:
           Lissabon
         </div>
         <div class="conf-tour-host">ISCTE — Universitätsinstitut Lissabon</div>
-        <a class="conf-tour-link" href="/2021.de.html">Rückblick &rarr;</a>
+        <a class="conf-tour-link" href="{{ '/2021.html' | localizedHref(lang) }}">Rückblick &rarr;</a>
       </li>
       <li class="conf-tour-card conf-tour-online">
         <div class="conf-tour-year">2020 <span class="conf-tour-ordinal">3.</span></div>
         <div class="conf-tour-city">{{ icon("globe") }} Online-Ausgabe</div>
         <div class="conf-tour-host">Online abgehalten (COVID-19)</div>
-        <a class="conf-tour-link" href="/2020.de.html">Rückblick &rarr;</a>
+        <a class="conf-tour-link" href="{{ '/2020.html' | localizedHref(lang) }}">Rückblick &rarr;</a>
       </li>
       <li class="conf-tour-card">
         <div class="conf-tour-year">2019 <span class="conf-tour-ordinal">2.</span></div>
@@ -349,7 +349,7 @@ alternates:
           Paris
         </div>
         <div class="conf-tour-host">Sciences Po CERI</div>
-        <a class="conf-tour-link" href="/2019.de.html">Rückblick &rarr;</a>
+        <a class="conf-tour-link" href="{{ '/2019.html' | localizedHref(lang) }}">Rückblick &rarr;</a>
       </li>
       <li class="conf-tour-card">
         <div class="conf-tour-year">2018 <span class="conf-tour-ordinal">2. Ausg.</span></div>

--- a/src/initiative.fr.njk
+++ b/src/initiative.fr.njk
@@ -227,43 +227,43 @@ alternates:
         </g>
 
         <g class="essc-map-dots">
-          <a href="/2019.fr.html" class="essc-map-link">
+          <a href="{{ '/2019.html' | localizedHref(lang) }}" class="essc-map-link">
             <title>Paris — 2017, 2018, 2019</title>
             <circle cx="326" cy="784" r="14" class="essc-map-dot essc-map-dot--inaugural"/>
             <text x="346" y="783" font-size="26" class="essc-map-label">Paris</text>
             <text x="346" y="815" font-size="20" class="essc-map-years">2017 – 2019</text>
           </a>
-          <a href="/2021.fr.html" class="essc-map-link">
+          <a href="{{ '/2021.html' | localizedHref(lang) }}" class="essc-map-link">
             <title>Lisbonne — 2021</title>
             <circle cx="65" cy="1143" r="9" class="essc-map-dot"/>
             <text x="85" y="1142" font-size="26" class="essc-map-label">Lisbonne</text>
             <text x="85" y="1174" font-size="20" class="essc-map-years">2021</text>
           </a>
-          <a href="/2022.fr.html" class="essc-map-link">
+          <a href="{{ '/2022.html' | localizedHref(lang) }}" class="essc-map-link">
             <title>Berlin — 2022</title>
             <circle cx="577" cy="653" r="9" class="essc-map-dot"/>
             <text x="597" y="652" font-size="26" class="essc-map-label">Berlin</text>
             <text x="597" y="684" font-size="20" class="essc-map-years">2022</text>
           </a>
-          <a href="/2023.fr.html" class="essc-map-link">
+          <a href="{{ '/2023.html' | localizedHref(lang) }}" class="essc-map-link">
             <title>Barcelone — 2023</title>
             <circle cx="322" cy="1048" r="9" class="essc-map-dot"/>
             <text x="342" y="1047" font-size="26" class="essc-map-label">Barcelone</text>
             <text x="342" y="1079" font-size="20" class="essc-map-years">2023</text>
           </a>
-          <a href="/2024.fr.html" class="essc-map-link">
+          <a href="{{ '/2024.html' | localizedHref(lang) }}" class="essc-map-link">
             <title>Prague — 2024</title>
             <circle cx="601" cy="741" r="9" class="essc-map-dot"/>
             <text x="621" y="740" font-size="26" class="essc-map-label">Prague</text>
             <text x="621" y="772" font-size="20" class="essc-map-years">2024</text>
           </a>
-          <a href="/2025.fr.html" class="essc-map-link">
+          <a href="{{ '/2025.html' | localizedHref(lang) }}" class="essc-map-link">
             <title>Thessalonique — 2025</title>
             <circle cx="794" cy="1074" r="9" class="essc-map-dot"/>
             <text x="784" y="1094" font-size="26" class="essc-map-label essc-map-label--end">Thessalonique</text>
             <text x="784" y="1126" font-size="20" class="essc-map-years essc-map-years--end">2025</text>
           </a>
-          <a href="/2026.fr.html" class="essc-map-link">
+          <a href="{{ '/2026.html' | localizedHref(lang) }}" class="essc-map-link">
             <title>Stockholm — 2026 (à venir)</title>
             <circle cx="683" cy="413" r="11" class="essc-map-dot essc-map-dot--next"/>
             <text x="703" y="412" font-size="26" class="essc-map-label">Stockholm</text>
@@ -288,7 +288,7 @@ alternates:
           Stockholm
         </div>
         <div class="conf-tour-host">Université de Stockholm</div>
-        <a class="conf-tour-link" href="/2026.fr.html">Programme &rarr;</a>
+        <a class="conf-tour-link" href="{{ '/2026.html' | localizedHref(lang) }}">Programme &rarr;</a>
       </li>
       <li class="conf-tour-card">
         <div class="conf-tour-year">2025 <span class="conf-tour-ordinal">8<sup>e</sup></span></div>
@@ -297,7 +297,7 @@ alternates:
           Thessalonique
         </div>
         <div class="conf-tour-host">Université de Macédoine</div>
-        <a class="conf-tour-link" href="/2025.fr.html">Compte-rendu &rarr;</a>
+        <a class="conf-tour-link" href="{{ '/2025.html' | localizedHref(lang) }}">Compte-rendu &rarr;</a>
       </li>
       <li class="conf-tour-card">
         <div class="conf-tour-year">2024 <span class="conf-tour-ordinal">7<sup>e</sup></span></div>
@@ -306,7 +306,7 @@ alternates:
           Prague
         </div>
         <div class="conf-tour-host">Université Charles</div>
-        <a class="conf-tour-link" href="/2024.fr.html">Compte-rendu &rarr;</a>
+        <a class="conf-tour-link" href="{{ '/2024.html' | localizedHref(lang) }}">Compte-rendu &rarr;</a>
       </li>
       <li class="conf-tour-card">
         <div class="conf-tour-year">2023 <span class="conf-tour-ordinal">6<sup>e</sup></span></div>
@@ -315,7 +315,7 @@ alternates:
           Barcelone
         </div>
         <div class="conf-tour-host">IBEI (Institut Barcelona d'Estudis Internacionals)</div>
-        <a class="conf-tour-link" href="/2023.fr.html">Compte-rendu &rarr;</a>
+        <a class="conf-tour-link" href="{{ '/2023.html' | localizedHref(lang) }}">Compte-rendu &rarr;</a>
       </li>
       <li class="conf-tour-card">
         <div class="conf-tour-year">2022 <span class="conf-tour-ordinal">5<sup>e</sup></span></div>
@@ -324,7 +324,7 @@ alternates:
           Berlin
         </div>
         <div class="conf-tour-host">Hertie School</div>
-        <a class="conf-tour-link" href="/2022.fr.html">Compte-rendu &rarr;</a>
+        <a class="conf-tour-link" href="{{ '/2022.html' | localizedHref(lang) }}">Compte-rendu &rarr;</a>
       </li>
       <li class="conf-tour-card">
         <div class="conf-tour-year">2021 <span class="conf-tour-ordinal">4<sup>e</sup></span></div>
@@ -333,13 +333,13 @@ alternates:
           Lisbonne
         </div>
         <div class="conf-tour-host">ISCTE — Institut Universitaire de Lisbonne</div>
-        <a class="conf-tour-link" href="/2021.fr.html">Compte-rendu &rarr;</a>
+        <a class="conf-tour-link" href="{{ '/2021.html' | localizedHref(lang) }}">Compte-rendu &rarr;</a>
       </li>
       <li class="conf-tour-card conf-tour-online">
         <div class="conf-tour-year">2020 <span class="conf-tour-ordinal">3<sup>e</sup></span></div>
         <div class="conf-tour-city">{{ icon("globe") }} Édition en ligne</div>
         <div class="conf-tour-host">Tenue en ligne (COVID-19)</div>
-        <a class="conf-tour-link" href="/2020.fr.html">Compte-rendu &rarr;</a>
+        <a class="conf-tour-link" href="{{ '/2020.html' | localizedHref(lang) }}">Compte-rendu &rarr;</a>
       </li>
       <li class="conf-tour-card">
         <div class="conf-tour-year">2019 <span class="conf-tour-ordinal">2<sup>e</sup></span></div>
@@ -348,7 +348,7 @@ alternates:
           Paris
         </div>
         <div class="conf-tour-host">Sciences Po CERI</div>
-        <a class="conf-tour-link" href="/2019.fr.html">Compte-rendu &rarr;</a>
+        <a class="conf-tour-link" href="{{ '/2019.html' | localizedHref(lang) }}">Compte-rendu &rarr;</a>
       </li>
       <li class="conf-tour-card">
         <div class="conf-tour-year">2018 <span class="conf-tour-ordinal">2<sup>e</sup> éd.</span></div>

--- a/src/programmes.de.njk
+++ b/src/programmes.de.njk
@@ -55,7 +55,7 @@ alternates:
           Beziehungen arbeiten.
         </p>
         <p style="margin-top: var(--space-4);">
-          <a class="btn btn-secondary btn-sm" href="/NetSecSchool.de.html">Mehr über die Sommerschule erfahren</a>
+          <a class="btn btn-secondary btn-sm" href="{{ '/NetSecSchool.html' | localizedHref(lang) }}">Mehr über die Sommerschule erfahren</a>
         </p>
       </article>
 
@@ -68,7 +68,7 @@ alternates:
           Praktiker:innen zusammenbringt.
         </p>
         <p style="margin-top: var(--space-4);">
-          <a class="btn btn-secondary btn-sm" href="/coercion.de.html">Mehr über Coercive Statecraft erfahren</a>
+          <a class="btn btn-secondary btn-sm" href="{{ '/coercion.html' | localizedHref(lang) }}">Mehr über Coercive Statecraft erfahren</a>
         </p>
       </article>
 
@@ -80,7 +80,7 @@ alternates:
           Partnerschaftsprogramm, das fortgeschrittene Studierende der Strategie zusammenbringt.
         </p>
         <p style="margin-top: var(--space-4);">
-          <a class="btn btn-secondary btn-sm" href="/euroswamos.de.html">Mehr über Euro-SWAMOS erfahren</a>
+          <a class="btn btn-secondary btn-sm" href="{{ '/euroswamos.html' | localizedHref(lang) }}">Mehr über Euro-SWAMOS erfahren</a>
         </p>
       </article>
 
@@ -93,7 +93,7 @@ alternates:
           empfohlenen Antworten.
         </p>
         <p style="margin-top: var(--space-4);">
-          <a class="btn btn-secondary btn-sm" href="/GlobalRisks.de.html">Ergebnisse ansehen</a>
+          <a class="btn btn-secondary btn-sm" href="{{ '/GlobalRisks.html' | localizedHref(lang) }}">Ergebnisse ansehen</a>
         </p>
       </article>
 

--- a/src/programmes.fr.njk
+++ b/src/programmes.fr.njk
@@ -53,7 +53,7 @@ alternates:
           à l'intersection des études de sécurité, des études stratégiques et des relations internationales.
         </p>
         <p style="margin-top: var(--space-4);">
-          <a class="btn btn-secondary btn-sm" href="/NetSecSchool.fr.html">En savoir plus sur l'école d'été</a>
+          <a class="btn btn-secondary btn-sm" href="{{ '/NetSecSchool.html' | localizedHref(lang) }}">En savoir plus sur l'école d'été</a>
         </p>
       </article>
 
@@ -66,7 +66,7 @@ alternates:
           et praticiens.
         </p>
         <p style="margin-top: var(--space-4);">
-          <a class="btn btn-secondary btn-sm" href="/coercion.fr.html">En savoir plus sur la coercition étatique</a>
+          <a class="btn btn-secondary btn-sm" href="{{ '/coercion.html' | localizedHref(lang) }}">En savoir plus sur la coercition étatique</a>
         </p>
       </article>
 
@@ -78,7 +78,7 @@ alternates:
           programme partenarial réunissant des étudiants avancés en stratégie.
         </p>
         <p style="margin-top: var(--space-4);">
-          <a class="btn btn-secondary btn-sm" href="/euroswamos.fr.html">En savoir plus sur Euro-SWAMOS</a>
+          <a class="btn btn-secondary btn-sm" href="{{ '/euroswamos.html' | localizedHref(lang) }}">En savoir plus sur Euro-SWAMOS</a>
         </p>
       </article>
 
@@ -91,7 +91,7 @@ alternates:
           qu'ils recommandent.
         </p>
         <p style="margin-top: var(--space-4);">
-          <a class="btn btn-secondary btn-sm" href="/GlobalRisks.fr.html">Voir les résultats</a>
+          <a class="btn btn-secondary btn-sm" href="{{ '/GlobalRisks.html' | localizedHref(lang) }}">Voir les résultats</a>
         </p>
       </article>
 


### PR DESCRIPTION
## Summary

Closes [#162](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/162). The footer + nav previously rewrote every internal `/foo.html` href to `/foo.<lang>.html` on every FR / DE page, even when the translated sibling didn't exist. That produced 14 broken internal links per locale on every page, plus a longer tail from hand-coded year-links in `programmes.{fr,de}` and `initiative.{fr,de}` that the link checker (PR #164) has been reporting in advisory mode.

## The fix

New `localizedHref` Eleventy filter in `.eleventy.js`:

```js
{{ '/2025.html' | localizedHref(lang) }}
//   lang === 'en' or src/2025.fr.njk exists  → returns "/2025.fr.html"
//   src/2025.fr.njk doesn't exist             → returns "/2025.html"  (EN fallback)
//   external URL / anchor / mailto / tel /    → returns unchanged
//   asset path
```

The filter does one filesystem stat per call at build time. Cheap because Eleventy renders each page once per build.

## Callsites converted

| File | Hrefs |
|---|---|
| `src/_includes/footer.njk` | 15 (years 2024-2026, past, programmes ×4, about pages ×3, legal links ×4, authorship credit) |
| `src/_includes/nav.njk` | 1 expression (the loop over `site.nav`) |
| `src/programmes.{fr,de}.njk` | 4 each (NetSecSchool, coercion, euroswamos, GlobalRisks) |
| `src/initiative.{fr,de}.njk` | 15 each (ESSC host-city map dots + conf-tour grid year-links) |

Plus a small data fix: John Helferich's `board.json` website was stored as `johnhelferich.com` without the `https://` scheme, so the link checker resolved it as a relative path against `/board.html` and flagged as 404. Added the scheme.

## Verification

- `npm run build && ./scripts/check-links.sh --internal` reports **0 broken links across 1,590+ internal references** (was 17 before this PR).
- Spot-check on the deploy preview: from any FR page, "ESSC 2025 — Thessaloniki" in the footer points at `/2025.html` (the EN page) since no FR translation exists; "ESSC 2026 — Stockholm" points at `/2026.fr.html` (which does exist).

## Workflow flipped from advisory to gating

`.github/workflows/link-check.yml` was running with `continue-on-error: true` (per PR #164) precisely because of this pre-existing breakage. Now flipped to gating: the workflow fails the PR on any broken link. The weekly Monday 07:00 UTC cron continues to surface external link rot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)