### PR TITLE
build: pin CHANGELOG.md merge=union to stop dropped bullets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Append-only logs: on a merge or squash conflict, keep BOTH sides
+# instead of letting Git silently pick one. This is the mechanical
+# backstop for the recurring dropped-CHANGELOG-bullet problem documented
+# in CLAUDE.md §4: when two PRs each add a bullet to the same
+# [Unreleased] sub-section, the `union` driver concatenates both rather
+# than discarding the older one. Bullets may land slightly out of order
+# and are tidied at release time; a stray duplicate is obvious in the
+# release-prep review. Far better than a silent loss.
+CHANGELOG.md merge=union

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,21 @@ cross-check the `[Unreleased]` bullet count against
 bullet was lost. Use `git log -G '<headline phrase>' -- CHANGELOG.md`
 to trace where, then restore in the release-prep commit.
 
+**Mechanical backstop (`.gitattributes`).** A rule cannot stop a
+merge-time race, so the repo now pins `CHANGELOG.md merge=union` in
+`.gitattributes`. On a conflicting hunk Git keeps **both** sides
+instead of discarding one, so concurrent bullet additions concatenate
+rather than vanish. This is the primary defence. The cross-check
+recipe above is now the secondary net for the residual cases union
+does not catch (identical-line edits, or a host that bypasses the
+merge driver). Trade-off: union can land bullets slightly out of order
+or leave a stray duplicate. Both are visible and cheap to tidy in the
+release-prep review, unlike a silent loss. The NetSec sister repo
+should carry the same `.gitattributes` line (mirror it there too). If the drop ever
+recurs despite union, escalate to per-PR changelog fragments
+(`changelog.d/`, one file per PR, collated by `release.sh`), which
+removes the shared-file conflict entirely.
+
 ## 5. Release-time four-point cross-check (minor / major only)
 
 Every **minor (`X.Y.0` where `Y > prev`) or major (`X.0.0`)


### PR DESCRIPTION
## Problem

The concurrent-PR CHANGELOG drop (CLAUDE.md §4) keeps happening — most recently #339's bullet vanished when #345 squash-merged (restored in #348), and the same pattern has bitten on NetSec. CLAUDE.md §4 *documents* the trap, but **a written rule can't prevent a merge-time race.** The fix has to be mechanical.

## Fix

A one-line `.gitattributes`:

```
CHANGELOG.md merge=union
```

`union` is a built-in Git merge driver. On a conflicting hunk it keeps **both** sides instead of letting the merge/squash pick one, so two PRs each appending a bullet to the same `[Unreleased]` sub-section concatenate rather than one being discarded. GitHub honours built-in merge drivers for its merge and squash methods.

**Trade-off:** union can land bullets slightly out of order or leave a stray duplicate if two PRs add an identical line. Both are visible and trivially tidied in the release-prep review — unlike a silent loss, which only surfaces (if ever) via the manual count cross-check.

This becomes the **primary** defence; the §4 count cross-check (`[Unreleased]` bullets vs `git log --merges`) is demoted to the secondary net for the residual cases union can't catch.

## Also

- CLAUDE.md §4 updated to describe the backstop and note the NetSec sister repo should mirror the same `.gitattributes` line.
- If a drop ever recurs *despite* union, the documented escalation is per-PR changelog fragments (`changelog.d/`), which removes the shared-file conflict entirely.

Docs + config only, no site change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)