### PR TITLE
ci: SHA-pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,9 +36,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "20"
 
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: _site
 
@@ -75,4 +75,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/i18n-drift.yml
+++ b/.github/workflows/i18n-drift.yml
@@ -27,9 +27,9 @@ jobs:
     name: Verify translations match their English sources
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -48,10 +48,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -63,7 +63,7 @@ jobs:
         run: npm run build
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/probe-indico-api.yml
+++ b/.github/workflows/probe-indico-api.yml
@@ -24,9 +24,9 @@ jobs:
     name: Probe candidate endpoints
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/roadmap-progress.yml
+++ b/.github/workflows/roadmap-progress.yml
@@ -50,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
 
@@ -80,7 +80,7 @@ jobs:
 
       - name: Open or update PR if progress changed
         id: create-pr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: roadmap-progress/auto

--- a/.github/workflows/scheduled-rebuild.yml
+++ b/.github/workflows/scheduled-rebuild.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch the build-and-deploy workflow
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/sync-board.yml
+++ b/.github/workflows/sync-board.yml
@@ -46,10 +46,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
           cache: pip
@@ -92,7 +92,7 @@ jobs:
           } > /tmp/board-pr-body.md
 
       - name: Open or update PR if board.json or photos changed
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: board-sync/auto

--- a/.github/workflows/sync-indico.yml
+++ b/.github/workflows/sync-indico.yml
@@ -47,9 +47,9 @@ jobs:
     name: Refresh indico.json from the export API
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
           cache: pip
@@ -89,7 +89,7 @@ jobs:
 
       - name: Open detailed PR for substantive changes
         if: steps.sync.outputs.substantive == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           branch: indico-sync/auto
           base: master

--- a/.github/workflows/sync-roadmap.yml
+++ b/.github/workflows/sync-roadmap.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # fetch-depth: 0 so `git tag --list --sort=-v:refname` sees
           # the full tag history. Shallow clones default to depth 1,
@@ -81,7 +81,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
 
@@ -111,7 +111,7 @@ jobs:
 
       - name: Open or update PR if autostamp changed
         id: create-pr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: roadmap-sync/auto

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,11 @@ authoritative for EISS.
   Don't push more commits to a branch whose PR is already open,
   even if "the merge hasn't happened yet" — by the time `git push`
   returns, it often has.
+- **SHA-pin GitHub Actions.** Every `uses:` in `.github/workflows/`
+  is pinned to a full 40-character commit SHA with a trailing
+  `# vN` comment (e.g. `uses: actions/checkout@de0fac2… # v6`).
+  Dependabot's `github-actions` block keeps the pins current and the
+  comment human-readable. New workflows pin by default.
 
 ## 3. Open a GitHub issue for every deferred item
 


### PR DESCRIPTION
## What this does

Pins every `uses:` line across `.github/workflows/` to a full 40-character commit SHA, with a trailing `# vN` comment so the version stays human-readable and Dependabot's `github-actions` block can keep the pins current.

This makes the `.github/dependabot.yml` docstring honest: it already claims we SHA-pin third-party Actions, but the workflows used floating tags.

## Why it matters

Supply-chain hardening. `peter-evans/create-pull-request` runs in the board-sync, indico-sync, roadmap and roadmap-progress auto-PR bots with **Contents + PR write**, so a retagged or compromised upstream would inherit write scope on the next run. SHA pinning removes that mutable-tag exposure.

## Scope

- 24 `uses:` lines across 9 workflow files.
- Pinned actions: `actions/checkout@v6`, `actions/setup-node@v6`, `actions/setup-python@v6`, `actions/github-script@v9`, `actions/upload-pages-artifact@v5`, `actions/deploy-pages@v5`, `peter-evans/create-pull-request@v8`.
- Added a one-line rule to CLAUDE.md §2 so new workflows pin by default.

All SHAs resolved via `gh api repos/<org>/<repo>/commits/<tag>`. All workflow files re-validated as parseable YAML.

Internal change (workflows + project docs): no CHANGELOG bullet, no build.

Closes #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)