### PR TITLE
initiative: replace Meijer quote + shorten origins around EISS (EN/FR/DE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,10 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ## [Unreleased]
 
-_Nothing yet._
+### Changed
+
+- **`/initiative` Meijer pull-quote replaced** with the longer founder quote on European fragmentation in security studies (EN, FR, DE). Reads as a clearer statement of what EISS was set up to do: overcome the fragmentation of European security studies by federating and consolidating a Europe-wide field. The previous quote, "EISS aims to fill this gap by contributing to the formation of a European community of researchers in security studies", was the closing line of the same Meijer 2017 *Champs de Mars* piece; the new quote opens with the problem framing and lands on the solution. Citation link unchanged.
+- **`/initiative` origins section recentred on EISS rather than AEGES** (EN, FR, DE). The two paragraphs previously dwelled on AEGES history (Holeindre's 2015 founding, the CNRS Éditions + Armand Colin book series, the Prix Bastien Irondelle) before pivoting to EISS. Recast to keep AEGES as the founding context in one short sentence, then foreground what EISS has become independently: a Europe-wide network spanning N countries, N+ ESSC editions across the continent, founding member of the NetSec COST Action in 2025. AEGES is acknowledged as a sister organisation; EISS's centre of gravity is now European.
 
 ## [2.23.0] · 2026-05-26 — Brand identity and Initiative depth
 

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -18,13 +18,13 @@
     "src/initiative.njk": {
       "fr": {
         "file": "src/initiative.fr.njk",
-        "source_sha1": "447a821e4a499d63384468b228a5d9c70dab8ef3",
+        "source_sha1": "4879c256b81a38252db4430808d26ef95ff37106",
         "translated_on": "2026-05-26",
         "status": "beta"
       },
       "de": {
         "file": "src/initiative.de.njk",
-        "source_sha1": "447a821e4a499d63384468b228a5d9c70dab8ef3",
+        "source_sha1": "4879c256b81a38252db4430808d26ef95ff37106",
         "translated_on": "2026-05-26",
         "status": "beta"
       }

--- a/src/initiative.de.njk
+++ b/src/initiative.de.njk
@@ -122,8 +122,11 @@ alternates:
       <h2 id="founded-to-do-title" style="margin-top: 0;">Wofür EISS gegründet wurde</h2>
 
       <blockquote>
-        EISS will diese Lücke schließen, indem sie zur Bildung einer europäischen Gemeinschaft von
-        Forschenden im Bereich der Sicherheitsstudien beiträgt.
+        Vor der EISS war das Feld der Sicherheitsstudien in Europa fragmentiert, insofern es kein
+        europäisches Forum gab, das Wissenschaftler:innen zusammenführen und den Austausch zwischen
+        Forschenden und Universitätsangehörigen fördern konnte. Die EISS möchte diese Fragmentierung
+        überwinden, indem sie ein wahrhaft gesamteuropäisches Feld der Sicherheitsstudien föderiert und
+        konsolidiert.
         <footer style="margin-top: var(--space-2); font-style: normal; font-size: var(--fs-sm); color: var(--text-muted);">
           — Hugo Meijer, Gründer ·
           <cite><a href="https://shs.cairn.info/annuaire-francais-de-relations--9791090429956-page-95?lang=fr"
@@ -448,25 +451,25 @@ alternates:
     <div class="origin-layout">
       <article class="prose" style="max-width: none;">
         <p>
-          EISS wurde 2017 von Hugo Meijer als europäische Erweiterung der
-          <a href="https://aeges.fr/" target="_blank" rel="noopener">Association pour les Études sur la Guerre et la Stratégie (AEGES)</a>
-          gegründet — einer 2015 unter dem Vorsitz von Jean-Vincent Holeindre (Université de Poitiers)
-          ins Leben gerufenen französischen akademischen Vereinigung, die die nach langer
-          Marginalisierung geschwächten Sicherheitsstudien an französischen Universitäten neu aufbauen
-          sollte. Die AEGES verankert die französische Seite des Netzwerks über zwei Buchreihen — bei
-          <strong>CNRS Éditions</strong> und <strong>Armand Colin</strong> — eine geplante
-          englischsprachige Reihe sowie den seit 2017 jährlich vergebenen <strong>Prix Bastien
-          Irondelle</strong> für die beste Dissertation in den strategischen Studien.
+          Die EISS wurde 2017 von Hugo Meijer als europäische Erweiterung der französischen akademischen
+          Vereinigung
+          <a href="https://aeges.fr/" target="_blank" rel="noopener">AEGES</a>
+          gegründet, deren internationale Forschungspartnerschaften er leitete. Die Eröffnungskonferenz
+          an der Panthéon-Assas im Januar 2017 (siehe rechts) versammelte rund 100 Wissenschaftler:innen
+          aus 62 Universitäten in 15 europäischen Ländern.
         </p>
         <p>
-          Hugo Meijer leitete die internationalen Forschungspartnerschaften der AEGES und gründete EISS,
-          um das Projekt auf die europäische Ebene auszuweiten. Die Initiative wurde von Anfang an als
-          europaweites Netzwerk konzipiert — offen für alle theoretischen Ansätze, alle Disziplinen und
-          Forschende auf jeder Karrierestufe. 2025 schloss sich EISS elf weiteren Institutionen als
-          Gründungsmitglied der COST-Aktion
-          <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a> an — viele ihrer
-          führenden Köpfe stammen aus dem EISS-Netzwerk — und formalisierte damit die Rolle des Netzwerks
-          als eine der zentralen europäischen Plattformen der Sicherheitsstudien.
+          Was als außenorientierter Zweig einer nationalen Vereinigung begann, wurde schnell zu etwas
+          Größerem. Die EISS ist heute ein unabhängiges europaweites Netzwerk, dessen Vorstand und
+          Gemeinschaft {{ boardSorted.counts.countriesTotal }} Länder umfassen; sie ist offen für alle
+          theoretischen Ansätze und Disziplinen und nimmt Forschende auf jeder Karrierestufe auf.
+          {{ confCount }} Ausgaben der ESSC sind auf die Gründung von 2017 gefolgt und durch
+          unterschiedliche Gastländer auf dem ganzen Kontinent gewandert. 2025 schloss sich die EISS elf
+          weiteren Institutionen als Gründungsmitglied der COST-Aktion
+          <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a> an und
+          formalisierte damit die Rolle des Netzwerks als eine der zentralen europäischen Plattformen
+          der Sicherheitsstudien. Die AEGES bleibt eine Schwesterorganisation auf französischer Seite;
+          der Schwerpunkt der EISS liegt heute in Europa.
         </p>
       </article>
 

--- a/src/initiative.fr.njk
+++ b/src/initiative.fr.njk
@@ -122,8 +122,10 @@ alternates:
       <h2 id="founded-to-do-title" style="margin-top: 0;">Pourquoi EISS a été fondée</h2>
 
       <blockquote>
-        L'EISS vise à combler cette lacune en contribuant à la constitution d'une communauté européenne
-        de chercheurs dans le domaine des études de sécurité.
+        Avant l'EISS, le champ des études de sécurité en Europe était fragmenté, dans la mesure où il
+        n'existait aucun forum européen capable de réunir les chercheurs et de favoriser les échanges
+        entre chercheurs et universitaires. L'EISS vise à surmonter cette fragmentation en fédérant et
+        en consolidant un champ des études de sécurité véritablement paneuropéen.
         <footer style="margin-top: var(--space-2); font-style: normal; font-size: var(--fs-sm); color: var(--text-muted);">
           — Hugo Meijer, fondateur ·
           <cite><a href="https://shs.cairn.info/annuaire-francais-de-relations--9791090429956-page-95?lang=fr"
@@ -447,24 +449,25 @@ alternates:
     <div class="origin-layout">
       <article class="prose" style="max-width: none;">
         <p>
-          EISS a été fondée en 2017 par Hugo Meijer comme extension européenne de l'
-          <a href="https://aeges.fr/" target="_blank" rel="noopener">Association pour les Études sur la Guerre et la Stratégie (AEGES)</a>,
-          association universitaire française créée en 2015 sous la présidence de Jean-Vincent Holeindre
-          (Université de Poitiers) pour reconstruire les études de sécurité dans les universités françaises
-          après une longue marginalisation. L'AEGES ancre le versant français du réseau à travers deux
-          collections — chez <strong>CNRS Éditions</strong> et <strong>Armand Colin</strong> — une
-          collection anglophone en projet, et le <strong>Prix Bastien Irondelle</strong> de la meilleure
-          thèse en études stratégiques, décerné chaque année depuis 2017.
+          EISS a été fondée en 2017 par Hugo Meijer comme extension européenne de l'association
+          académique française
+          <a href="https://aeges.fr/" target="_blank" rel="noopener">AEGES</a>,
+          dont il dirigeait les partenariats de recherche internationaux. La conférence inaugurale à
+          Panthéon-Assas en janvier 2017 (voir à droite) a réuni une centaine de chercheurs venus de
+          62 universités dans 15 pays européens.
         </p>
         <p>
-          Hugo Meijer dirigeait les partenariats de recherche internationaux de l'AEGES et a fondé EISS
-          pour étendre le projet à l'échelle européenne. L'initiative a été conçue dès l'origine comme un
-          réseau paneuropéen — ouvert à toutes les approches théoriques, toutes les disciplines, et à
-          tous les profils de chercheurs. En 2025, EISS a rejoint onze autres institutions comme membre
-          fondateur de l'Action COST
-          <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a> — dont une grande
-          partie des responsables est issue du réseau EISS — formalisant le rôle du réseau comme l'un des
-          principaux lieux de convergence européens des études de sécurité.
+          Ce qui avait commencé comme un volet international d'une association nationale est rapidement
+          devenu autre chose. L'EISS est aujourd'hui un réseau paneuropéen indépendant, dont le bureau et
+          la communauté représentent {{ boardSorted.counts.countriesTotal }} pays ; il est ouvert à
+          l'ensemble des approches théoriques et disciplines, et accueille les chercheurs à toutes les
+          étapes de leur carrière. {{ confCount }} éditions de l'ESSC ont suivi la fondation de 2017, en
+          tournant à travers des pays hôtes sur tout le continent. En 2025 l'EISS a rejoint onze autres
+          institutions comme membre fondateur de l'Action COST
+          <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a>, formalisant le
+          rôle du réseau comme l'un des principaux lieux de convergence européens des études de sécurité.
+          L'AEGES demeure une organisation sœur du côté français ; le centre de gravité de l'EISS est
+          désormais européen.
         </p>
       </article>
 

--- a/src/initiative.njk
+++ b/src/initiative.njk
@@ -126,8 +126,10 @@ alternates:
       <h2 id="founded-to-do-title" style="margin-top: 0;">What EISS was founded to do</h2>
 
       <blockquote>
-        EISS aims to fill this gap by contributing to the formation of a European community of researchers
-        in security studies.
+        Prior to EISS, the field of security studies in Europe was fragmented, insofar as there was no
+        European forum capable of bringing together scholars and fostering exchanges among researchers
+        and academics. EISS aims to overcome this fragmentation by federating and consolidating a truly
+        Europe-wide field of security studies.
         <footer style="margin-top: var(--space-2); font-style: normal; font-size: var(--fs-sm); color: var(--text-muted);">
           — Hugo Meijer, founder ·
           <cite><a href="https://shs.cairn.info/annuaire-francais-de-relations--9791090429956-page-95?lang=fr"
@@ -458,23 +460,24 @@ alternates:
     <div class="origin-layout">
       <article class="prose" style="max-width: none;">
         <p>
-          EISS was founded in 2017 by Hugo Meijer as a European extension of the
-          <a href="https://aeges.fr/" target="_blank" rel="noopener">Association pour les Études sur la Guerre et la Stratégie (AEGES)</a>,
-          a French academic association created in 2015 under the presidency of Jean-Vincent Holeindre
-          (Univ. Poitiers) to rebuild security studies in French universities after long marginalisation.
-          AEGES anchors the French side of the network through two book series — at
-          <strong>CNRS Éditions</strong> and <strong>Armand Colin</strong> — a planned English-language
-          series, and the annual <strong>Prix Bastien Irondelle</strong> PhD thesis prize in strategic
-          studies, awarded since 2017.
+          EISS was founded in 2017 by Hugo Meijer as a European extension of the French academic
+          association
+          <a href="https://aeges.fr/" target="_blank" rel="noopener">AEGES</a>,
+          where he led international research partnerships. The inaugural conference at
+          Panthéon-Assas in January 2017 (see right) gathered around 100 scholars from 62
+          universities across 15 European countries.
         </p>
         <p>
-          Hugo Meijer led AEGES's international research partnerships and founded EISS to extend the
-          project to a European scale. The initiative was conceived from the outset as a Europe-wide
-          network — open to all theoretical approaches, all disciplines, and scholars at every career
-          stage. In 2025, EISS joined eleven other institutions as a founding member of the COST Action
-          <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a> — many of its
-          leadership figures came from the EISS network — formalising the network's role as one of
-          Europe's main convening bodies in security studies.
+          What began as an outward-facing chapter of a national association quickly became
+          something larger. EISS is now an independent Europe-wide network with a board and
+          community spanning {{ boardSorted.counts.countriesTotal }} countries; it is open across
+          theoretical approaches and disciplines, and welcomes scholars at every career stage.
+          {{ confCount }} editions of the ESSC have followed the 2017 founding, rotating through host
+          countries across the continent. In 2025 EISS joined eleven other institutions as a founding
+          member of the COST Action
+          <a href="https://netsec-cost.eu/" target="_blank" rel="noopener">NetSec</a>, formalising
+          the network's role as one of Europe's main convening bodies in security studies. AEGES
+          remains a sister organisation on the French side; EISS's centre of gravity is European.
         </p>
       </article>
 


### PR DESCRIPTION
## Summary

Two content edits to `/initiative` per maintainer request, applied across EN, FR, DE.

### 1. New Meijer pull-quote

Old:
> EISS aims to fill this gap by contributing to the formation of a European community of researchers in security studies.

New:
> Prior to EISS, the field of security studies in Europe was fragmented, insofar as there was no European forum capable of bringing together scholars and fostering exchanges among researchers and academics. EISS aims to overcome this fragmentation by federating and consolidating a truly Europe-wide field of security studies.

The new quote opens with the problem framing before landing on the solution. The previous quote was the closing line of the same 2017 *Champs de Mars* piece; the new one is the opening framing. Citation link unchanged.

### 2. Origins section recentred on EISS

The two paragraphs under *Les origines d'EISS* / *How EISS started* / *Wie EISS entstanden ist* used to dwell on AEGES history (Holeindre's 2015 founding, CNRS Éditions + Armand Colin book series, the Prix Bastien Irondelle PhD prize) before pivoting to EISS. Recast to:

- **One short sentence** acknowledging AEGES as the founding context (Meijer led their international research partnerships, EISS started as a European extension)
- **One short sentence** on the inaugural Panthéon-Assas conference (which is the kind of EISS-specific historical anchor worth keeping)
- **One paragraph** foregrounding what EISS has become independently: Europe-wide network spanning {{ boardSorted.counts.countriesTotal }} countries, {{ confCount }} ESSC editions across the continent, founding member of NetSec in 2025, AEGES now a sister organisation rather than a parent

Lines down from ~16 to ~10 per locale.

## Translations

FR is hand-translated (you're native FR; please tweak whatever doesn't read right). DE is hand-translated and ships with the existing `status: beta` ribbon flagging it for the native-speaker review milestone. The drift checker has been marked fresh for both.

## Test plan

- [ ] Read the new Meijer quote on `/initiative`, `/initiative.fr`, `/initiative.de` in browser
- [ ] Read the new origins section on all three locales; confirm AEGES is no longer the centre of gravity
- [ ] Confirm `confCount` and `boardSorted.counts.countriesTotal` substitute correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)