### PR TITLE
fix(chrome): track variable sticky-chrome height for anchor scroll offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 - **Public roadmap page at `/roadmap.html` (EN + FR + DE).** A visitor-facing view of what's shipped, in progress, and planned, mirroring the sister NetSec site. Quarterly sections (Q2 / Q3 / Q4 2026) carry version cards with a status pill (Shipped / In progress / Planned / Under watch), the release date and SemVer tag, a short description, and a *Release notes* link on shipped releases. In-flight cards carry `data-milestone="vX.Y.Z"`; `assets/js/roadmap-progress.js` reads `/data/roadmap-progress.json` (closed / total issues on the matching GitHub milestone) to draw a live progress bar and promote the next release to *In progress*. An *Under watch* section lists items waiting on an external trigger, and a CTA row links the issue tracker, the milestones, and the releases. Content lives in `src/_data/roadmap.js` (hand-translated per locale); linked from the footer and the visual sitemap. Mirrors the version-tied milestones adopted in v2.24.0's follow-up.
 
+### Fixed
+
+- **In-page anchors no longer land under the sticky chrome.** The chrome's height is variable (the What's New banner adds height, and FR/DE pages add the beta ribbon), so the old static scroll offset left clicked anchors hidden behind the chrome in those states. `theme.js` now measures the chrome's real rendered height and publishes it as `scroll-padding-top` on `<html>`, recomputed on load, on resize, and whenever the banner mounts or is dismissed. A static fallback covers the pre-hydration and no-JS case (closes [#278](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/278)).
+
 ## [2.24.0] · 2026-05-30 — Live programme depth and a print overhaul
 
 > ESSC 2026 opens in Stockholm on 11–12 June, and this release is built around the conference pages that carry it. The live programme on `/2026` now shows the full panel line-ups with every co-author and marks who is presenting, and printing it produces a clean handout rather than a stack of near-empty pages. Around it the archive fills out, the People page reflects who has moved on, and the English copy gets a consistent voice.

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -226,12 +226,18 @@ button:focus-visible,
   box-shadow: 0 0 0 6px var(--accent-soft);
 }
 
-/* Anchor targets shouldn't be hidden behind the sticky nav header.
-   ~6rem matches the nav's effective height + a small visual margin.
-   Applies anywhere an in-page anchor (`#programme`, `#venue`,
-   `#arthur-laudrain`, …) is the scroll target. */
-:where([id]) {
-  scroll-margin-top: 6rem;
+/* Anchor targets shouldn't be hidden behind the sticky chrome.
+   The chrome height is variable (What's New banner sets --whats-new-h,
+   FR/DE pages add the beta ribbon), so the live offset is published as
+   scroll-padding-top on <html> by theme.js (window.eissSyncScrollPadding),
+   recomputed on load, resize, and banner mount/dismiss. This ~6rem rule is
+   the no-JS / pre-hydration fallback: it covers the nav's effective height
+   plus a small margin until the script measures the real chrome bottom.
+   Once the script runs it sets a 0px scroll-padding-top when no chrome is
+   present, and the measured value otherwise, so the two don't double up in
+   the common case (the script's scroll-padding-top wins on <html>). */
+:root {
+  scroll-padding-top: 6rem;
 }
 
 /* `:target` highlight pulse. When a visitor lands on a deep link

--- a/src/assets/js/theme.js
+++ b/src/assets/js/theme.js
@@ -241,6 +241,7 @@
       if (h > 0) {
         document.documentElement.style.setProperty("--whats-new-h", h + "px");
       }
+      if (window.eissSyncScrollPadding) window.eissSyncScrollPadding();
     };
     syncH();
     if (document.readyState !== "complete") {
@@ -251,6 +252,32 @@
       try { new ResizeObserver(syncH).observe(banner); } catch (e) {}
     }
   }
+})();
+
+/* Sticky-chrome scroll offset — keep anchored headings clear of the chrome.
+   ─────────────────────────────────────────────────────────────────────────
+   The sticky chrome (.sticky-chrome) is variable height: the What's New
+   banner shifts it down via --whats-new-h, and FR/DE pages add the beta
+   ribbon. A static scroll-margin-top can't track that, so in-page anchors
+   used to land under the chrome on those states. Measure the chrome's real
+   rendered bottom and publish it as scroll-padding-top on <html>, recomputed
+   on load, resize, and whenever the banner mounts or is dismissed (the
+   banner's syncH calls window.eissSyncScrollPadding). */
+(function () {
+  var GAP = 12; /* px of breathing room below the chrome */
+  function sync() {
+    var chrome = document.querySelector(".sticky-chrome");
+    var h = chrome ? chrome.getBoundingClientRect().height : 0;
+    document.documentElement.style.scrollPaddingTop = (h > 0 ? h + GAP : 0) + "px";
+  }
+  window.eissSyncScrollPadding = sync;
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", sync);
+  } else {
+    sync();
+  }
+  window.addEventListener("load", sync);
+  window.addEventListener("resize", sync, { passive: true });
 })();
 
 /* Print prep for the live programme grid.


### PR DESCRIPTION
## What

Anchored in-page headings (e.g. `/board.html#arthur-laudrain`, `/2026#programme`) landed **under** the sticky chrome whenever the chrome was taller than the static scroll offset assumed: when the What's New banner is active (adds `--whats-new-h`) or on FR/DE pages (the beta ribbon).

## How

- `src/assets/js/theme.js`: a tiny dependency-free routine measures the rendered height of `.sticky-chrome` and publishes it as `scroll-padding-top` on `<html>` (plus a 12px gap). It recomputes on `DOMContentLoaded`/`load`, on `resize`, and whenever the What's New banner mounts or is dismissed (the banner's existing `syncH` now calls the new `window.eissSyncScrollPadding`).
- `src/assets/css/site.css`: replaced the static `scroll-margin-top: 6rem` on `:where([id])` with a static `scroll-padding-top: 6rem` fallback on `:root`. Both the fallback and the JS value live on the same element, so the script's measured value wins once it runs and the two never double up. The fallback covers the pre-hydration and no-JS case.

## Verify

- `npm run build` succeeds.
- `python3 scripts/check-i18n-drift.py` reports "All translations match".

This is a behavioural fix to scroll positioning rather than a layout/copy change, but it affects what a visitor sees after clicking a deep link. Visual change — preview review requested (CLAUDE.md §2).

Closes #278.