### PR TITLE
ci: skip three bot-blocking hosts in check-links.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ### Fixed
 
+- **Link-checker skip list expanded with three bot-blocking hosts**. The first PR that ran the link checker after the brand rollout failed on three external links that GitHub Actions' anonymous HEAD/GET requests can't reach: `www.linkedin.com` (HTTP 999 to all bots, blanket block), `shs.cairn.info` (academic publisher, 403 to anonymous fetches), and `www.berlin-airport.de` (anti-bot UA filter, 403). All three URLs work for real visitors. Added them to the existing `SKIP_HOSTS` set in `scripts/check-links.sh`, alongside the two pre-existing entries (`docs.google.com`, `indico.eiss-europa.com`). The skip-list comment was expanded to distinguish the two reasons a host lands here: auth-gated services and anti-bot filters.
 - **`sync-roadmap.yml` self-feeding loop broken**. The workflow used to fire when `docs/roadmap-2026.md` changed, which included the auto-PR's own merge commit (the auto-PR updates exactly that file). When several content PRs landed in quick succession the cycles overlapped, GitHub's anti-abuse heuristic flagged a couple of the runs as **disruptive**, and the workflow_dispatch endpoint started returning `Failed to queue workflow run` for ~30 minutes. The fix removes `docs/roadmap-2026.md` from the path trigger so the workflow listens only to its inputs (`CHANGELOG.md`, the script, the workflow file). Output-change retriggering is gone; the loop is impossible.
 
 ### Removed

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -76,15 +76,33 @@ GET_HOSTS = {
     "docs.google.com", "forms.google.com",
 }
 
-# Hosts we deliberately skip (auth-gated, internal-only):
+# Hosts we deliberately skip. Two categories collapse here. (a)
+# Auth-gated services that require login (the form/page works for
+# real visitors but returns 4xx to anonymous HEAD/GET). (b) Anti-bot
+# filters that block automated requests regardless of method, the
+# destination still works fine for human visitors.
 SKIP_HOSTS = {
-    "docs.google.com",          # Google Forms require user auth; the
+    "docs.google.com",          # Google Forms require user auth. The
                                 # form works for real visitors but
                                 # returns 401 to unauthenticated HEAD
                                 # /GET from this checker.
-    "indico.eiss-europa.com",   # Indico HEADs return 400; works for
+    "indico.eiss-europa.com",   # Indico HEADs return 400, works for
                                 # visitors. Real-URL health is
                                 # confirmed manually.
+    "www.linkedin.com",         # LinkedIn 999s every automated
+                                # request regardless of UA. Member
+                                # profile URLs (board cards) work for
+                                # any logged-out visitor with a
+                                # browser.
+    "shs.cairn.info",           # Cairn (academic publisher hosting
+                                # the Champs de Mars article in /
+                                # initiative) returns 403 to anonymous
+                                # HEAD/GET. Article reads fine in a
+                                # browser.
+    "www.berlin-airport.de",    # Anti-bot UA filter, returns 403 to
+                                # unrecognised User-Agent strings.
+                                # The transit-info page works for
+                                # visitors heading to ESSC 2022.
 }
 
 internal_links = {}  # (file, target) for de-dupe display


### PR DESCRIPTION
## Summary

The link checker on PR #179 failed on three external URLs that block automated requests:

| Host | Response | First seen on |
|---|---|---|
| `www.linkedin.com` | HTTP 999 | `board.de.html` (board card LinkedIn link) |
| `shs.cairn.info` | HTTP 403 | `initiative.de.html` (Champs de Mars citation) |
| `www.berlin-airport.de` | HTTP 403 | `practical.html` (ESSC 2022 transit info) |

All three URLs work for human visitors. The checker's anonymous HEAD / GET requests trip blanket anti-bot filters that the hosts apply regardless of User-Agent.

## Fix

Added all three to `scripts/check-links.sh`'s `SKIP_HOSTS` set, alongside the existing `docs.google.com` and `indico.eiss-europa.com` entries. Skip-list header comment expanded to distinguish auth-gated services (Google Forms, Indico) from anti-bot filters (LinkedIn, Cairn, Berlin Airport).

## Test plan

- [x] Local `./scripts/check-links.sh` no longer reports the three hosts as broken
- [ ] CI re-run on the next link-check fire shows zero external failures
- [ ] PR #179 unblocks once this lands and a re-check runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)