### PR TITLE
feat(build): content-hash cache-busting for CSS/JS (closes #308)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,10 +1,30 @@
 const fs = require("fs");
 const path = require("path");
+const crypto = require("crypto");
 
 module.exports = function (eleventyConfig) {
   eleventyConfig.setQuietMode(true);
 
   eleventyConfig.addFilter("year", () => new Date().getUTCFullYear());
+
+  // {{ '/assets/css/site.css' | bust }} -> '/assets/css/site.css?v=ab12cd34'
+  // Cache-busts CSS/JS by appending the first 8 hex of the file's
+  // SHA-256, so a returning visitor never renders new HTML against a
+  // stale cached asset (GitHub Pages serves assets with max-age=600).
+  // Computed from the src/ source at build time, so it can never go
+  // stale: change the file, the hash changes, the URL changes. No
+  // stamping script or CI gate needed (unlike a no-build site). A
+  // missing file falls back to the bare URL rather than breaking.
+  eleventyConfig.addFilter("bust", (url) => {
+    try {
+      const rel = String(url).replace(/^\//, "").split("?")[0];
+      const buf = fs.readFileSync(path.join(__dirname, "src", rel));
+      const hash = crypto.createHash("sha256").update(buf).digest("hex").slice(0, 8);
+      return `${url}?v=${hash}`;
+    } catch (_) {
+      return url;
+    }
+  });
 
   // {% inlineSvg "assets/images/brand/logo-lockup.svg" %} — reads a
   // file from src/ at build time and dumps the bytes verbatim into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,8 +77,7 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 ### Fixed
 
 - **In-page anchors no longer land under the sticky chrome.** The chrome's height is variable (the What's New banner adds height, and FR/DE pages add the beta ribbon), so the old static scroll offset left clicked anchors hidden behind the chrome in those states. `theme.js` now measures the chrome's real rendered height and publishes it as `scroll-padding-top` on `<html>`, recomputed on load, on resize, and whenever the banner mounts or is dismissed. A static fallback covers the pre-hydration and no-JS case (closes [#278](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/278)).
-
-## [2.24.0] · 2026-05-30 — Live programme depth and a print overhaul
+- **CSS and JS no longer load stale from cache after a deploy.** The stylesheet and the scripts were linked with bare URLs, so a returning visitor could fetch new HTML while the browser served the old `site.css` from cache (GitHub Pages caches assets for ten minutes), briefly rendering new markup against old styles. A build-time `bust` filter now appends the first eight hex of each asset's SHA-256 (`site.css?v=…`), recomputed every build, so the URL changes only when the file does. No stamping script or CI gate is needed, the hash is derived at build time rather than written into the source.
 
 > ESSC 2026 opens in Stockholm on 11–12 June, and this release is built around the conference pages that carry it. The live programme on `/2026` now shows the full panel line-ups with every co-author and marks who is presenting, and printing it produces a clean handout rather than a stack of near-empty pages. Around it the archive fills out, the People page reflects who has moved on, and the English copy gets a consistent voice.
 

--- a/src/_includes/roadmap-timeline.njk
+++ b/src/_includes/roadmap-timeline.njk
@@ -87,4 +87,4 @@
   </div>
 </section>
 
-<script src="/assets/js/roadmap-progress.js" defer></script>
+<script src="{{ '/assets/js/roadmap-progress.js' | bust }}" defer></script>

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -166,7 +166,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap">
-  <link rel="stylesheet" href="/assets/css/site.css">
+  <link rel="stylesheet" href="{{ '/assets/css/site.css' | bust }}">
 </head>
 <body>
   <a class="skip-link" href="#main">{{ t.skipLink }}</a>
@@ -196,8 +196,8 @@
   {% include "search-modal.njk" %}
   <span data-search-strings='{"noResults":"{{ t.search.noResults }}","unavailable":"{{ t.search.unavailable }}","searching":"{{ t.search.searching }}"}' hidden></span>
 
-  <script src="/assets/js/theme.js" defer></script>
-  <script src="/assets/js/search.js" defer></script>
+  <script src="{{ '/assets/js/theme.js' | bust }}" defer></script>
+  <script src="{{ '/assets/js/search.js' | bust }}" defer></script>
   <script>
     // Save the user's chosen language whenever they click any link
     // that carries an `hreflang` attribute. The two sources on the


### PR DESCRIPTION
Addresses the same issue as NetSec PR #417 (stale cached CSS/JS for returning visitors), but the **Eleventy-native way** rather than porting NetSec's no-build machinery.

- New `bust` filter in `.eleventy.js` appends the first 8 hex of an asset's SHA-256; applied to `site.css`, `theme.js`, `search.js`, `roadmap-progress.js` in `base.njk` + `roadmap-timeline.njk`. Computed from the source at build time, so it can never go stale → **no `inject-seo.py` stamper, no `seo-asset-check.yml` CI gate** (those exist only because NetSec has no build step). Missing files fall back to the bare URL.
- Removed stray macOS Finder duplicates (`roadmap*.njk 2`, etc.) under `src/` that collided on permalinks and broke the local build.

Verified: every asset URL carries `?v=<8hex>`, the `site.css` hash is identical across all locales/pages, the filter degrades gracefully on a missing file, build green (81 files), i18n drift clean.

Closes #308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)