### PR TITLE
chore: add GitHub issue-form templates (bug / enhancement / docs)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,53 @@
+name: Bug report
+description: Something on the site is broken or behaving wrongly.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. The three sections below
+        mirror the issue shape the maintainer keeps for this repository
+        (What's happening / Why it matters / Fix path), so a filled-in form
+        lands ready to triage.
+  - type: textarea
+    id: whats-happening
+    attributes:
+      label: What's happening
+      description: One paragraph, plus a concrete repro or a pointer to where it shows up.
+      placeholder: |
+        On /roadmap the FR card titles render empty. Repro: open
+        https://eiss-europa.com/roadmap.fr.html, the first card has no heading.
+    validations:
+      required: true
+  - type: textarea
+    id: why-it-matters
+    attributes:
+      label: Why it matters
+      description: One paragraph. User impact, audit-trail context, or accessibility angle.
+    validations:
+      required: true
+  - type: textarea
+    id: fix-path
+    attributes:
+      label: Fix path (or fix options)
+      description: >-
+        Specific enough that a maintainer can pick it up without re-deriving the
+        analysis. Code paths, file names, line numbers where you can.
+    validations:
+      required: false
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Milestone
+      description: >-
+        The target release. Pick "Backlog — Under watch" when there is no
+        committed release. Never leave it blank.
+      options:
+        - v2.25.0
+        - v2.26.0
+        - v2.27.0
+        - "Backlog — Under watch"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security issue
+    url: https://github.com/EISSeuropa/EISSeuropa.github.io/security/advisories/new
+    about: Found a vulnerability? Report it privately through a GitHub security advisory rather than a public issue.
+  - name: General questions
+    url: mailto:contact@eiss-europa.com
+    about: Questions about EISS, the events, or the site that are not a bug, feature, or docs issue.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,52 @@
+name: Documentation
+description: Something in the public copy or the repo docs is wrong, missing, or stale.
+title: "docs: "
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for flagging a documentation gap. The three sections below mirror
+        the issue shape the maintainer keeps for this repository
+        (What's happening / Why it matters / Fix path), so a filled-in form
+        lands ready to triage.
+  - type: textarea
+    id: whats-happening
+    attributes:
+      label: What's happening
+      description: >-
+        One paragraph, plus a pointer to the page or doc (a URL, or a file under
+        docs/).
+    validations:
+      required: true
+  - type: textarea
+    id: why-it-matters
+    attributes:
+      label: Why it matters
+      description: One paragraph. Reader impact, audit-trail context, or compliance angle.
+    validations:
+      required: true
+  - type: textarea
+    id: fix-path
+    attributes:
+      label: Fix path (or fix options)
+      description: >-
+        Specific enough that a maintainer can pick it up without re-deriving the
+        analysis. File names, sections, line numbers where you can.
+    validations:
+      required: false
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Milestone
+      description: >-
+        The target release. Pick "Backlog — Under watch" when there is no
+        committed release. Never leave it blank.
+      options:
+        - v2.25.0
+        - v2.26.0
+        - v2.27.0
+        - "Backlog — Under watch"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,52 @@
+name: Enhancement
+description: A feature need or improvement to an existing page or workflow.
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. The three sections below mirror
+        the issue shape the maintainer keeps for this repository
+        (What's happening / Why it matters / Fix path), so a filled-in form
+        lands ready to triage.
+  - type: textarea
+    id: whats-happening
+    attributes:
+      label: What's happening
+      description: >-
+        One paragraph describing the need, plus a concrete pointer (a user
+        journey, a page, a maintainer conversation).
+    validations:
+      required: true
+  - type: textarea
+    id: why-it-matters
+    attributes:
+      label: Why it matters
+      description: One paragraph. User impact, audit-trail context, or accessibility angle.
+    validations:
+      required: true
+  - type: textarea
+    id: fix-path
+    attributes:
+      label: Fix path (or fix options)
+      description: >-
+        Specific enough that a maintainer can pick it up without re-deriving the
+        analysis. Code paths, file names, line numbers where you can.
+    validations:
+      required: false
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Milestone
+      description: >-
+        The target release. Pick "Backlog — Under watch" when there is no
+        committed release. Never leave it blank.
+      options:
+        - v2.25.0
+        - v2.26.0
+        - v2.27.0
+        - "Backlog — Under watch"
+    validations:
+      required: true


### PR DESCRIPTION
Adds YAML issue forms under `.github/ISSUE_TEMPLATE/` so new issues land pre-shaped in the CLAUDE.md §3 form and pre-milestoned per §10.

## What's in here

- `bug.yml`, `enhancement.yml`, `documentation.yml`: each is a GitHub issue form with a title prefix, the three §3 sections as textarea fields (What's happening with a repro/pointer, Why it matters, Fix path), and a required Milestone dropdown offering `v2.25.0`, `v2.26.0`, `v2.27.0`, and `Backlog — Under watch`.
- Each form applies the matching existing label (`bug` / `enhancement` / `documentation`) through the form's `labels` field.
- `config.yml`: sets `blank_issues_enabled: false` and adds two contact links, one routing security reports to a private GitHub security advisory and one routing general questions to `contact@eiss-europa.com`.

## What's deliberately not here

No issue-lifecycle automation (no stale, lock, or sweep workflows), per the issue.

Internal-only change: no user-visible surface, so no CHANGELOG bullet and no build needed. All four files validated as parseable YAML.

Closes #277.