### PR TITLE
chrome: archive-page disclaimer ribbon (12 pages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ## [Unreleased]
 
+### Added
+
+- **Archive-page disclaimer ribbon** on past-conference and past-workshop pages. New `src/_includes/archive-ribbon.njk` renders above the nav whenever a page's frontmatter sets `status: archive`, mirroring the existing beta-translation ribbon pattern but in a quieter neutral grey rather than warning-yellow. Visitors landing on `/2019.html` through `/2025.html`, `/JPW2019.html`, `/JPW2022.html`, `/JPW23.html`, `/NDC.html`, and `/Ukraine.html` now see a one-line note: *"This page is part of our archive. It documents a past EISS event and may not be as complete or polished as current pages."* Sets expectations so the static-since-Mobirise pages don't read as broken or neglected against the polished current-conference and live-programme pages. The 2026 conference page, NetSec / Euro-SWAMOS / Coercive Statecraft / Global Risks programme pages stay unmarked, since they're current content. Ribbon text hardcoded EN for now (every archive page is currently EN-only); if any archive page gets translated, switch to a `t.archiveRibbon.*` i18n catalog lookup as the beta-ribbon partial does.
+
 ### Fixed
 
 - **Link-checker skip list expanded with three bot-blocking hosts**. The first PR that ran the link checker after the brand rollout failed on three external links that GitHub Actions' anonymous HEAD/GET requests can't reach: `www.linkedin.com` (HTTP 999 to all bots, blanket block), `shs.cairn.info` (academic publisher, 403 to anonymous fetches), and `www.berlin-airport.de` (anti-bot UA filter, 403). All three URLs work for real visitors. Added them to the existing `SKIP_HOSTS` set in `scripts/check-links.sh`, alongside the two pre-existing entries (`docs.google.com`, `indico.eiss-europa.com`). The skip-list comment was expanded to distinguish the two reasons a host lands here: auth-gated services and anti-bot filters.

--- a/src/2019.njk
+++ b/src/2019.njk
@@ -5,6 +5,7 @@ title: 2019 Conference — Paris
 description: 2nd EISS Annual Conference, 27 — 28 June 2019 at Sciences Po CERI, Paris.
 metaImage: /assets/images/2025-meta.jpg
 navKey: conferences
+status: archive
 ---
 
 <header class="page-header">

--- a/src/2020.njk
+++ b/src/2020.njk
@@ -5,6 +5,7 @@ title: 2020 Conference — deferred to 2021
 description: The 2020 EISS Conference was deferred to 2021 due to the COVID-19 pandemic and held in Lisbon, 3 — 4 September 2021.
 metaImage: /assets/images/index-meta.jpg
 navKey: conferences
+status: archive
 ---
 
 <header class="page-header">

--- a/src/2021.njk
+++ b/src/2021.njk
@@ -5,6 +5,7 @@ title: 2021 Conference — Lisbon
 description: 4th EISS Annual Conference, 3 — 4 September 2021 at ISCTE-IUL, Lisbon, Portugal. In person and online.
 metaImage: /assets/images/index-meta.jpg
 navKey: conferences
+status: archive
 ---
 
 <header class="page-header">

--- a/src/2022.njk
+++ b/src/2022.njk
@@ -5,6 +5,7 @@ title: 2022 Conference — Berlin
 description: 5th EISS Annual Conference, 30 June — 1 July 2022 at the Hertie School, Berlin.
 metaImage: /assets/images/2022-meta.jpg
 navKey: conferences
+status: archive
 ---
 
 <header class="page-header">

--- a/src/2023.njk
+++ b/src/2023.njk
@@ -5,6 +5,7 @@ title: 2023 Conference — Barcelona
 description: 6th EISS Annual Conference, 29 — 30 June 2023 at the Institut Barcelona d'Estudis Internacionals (IBEI), Barcelona.
 metaImage: /assets/images/2023-meta.jpg
 navKey: conferences
+status: archive
 ---
 
 <header class="page-header">

--- a/src/2024.njk
+++ b/src/2024.njk
@@ -5,6 +5,7 @@ title: 2024 Conference — Prague
 description: 7th EISS Annual Conference, 27 — 28 June 2024 at Charles University, Prague.
 metaImage: /assets/images/2024-meta.jpg
 navKey: conferences
+status: archive
 ---
 
 <header class="page-header">

--- a/src/2025.njk
+++ b/src/2025.njk
@@ -5,6 +5,7 @@ title: 2025 Conference — Thessaloniki
 description: 8th EISS Annual Conference, 26 — 27 June 2025 at the University of Macedonia, Thessaloniki.
 metaImage: /assets/images/2025-meta.jpg
 navKey: conferences
+status: archive
 ---
 
 <header class="page-header">

--- a/src/JPW2019.njk
+++ b/src/JPW2019.njk
@@ -4,6 +4,7 @@ permalink: /JPW2019.html
 title: Joint Policy Workshop 2019
 description: 2019 Joint Policy Workshop on Intra-Alliance Challenges to NATO's Cohesion and European Security — EISS, NATO Defense College, and VUB Institute for European Studies.
 navKey: ""
+status: archive
 ---
 
 {% include "jpw-2019-body.njk" %}

--- a/src/JPW2022.njk
+++ b/src/JPW2022.njk
@@ -4,6 +4,7 @@ permalink: /JPW2022.html
 title: Joint Policy Workshop 2022
 description: 2022 Joint Policy Workshop on Military Alliances and Challenges to the Use of Military Force — 9 November 2022, VUB Brussels School of Governance.
 navKey: ""
+status: archive
 ---
 {% from "icons.njk" import icon %}
 

--- a/src/JPW23.njk
+++ b/src/JPW23.njk
@@ -4,6 +4,7 @@ permalink: /JPW23.html
 title: Joint Policy Workshop 2023
 description: 2023 Joint Policy Workshop — EISS, NATO Defence College, and the Centre for Security, Diplomacy and Strategy at the Brussels School of Governance.
 navKey: ""
+status: archive
 ---
 {% from "icons.njk" import icon %}
 

--- a/src/NDC.njk
+++ b/src/NDC.njk
@@ -4,6 +4,7 @@ permalink: /NDC.html
 title: Joint Policy Workshop 2019 — NATO Defense College
 description: 2019 Joint Policy Workshop on Intra-Alliance Challenges to NATO's Cohesion and European Security — EISS, NATO Defense College, and VUB Institute for European Studies.
 navKey: ""
+status: archive
 ---
 
 {% include "jpw-2019-body.njk" %}

--- a/src/Ukraine.njk
+++ b/src/Ukraine.njk
@@ -5,6 +5,7 @@ title: Joint Conference on the War in Ukraine
 description: Joint Conference on the War in Ukraine — Lessons Learned and the Future Political Settlement. EISS, the Canadian Network for Strategic Analysis, and The Citadel.
 metaImage: /assets/images/Ukraine-meta.jpg
 navKey: ""
+status: archive
 ---
 {% from "icons.njk" import icon %}
 

--- a/src/_includes/archive-ribbon.njk
+++ b/src/_includes/archive-ribbon.njk
@@ -1,0 +1,24 @@
+{# Archive-page disclaimer ribbon.
+   Rendered by base.njk when the page's front-matter sets
+   `status: "archive"`. Used on documentation of past conferences and
+   workshops (the /YYYY.html year pages, the /JPW*.html policy
+   workshops, the one-off /Ukraine.html and /NDC.html pages) where
+   the content is preserved for the record but won't get the same
+   ongoing polish as live pages.
+
+   Text is hardcoded EN because every archive page on the site today
+   is EN-only. If an archive page gets translated, switch to a
+   `t.archiveRibbon.*` lookup against the i18n catalog (mirroring the
+   pattern in beta-ribbon.njk).
+
+   Visually quieter than the beta-translation ribbon: a neutral grey
+   tone rather than the warning-yellow used for unreviewed
+   translations. Archive content is fine, it's just static. #}
+<div class="archive-ribbon" role="note" aria-label="Archive page disclaimer">
+  <div class="container archive-ribbon-inner">
+    <span class="archive-ribbon-badge" aria-hidden="true">A</span>
+    <span class="archive-ribbon-text">
+      This page is part of our archive. It documents a past EISS event and may not be as complete or polished as current pages.
+    </span>
+  </div>
+</div>

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -172,6 +172,7 @@
   <a class="skip-link" href="#main">{{ t.skipLink }}</a>
 
   {% if status == "beta" %}{% include "beta-ribbon.njk" %}{% endif %}
+  {% if status == "archive" %}{% include "archive-ribbon.njk" %}{% endif %}
 
   {% include "nav.njk" %}
 

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -414,6 +414,57 @@ h4 { font-size: var(--fs-lg); }
 
 .beta-ribbon-text { flex: 1; }
 
+/* ---------- archive-page disclaimer ribbon ---------- */
+/* Rendered by src/_includes/archive-ribbon.njk when page front-matter
+   sets status: "archive". Used on past-conference and past-workshop
+   pages where the content is preserved for the record but won't get
+   the same ongoing polish as live pages. Sits in the same slot above
+   the nav as the beta ribbon, but uses a quieter neutral tone:
+   archive content isn't broken, just static. */
+.archive-ribbon {
+  background: hsl(220, 14%, 94%);
+  color: hsl(220, 18%, 32%);
+  border-bottom: 1px solid hsl(220, 12%, 82%);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-snug);
+}
+
+[data-theme="dark"] .archive-ribbon {
+  background: hsl(220, 14%, 18%);
+  color: hsl(220, 16%, 75%);
+  border-bottom-color: hsl(220, 14%, 28%);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .archive-ribbon {
+    background: hsl(220, 14%, 18%);
+    color: hsl(220, 16%, 75%);
+    border-bottom-color: hsl(220, 14%, 28%);
+  }
+}
+
+.archive-ribbon-inner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding-block: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.archive-ribbon-badge {
+  flex: none;
+  display: inline-grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: hsl(220, 18%, 50%);
+  color: white;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.archive-ribbon-text { flex: 1; }
+
 .beta-ribbon-link {
   color: inherit;
   font-weight: 600;


### PR DESCRIPTION
## Summary

Small grey banner above the nav on past-conference and past-workshop pages, setting visitor expectations that the content is preserved for the record but won't get the same ongoing polish as live pages.

Mirrors the existing beta-translation ribbon pattern in `src/_includes/beta-ribbon.njk` but in a neutral grey rather than warning-yellow. Beta says "unreviewed", archive says "static". Different signals, parallel mechanics.

## How it's wired

| Layer | Mechanism |
|---|---|
| Frontmatter trigger | `status: archive` on each archive page |
| Rendering hook | One line added to `base.njk`: `{% if status == "archive" %}{% include "archive-ribbon.njk" %}{% endif %}` |
| Partial | New `src/_includes/archive-ribbon.njk` (15 lines) |
| Styles | New `.archive-ribbon{,-inner,-badge,-text}` block in `site.css`, dark-mode aware |

## Pages marked archive (12 files)

| Past conferences | Past workshops |
|---|---|
| `/2019.html` through `/2025.html` (7 pages) | `/JPW2019.html`, `/JPW2022.html`, `/JPW23.html` |
| | `/NDC.html`, `/Ukraine.html` |

## Pages deliberately NOT marked

- `/2026.html` (live conference page, polished)
- `/NetSecSchool.html`, `/euroswamos.html`, `/coercion.html`, `/GlobalRisks.html` (current programme pages, EISS still runs all of these)

## What the banner says

> This page is part of our archive. It documents a past EISS event and may not be as complete or polished as current pages.

Text is hardcoded EN since every archive page is currently EN-only. If any archive page later gets a FR or DE translation, switch the partial to a `t.archiveRibbon.*` catalog lookup (mirroring the beta-ribbon).

## Test plan

- [ ] Open `/2025.html` on the deploy preview — grey "Archive page" banner appears above the nav
- [ ] Open `/2026.html` and `/index.html` — no banner appears
- [ ] Switch to dark mode — banner switches to the dark-mode palette (browns/greys, not yellows)
- [ ] Browser tab in light + dark — banner blends with the rest of the chrome rather than competing visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)