### PR TITLE
feat(past): run the 2025 conference film beside the archive cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 - **The Inter typeface is now self-hosted instead of loaded from Google Fonts.** The font is served from the site's own origin (vendored under `src/assets/fonts/`, variable weight, Latin + Latin-Extended), so no visitor IP is sent to Google on first paint. This matches the site's no-tracking stance, removes a render-blocking cross-origin request, and drops the corresponding entries from the privacy notice.
 - **The conference venue map no longer embeds Google Maps.** The `/YYYY` venue block was a Google Maps iframe that loaded on page view, sending every visitor's IP to Google. It is replaced by a plain address card with a link to OpenStreetMap that opens only when clicked. No third party is contacted on page load. The Google Maps entry is removed from the privacy notice accordingly.
+- **The 2025 conference film now also runs on the `/past` conferences page.** The same `film-embed.njk` player sits in a portrait column beside the year-by-year archive cards on desktop, staying in view as the list scrolls, and stacks below the cards on mobile. It reuses the self-hosted GitHub Release asset and the scroll-into-view muted autoplay already used on `/2025`, so nothing downloads until it enters the viewport. Part of [#330](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/330).
 
 ### Fixed
 

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -88,14 +88,14 @@
     "src/past.njk": {
       "fr": {
         "file": "src/past.fr.njk",
-        "source_sha1": "801fb8991f86cb23a92cdefac53c41b814e584f9",
-        "translated_on": "2026-05-29",
+        "source_sha1": "bb9ac797479550899f3cc0a2cecd2f9903747478",
+        "translated_on": "2026-06-01",
         "status": "beta"
       },
       "de": {
         "file": "src/past.de.njk",
-        "source_sha1": "801fb8991f86cb23a92cdefac53c41b814e584f9",
-        "translated_on": "2026-05-29",
+        "source_sha1": "bb9ac797479550899f3cc0a2cecd2f9903747478",
+        "translated_on": "2026-06-01",
         "status": "beta"
       }
     },

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -3335,6 +3335,17 @@ h4 { font-size: var(--fs-lg); }
   .film-feature .film-caption { text-align: left; }
 }
 
+/* Archive list beside the conference film. The cards take the fluid
+   column; the film holds a fixed portrait column and stays in view as
+   the list scrolls. Single column on mobile (film below the cards). */
+.archive-layout { display: grid; gap: var(--space-6); align-items: start; }
+@media (min-width: 56rem) {
+  .archive-layout { grid-template-columns: 1fr minmax(280px, 340px); }
+  .archive-film { position: sticky; top: 6rem; }
+  .archive-film .film { margin: 0; }
+  .archive-film .film-caption { text-align: left; }
+}
+
 /* ---------- utilities ---------- */
 .sr-only {
   position: absolute;

--- a/src/past.de.njk
+++ b/src/past.de.njk
@@ -64,6 +64,7 @@ alternates:
 <section class="section-tight" aria-labelledby="archive-title">
   <div class="container">
     <h2 id="archive-title" style="margin-bottom: var(--space-5);">Archiv</h2>
+    <div class="archive-layout">
     <div class="conference-list">
       {%- for c in conferences.past %}
       {%- if c.hasOwnPage %}
@@ -77,6 +78,14 @@ alternates:
       </a>
       {%- endif %}
       {%- endfor %}
+    </div>
+    <div class="archive-film">
+      {%- set filmSrc = "https://github.com/EISSeuropa/EISSeuropa.github.io/releases/download/media-assets/essc-2025.mp4" -%}
+      {%- set filmPoster = "/assets/images/2025/essc-2025-film-poster.jpg" -%}
+      {%- set filmYoutube = "https://youtube.com/shorts/CFtUrpwgYXY" -%}
+      {%- set filmCaption = "ESSC 2025 · Thessaloniki" -%}
+      {% include "film-embed.njk" %}
+    </div>
     </div>
     <p class="muted" style="font-size: var(--fs-sm); margin-top: var(--space-4);">
       <em>Die einzelnen Archivseiten sind nur auf Englisch verfügbar.</em>

--- a/src/past.fr.njk
+++ b/src/past.fr.njk
@@ -64,6 +64,7 @@ alternates:
 <section class="section-tight" aria-labelledby="archive-title">
   <div class="container">
     <h2 id="archive-title" style="margin-bottom: var(--space-5);">Archive</h2>
+    <div class="archive-layout">
     <div class="conference-list">
       {%- for c in conferences.past %}
       {%- if c.hasOwnPage %}
@@ -77,6 +78,14 @@ alternates:
       </a>
       {%- endif %}
       {%- endfor %}
+    </div>
+    <div class="archive-film">
+      {%- set filmSrc = "https://github.com/EISSeuropa/EISSeuropa.github.io/releases/download/media-assets/essc-2025.mp4" -%}
+      {%- set filmPoster = "/assets/images/2025/essc-2025-film-poster.jpg" -%}
+      {%- set filmYoutube = "https://youtube.com/shorts/CFtUrpwgYXY" -%}
+      {%- set filmCaption = "ESSC 2025 · Thessaloniki" -%}
+      {% include "film-embed.njk" %}
+    </div>
     </div>
     <p class="muted" style="font-size: var(--fs-sm); margin-top: var(--space-4);">
       <em>Les pages d'archive individuelles ne sont disponibles qu'en anglais.</em>

--- a/src/past.njk
+++ b/src/past.njk
@@ -65,6 +65,7 @@ alternates:
 <section class="section-tight" aria-labelledby="archive-title">
   <div class="container">
     <h2 id="archive-title" style="margin-bottom: var(--space-5);">Archive</h2>
+    <div class="archive-layout">
     <div class="conference-list">
       {%- for c in conferences.past %}
       {%- if c.hasOwnPage %}
@@ -78,6 +79,14 @@ alternates:
       </a>
       {%- endif %}
       {%- endfor %}
+    </div>
+    <div class="archive-film">
+      {%- set filmSrc = "https://github.com/EISSeuropa/EISSeuropa.github.io/releases/download/media-assets/essc-2025.mp4" -%}
+      {%- set filmPoster = "/assets/images/2025/essc-2025-film-poster.jpg" -%}
+      {%- set filmYoutube = "https://youtube.com/shorts/CFtUrpwgYXY" -%}
+      {%- set filmCaption = "ESSC 2025 · Thessaloniki" -%}
+      {% include "film-embed.njk" %}
+    </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## What

Wraps the `/past` **Archive** section in a two-column layout (EN + FR + DE):

- **Left (fluid column):** the year-by-year conference cards, unchanged.
- **Right (fixed portrait column, desktop):** the 2025 ESSC film, reusing the `film-embed.njk` partial already on master from #334. It is `position: sticky` so it stays in view while the archive list scrolls.
- **Mobile:** single column, film below the cards (`@media (min-width: 56rem)` gates the split).

The player reuses the self-hosted GitHub Release MP4 and the scroll-into-view muted-autoplay behaviour from `/2025`, so nothing downloads until it enters the viewport. FR/DE keep their "individual archive pages only in English" note as a footnote below the two-column layout.

## Verification

- Build clean (81 files), `check-i18n-drift.py` reports all translations match (`src/past.njk` fr/de marked fresh).
- Layout checked in the preview at desktop (grid `780px 340px`, film sticky) and mobile (single `343px` column, film static below cards).

## Review note (CLAUDE.md §2 carve-out)

This is a **visual change**, so auto-merge is **not** armed. Please eyeball the deploy preview of `/past` (and `/past.fr` / `/past.de`) before merging, in particular the sticky film column on desktop and the mobile stack.

Part of #330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)