### PR TITLE
content(initiative): recurate open-panel examples from the archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 - **The Inter typeface is now self-hosted instead of loaded from Google Fonts.** The font is served from the site's own origin (vendored under `src/assets/fonts/`, variable weight, Latin + Latin-Extended), so no visitor IP is sent to Google on first paint. This matches the site's no-tracking stance, removes a render-blocking cross-origin request, and drops the corresponding entries from the privacy notice.
 - **The conference venue map no longer embeds Google Maps.** The `/YYYY` venue block was a Google Maps iframe that loaded on page view, sending every visitor's IP to Google. It is replaced by a plain address card with a link to OpenStreetMap that opens only when clicked. No third party is contacted on page load. The Google Maps entry is removed from the privacy notice accordingly.
+- **The open-panel examples on `/initiative` now show the breadth of past ESSCs.** The short list of recent open panels is recurated from the conference archive to span 2018 to 2026 and to sit clearly apart from the nine permanent thematic sections: non-state actors and domestic politics (2018), climate change and security actors (2019), European security read through India (2021), organised crime in Latin America (2023), knowledge production on war (2024), and cyber and digital sovereignty (2026). Titles stay in English (their conference form) and are marked `lang="en"` on the FR and DE pages.
 
 ### Fixed
 

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -18,14 +18,14 @@
     "src/initiative.njk": {
       "fr": {
         "file": "src/initiative.fr.njk",
-        "source_sha1": "0de78aa688ebd0c37f29d97af1a992ada47aa667",
-        "translated_on": "2026-05-29",
+        "source_sha1": "f55bf059af6f6dbffb19fed45ff070586143e773",
+        "translated_on": "2026-06-01",
         "status": "beta"
       },
       "de": {
         "file": "src/initiative.de.njk",
-        "source_sha1": "0de78aa688ebd0c37f29d97af1a992ada47aa667",
-        "translated_on": "2026-05-29",
+        "source_sha1": "f55bf059af6f6dbffb19fed45ff070586143e773",
+        "translated_on": "2026-06-01",
         "status": "beta"
       }
     },

--- a/src/initiative.de.njk
+++ b/src/initiative.de.njk
@@ -208,12 +208,24 @@ alternates:
     </p>
     <ul class="open-panels" aria-label="Beispiele für jüngste offene Panels">
       <li class="open-panel">
-        <span class="open-panel-year">ESSC 2024</span>
-        <span class="open-panel-title" lang="en">Knowledge Production on War</span>
+        <span class="open-panel-year">ESSC 2018</span>
+        <span class="open-panel-title" lang="en">Asymmetric Threats, Non-State Actors and Domestic Politics</span>
+      </li>
+      <li class="open-panel">
+        <span class="open-panel-year">ESSC 2019</span>
+        <span class="open-panel-title" lang="en">Climate Change and Security Actors</span>
+      </li>
+      <li class="open-panel">
+        <span class="open-panel-year">ESSC 2021</span>
+        <span class="open-panel-title" lang="en">Thinking European Security through India</span>
+      </li>
+      <li class="open-panel">
+        <span class="open-panel-year">ESSC 2023</span>
+        <span class="open-panel-title" lang="en">(In)security and Organized Crime in Latin America</span>
       </li>
       <li class="open-panel">
         <span class="open-panel-year">ESSC 2024</span>
-        <span class="open-panel-title" lang="en">Nuclear Deterrence and Nuclear Strategy in the Third Nuclear Age</span>
+        <span class="open-panel-title" lang="en">Knowledge Production on War</span>
       </li>
       <li class="open-panel">
         <span class="open-panel-year">ESSC 2026</span>

--- a/src/initiative.fr.njk
+++ b/src/initiative.fr.njk
@@ -207,12 +207,24 @@ alternates:
     </p>
     <ul class="open-panels" aria-label="Exemples de panels ouverts récents">
       <li class="open-panel">
-        <span class="open-panel-year">ESSC 2024</span>
-        <span class="open-panel-title" lang="en">Knowledge Production on War</span>
+        <span class="open-panel-year">ESSC 2018</span>
+        <span class="open-panel-title" lang="en">Asymmetric Threats, Non-State Actors and Domestic Politics</span>
+      </li>
+      <li class="open-panel">
+        <span class="open-panel-year">ESSC 2019</span>
+        <span class="open-panel-title" lang="en">Climate Change and Security Actors</span>
+      </li>
+      <li class="open-panel">
+        <span class="open-panel-year">ESSC 2021</span>
+        <span class="open-panel-title" lang="en">Thinking European Security through India</span>
+      </li>
+      <li class="open-panel">
+        <span class="open-panel-year">ESSC 2023</span>
+        <span class="open-panel-title" lang="en">(In)security and Organized Crime in Latin America</span>
       </li>
       <li class="open-panel">
         <span class="open-panel-year">ESSC 2024</span>
-        <span class="open-panel-title" lang="en">Nuclear Deterrence and Nuclear Strategy in the Third Nuclear Age</span>
+        <span class="open-panel-title" lang="en">Knowledge Production on War</span>
       </li>
       <li class="open-panel">
         <span class="open-panel-year">ESSC 2026</span>

--- a/src/initiative.njk
+++ b/src/initiative.njk
@@ -206,12 +206,24 @@ alternates:
     </p>
     <ul class="open-panels" aria-label="Examples of recent open panels">
       <li class="open-panel">
-        <span class="open-panel-year">ESSC 2024</span>
-        <span class="open-panel-title">Knowledge Production on War</span>
+        <span class="open-panel-year">ESSC 2018</span>
+        <span class="open-panel-title">Asymmetric Threats, Non-State Actors and Domestic Politics</span>
+      </li>
+      <li class="open-panel">
+        <span class="open-panel-year">ESSC 2019</span>
+        <span class="open-panel-title">Climate Change and Security Actors</span>
+      </li>
+      <li class="open-panel">
+        <span class="open-panel-year">ESSC 2021</span>
+        <span class="open-panel-title">Thinking European Security through India</span>
+      </li>
+      <li class="open-panel">
+        <span class="open-panel-year">ESSC 2023</span>
+        <span class="open-panel-title">(In)security and Organized Crime in Latin America</span>
       </li>
       <li class="open-panel">
         <span class="open-panel-year">ESSC 2024</span>
-        <span class="open-panel-title">Nuclear Deterrence and Nuclear Strategy in the Third Nuclear Age</span>
+        <span class="open-panel-title">Knowledge Production on War</span>
       </li>
       <li class="open-panel">
         <span class="open-panel-year">ESSC 2026</span>


### PR DESCRIPTION
## What

Acts on Hugo Meijer's feedback on the open-panel examples on `/initiative`: they should make the **breadth** of past ESSCs concrete and sit clearly apart from the nine permanent thematic sections, with examples like non-state actors.

Recurated from `archiveProgrammes.js` (all final programmes) to span **2018 to 2026**:

| Year | Open panel |
|------|------------|
| 2018 | Asymmetric Threats, Non-State Actors and Domestic Politics |
| 2019 | Climate Change and Security Actors |
| 2021 | Thinking European Security through India |
| 2023 | (In)security and Organized Crime in Latin America |
| 2024 | Knowledge Production on War |
| 2026 | Cyber and Digital Sovereignty |

Drops the previous **Nuclear Deterrence … Third Nuclear Age** example, which overlapped the permanent WMD / non-proliferation section. Keeps *Knowledge Production on War* and *Cyber and Digital Sovereignty*.

## i18n

Panel titles stay in their English conference form, marked `lang="en"` on the FR and DE pages, matching the existing pattern. Only the intro line and `aria-label` are localised. `check-i18n-drift.py` clean (initiative fr/de marked fresh).

## Notes

- Reuses the existing `.open-panel` list component, no layout or brand change, so auto-merge is armed (i18n drift + CodeQL gate).
- The titles are verbatim from the transcribed final programmes.

Relates to #249 / #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)