### PR TITLE
docs: CLAUDE.md §4 "Concurrent-PR CHANGELOG conflict trap" paragraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,9 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **`CLAUDE.md` §4 gains a *"Concurrent-PR CHANGELOG conflict trap"* paragraph.** Documents the failure mode caught during v2.23.1 prep: when two PRs both add a bullet to the same `### Added` / `### Changed` / `### Fixed` / `### Removed` sub-section in close succession, GitHub's auto-merge can resolve the conflict by keeping only one side. The dropped bullet's code change still lands on `master` but the CHANGELOG no longer records it, so the audit trail breaks silently. Real-world example linked (PR #179 lost two `### Changed` entries when PR #180's auto-merge wiped them). Includes the diagnostic recipe (`[Unreleased]` bullet count vs `git log v<prev>..HEAD --merges --oneline`) and the recovery path (`git log -G '<headline phrase>' -- CHANGELOG.md` to trace, restore in the release-prep commit).
 
 ## [2.23.1] · 2026-05-27 — Archive banner and post-release polish
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,20 @@ hygiene). When in doubt, add the bullet. Cutting a release becomes:
 review what's already there, decide on the title,
 `scripts/release.sh`.
 
+**Concurrent-PR CHANGELOG conflict trap.** When two PRs both add a
+bullet to the same `### Added` / `### Changed` / `### Fixed` /
+`### Removed` sub-section in close succession, GitHub's auto-merge
+can resolve the conflict by keeping only one side. The dropped
+bullet's code change still lands on `master`, but the CHANGELOG no
+longer records it and the audit trail breaks silently. Caught in
+v2.23.1 prep: PR #179 added two `### Changed` entries (Champs de
+Mars citation drop, map projection re-tune), PR #180 added its own
+bullet, the merge wiped the #179 lines. Recipe at release-cut time:
+cross-check the `[Unreleased]` bullet count against
+`git log v<prev>..HEAD --merges --oneline`. Mismatches mean a
+bullet was lost. Use `git log -G '<headline phrase>' -- CHANGELOG.md`
+to trace where, then restore in the release-prep commit.
+
 ## 5. Release-time four-point cross-check (minor / major only)
 
 Every **minor (`X.Y.0` where `Y > prev`) or major (`X.0.0`)


### PR DESCRIPTION
## Summary

Codifies the failure mode caught during v2.23.1 release prep, when two PRs both added to `[Unreleased] → ### Changed` close enough together that auto-merge dropped one side's bullets while landing the code itself on `master`.

New paragraph in `CLAUDE.md` §4 (immediately after the existing *"Keep [Unreleased] current"* paragraph):

> **Concurrent-PR CHANGELOG conflict trap.** When two PRs both add a bullet to the same `### Added` / `### Changed` / `### Fixed` / `### Removed` sub-section in close succession, GitHub's auto-merge can resolve the conflict by keeping only one side. The dropped bullet's code change still lands on `master`, but the CHANGELOG no longer records it and the audit trail breaks silently. Caught in v2.23.1 prep: PR #179 added two `### Changed` entries (Champs de Mars citation drop, map projection re-tune), PR #180 added its own bullet, the merge wiped the #179 lines. Recipe at release-cut time: cross-check the `[Unreleased]` bullet count against `git log v<prev>..HEAD --merges --oneline`. Mismatches mean a bullet was lost. Use `git log -G '<headline phrase>' -- CHANGELOG.md` to trace where, then restore in the release-prep commit.

## Why §4 and not §5

§5 (the four-point cross-check) is patches-skip, but this check costs nothing and matters for any release size. Putting it in §4 alongside the *"Keep [Unreleased] current"* rule signals that the convention applies to every release-cut moment.

## Self-audit

Zero em dashes, zero semicolons, no rule-of-three rhythms in the new paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)