### PR TITLE
ops: break sync-roadmap self-feeding loop (closes the disruptive-runs surge)

### DIFF
--- a/.github/workflows/sync-roadmap.yml
+++ b/.github/workflows/sync-roadmap.yml
@@ -38,8 +38,17 @@ on:
   push:
     branches: [master]
     paths:
+      # Triggers only on the workflow's INPUTS, not its output. The
+      # autostamp lives in docs/roadmap-2026.md, so a previous version
+      # of this list included that file. That created a self-feeding
+      # loop: the auto-PR's merge would touch the roadmap, retrigger
+      # the workflow, possibly open another auto-PR if the count had
+      # moved meanwhile, and so on. With several content PRs landing
+      # close together the cycles overlapped and GitHub's anti-abuse
+      # heuristic flagged the runs as disruptive, blocking other
+      # workflow_dispatch calls for ~30 minutes. Listening to inputs
+      # only breaks the loop cleanly.
       - 'CHANGELOG.md'
-      - 'docs/roadmap-2026.md'
       - 'scripts/sync-roadmap.py'
       - '.github/workflows/sync-roadmap.yml'
   # Weekly belt-and-braces in case a push trigger ever misses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ## [Unreleased]
 
+### Fixed
+
+- **`sync-roadmap.yml` self-feeding loop broken**. The workflow used to fire when `docs/roadmap-2026.md` changed, which included the auto-PR's own merge commit (the auto-PR updates exactly that file). When several content PRs landed in quick succession the cycles overlapped, GitHub's anti-abuse heuristic flagged a couple of the runs as **disruptive**, and the workflow_dispatch endpoint started returning `Failed to queue workflow run` for ~30 minutes. The fix removes `docs/roadmap-2026.md` from the path trigger so the workflow listens only to its inputs (`CHANGELOG.md`, the script, the workflow file). Output-change retriggering is gone; the loop is impossible.
+
 ### Removed
 
 - **`scripts/extract_legacy.py` and `scripts/extract_prose.py` retired.** Two Mobirise-era utility scripts CodeQL had flagged as `py/bad-tag-filter` warnings for their `<script[^>]*>.*?</script>` / `<style[^>]*>.*?</style>` regex patterns (vulnerable to the classic split-tag bypass, e.g. `<script ><script>...</script ></script>`). Both scripts targeted `src/legacy/`, which was itself retired in v1.0; nothing else referenced them. `a11y_lint.py` stays as the useful survivor. Closes both open Code Scanning alerts at source rather than rewriting dead code. The roadmap's *Consolidate `scripts/`* P2 item is marked done. (Closes [code-scanning #1](https://github.com/EISSeuropa/EISSeuropa.github.io/security/code-scanning/1) + [#2](https://github.com/EISSeuropa/EISSeuropa.github.io/security/code-scanning/2).)


### PR DESCRIPTION
## Summary

This morning's rapid-fire PR merges triggered GitHub's anti-abuse heuristic. Symptoms you saw:

- "This workflow run has been marked as disruptive" on two recent sync-roadmap runs
- `gh workflow run deploy.yml` returning `Failed to queue workflow run. Please try again.`
- Deploys not firing on commits to master

Root cause: `sync-roadmap.yml` had `docs/roadmap-2026.md` in its path trigger. The autostamp PR it opens updates exactly that file. When that PR merged, the merge commit retriggered the workflow. If a content PR had merged in the meantime (bumping the `[Unreleased]` count), the second iteration would open ANOTHER auto-PR, and so on. With four PRs (#172 / #174 / #175 / #176) landing within ~25 minutes, the cycles overlapped enough for GitHub to flag the runs.

## The fix

Remove `docs/roadmap-2026.md` from the path trigger. The workflow now fires only on changes to its **inputs**:

```yaml
paths:
  - 'CHANGELOG.md'
  - 'scripts/sync-roadmap.py'
  - '.github/workflows/sync-roadmap.yml'
  # docs/roadmap-2026.md removed — output, not input
```

Cycle eliminated. The weekly Monday 06:00 UTC cron stays as the belt-and-braces backstop in case anyone hand-edits the roadmap and the AUTOSTAMP gets out of sync.

The inline comment in sync-roadmap.yml documents the diagnosis so the failure mode is recognisable next time.

## What this PR doesn't do

It doesn't UN-flag the existing disruptive runs or lift the current rate-limit on workflow_dispatch. That clears on GitHub's side in ~30 minutes. Once it does, `gh workflow run deploy.yml --ref master` (or the UI) will queue normally and the live site catches up to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)