### PR TITLE
style(countdown): solid accent pill for contrast on the hero

### DIFF
--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -3236,17 +3236,22 @@ h4 { font-size: var(--fs-lg); }
 .countdown {
   display: inline-flex;
   align-items: center;
-  gap: 0.45em;
+  gap: 0.5em;
   margin: var(--space-3) 0;
-  padding: 0.4em 0.85em;
+  padding: 0.5em 1em;
   border-radius: var(--radius-full);
-  background: var(--accent-soft);
-  color: var(--accent);
+  /* Solid accent fill (not the faint tint) so it reads clearly against
+     the conference-photo hero, where a translucent pill washed out. */
+  background: var(--accent);
+  color: var(--accent-text);
+  border: 1px solid hsl(0 0% 100% / 0.18);
   font-size: var(--fs-sm);
-  font-weight: 600;
+  font-weight: 700;
+  letter-spacing: 0.005em;
   font-variant-numeric: tabular-nums;
+  box-shadow: var(--shadow-2);
 }
-.countdown__icon { display: inline-flex; }
+.countdown__icon { display: inline-flex; opacity: 0.9; }
 .countdown__icon svg { width: 1rem; height: 1rem; }
 
 /* ---------- utilities ---------- */


### PR DESCRIPTION
Recovers a commit orphaned by the §2 trap: this contrast fix was pushed to the #314 branch *after* #314 had already merged, so it never reached master. Cherry-picked onto a fresh branch off current master.

The countdown pill used a translucent `--accent-soft` tint that washed out against the conference-photo hero (per maintainer feedback). Now a solid accent fill with white text, a hairline light border, stronger shadow, and bolder weight — clearly visible on both the photo hero and the light homepage card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)