### PR TITLE
fix(i18n): re-stamp src/2026.njk drift state after PR #204

### DIFF
--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -116,13 +116,13 @@
     "src/2026.njk": {
       "fr": {
         "file": "src/2026.fr.njk",
-        "source_sha1": "7ff9f4354c9f9b0b5a7f4e1034f08c1a051e1306",
+        "source_sha1": "e977360de85a54e6d9a0a40164668c6b30023f22",
         "translated_on": "2026-05-28",
         "status": "beta"
       },
       "de": {
         "file": "src/2026.de.njk",
-        "source_sha1": "7ff9f4354c9f9b0b5a7f4e1034f08c1a051e1306",
+        "source_sha1": "e977360de85a54e6d9a0a40164668c6b30023f22",
         "translated_on": "2026-05-28",
         "status": "beta"
       }


### PR DESCRIPTION
## Summary

PR #204 bumped the joint-orgs logo height (32 px → 56 px) and swapped the NetSec asset from the PNG to `netsec.svg` in all three locale variants (EN + FR + DE). The translations are structurally in sync, but `data/i18n-state.json` was not re-stamped in that PR, leaving it pointing at the pre-#204 SHA — hence the CI drift failure on PR #208.

This PR advances `source_sha1` for `src/2026.njk` (FR + DE entries) to `e977360de85a54e6d9a0a40164668c6b30023f22`, which matches the current file.

No template changes. Docs-only fix. Auto-merge safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)