### PR TITLE
fix(2026): align the registration badge and countdown pill

### DIFF
--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -116,13 +116,13 @@
     "src/2026.njk": {
       "fr": {
         "file": "src/2026.fr.njk",
-        "source_sha1": "2dec074713c7df9aefd41c2f181154382b4dea62",
+        "source_sha1": "4e45bdaf14f34eaeaa9d0e3fadd93fc872d8bee5",
         "translated_on": "2026-06-01",
         "status": "beta"
       },
       "de": {
         "file": "src/2026.de.njk",
-        "source_sha1": "2dec074713c7df9aefd41c2f181154382b4dea62",
+        "source_sha1": "4e45bdaf14f34eaeaa9d0e3fadd93fc872d8bee5",
         "translated_on": "2026-06-01",
         "status": "beta"
       }

--- a/src/2026.de.njk
+++ b/src/2026.de.njk
@@ -43,7 +43,7 @@ alternates:
       Universität Stockholm, Schweden
     </p>
     {% set year = "2026" %}
-    <div class="reveal reveal-delay-3" style="margin-top: var(--space-4);">
+    <div class="reveal reveal-delay-3 conf-status-row">
       {% include "registration-badge.njk" %}
       {% include "countdown.njk" %}
     </div>

--- a/src/2026.fr.njk
+++ b/src/2026.fr.njk
@@ -43,7 +43,7 @@ alternates:
       Université de Stockholm, Suède
     </p>
     {% set year = "2026" %}
-    <div class="reveal reveal-delay-3" style="margin-top: var(--space-4);">
+    <div class="reveal reveal-delay-3 conf-status-row">
       {% include "registration-badge.njk" %}
       {% include "countdown.njk" %}
     </div>

--- a/src/2026.njk
+++ b/src/2026.njk
@@ -45,7 +45,7 @@ alternates:
        conference dates in src/_data/conferences.js; CTA URL comes
        from the Indico sync in src/_data/indico.json. #}
     {% set year = "2026" %}
-    <div class="reveal reveal-delay-3" style="margin-top: var(--space-4);">
+    <div class="reveal reveal-delay-3 conf-status-row">
       {% include "registration-badge.njk" %}
       {% include "countdown.njk" %}
     </div>

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -3254,6 +3254,19 @@ h4 { font-size: var(--fs-lg); }
 .countdown__icon { display: inline-flex; opacity: 0.9; }
 .countdown__icon svg { width: 1rem; height: 1rem; }
 
+/* Conference-page status row: the registration badge and the countdown
+   pill sit side by side under the hero meta. Flex with centre alignment
+   so the two pills share a vertical centre line regardless of height,
+   and zero the children's own block margins so nothing offsets them. */
+.conf-status-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+.conf-status-row > * { margin-block: 0; }
+
 /* ---------- utilities ---------- */
 .sr-only {
   position: absolute;


### PR DESCRIPTION
Maintainer feedback: contrast is good now, but the countdown pill sat lower than the registration badge.

Cause: the two pills were `inline-flex` siblings in a plain `<div>`, so they aligned on the text baseline (different heights) and the countdown's own block margin offset it. Fix: wrap them in a `.conf-status-row` flex container (centre-aligned, gapped, wrapping) and zero the children's block margins, so the pair shares one vertical centre line on `/2026` (×3 locales). `/index` is unaffected (the countdown there is standalone).

Verified with a headless screenshot. Build green, drift clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)