### PR TITLE
fix(qa): style search + press kit, robust iOS film, archive consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 - **`/2025` now opens with the conference, not the programme.** The page leads with a short review of the Thessaloniki edition sitting beside the conference film (the film is no longer a standalone "Conference film" section lower down), then the keynote and round tables, then the full programme in the grid UI, then the photo gallery. The programme used to be the first thing on the page as a flat screenshot.
 - **Conference photo galleries crop to a consistent shape.** The `/2025`, `/2021` and `/2019` galleries (and the Joint Policy Workshop photos) now use a shared `.photo-gallery` grid where every tile holds a uniform 3:2 landscape box with `object-fit: cover`, instead of letting each photo set its own height. This fixes the ragged, oddly-cropped look from mixed source dimensions.
 - **The 2025 conference film now also runs on the `/past` conferences page.** The same `film-embed.njk` player sits in a portrait column beside the year-by-year archive cards on desktop, staying in view as the list scrolls, and stacks below the cards on mobile. It reuses the self-hosted GitHub Release asset and the scroll-into-view muted autoplay already used on `/2025`, so nothing downloads until it enters the viewport. Part of [#330](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/330).
+- **On `/past`, the conference film now comes before the list of past conferences.** It stacks on top on mobile and sits as the left column on desktop, rather than trailing after the list.
+- **`/2025` opens with the conference film folded into a short intro** instead of a separate "Conference film" section lower down, and the archive pages now follow a consistent section order. The `/2021` page drops an off-template "Read more about the EISS Board" signpost, and `/2019` drops a redundant open-and-closed-panels explainer (now covered on `/initiative`) with its gallery moved below the programme.
 
 ### Removed
 
@@ -92,6 +94,10 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ### Fixed
 
+- **The site-search modal and the press kit now actually render.** Both features had shipped with complete markup, JavaScript, and translated strings, but none of the classes they referenced were defined in `site.css`, so the search overlay opened as an unstyled block and the press-kit logos and swatches spilled full-width. The search dialog is now a centred, scrollable panel (a full-screen sheet on phones) with styled results and highlighted excerpts, and the press kit lays out as proper logo, swatch, and do/don't grids with contained images.
+- **The press kit is now reachable from the footer** (legal-links row, EN + FR + DE), not just from the visual sitemap.
+- **The 2025 conference film now plays on iOS.** Muted inline autoplay is started with the `muted` property set and the source `load()`-ed (Safari needs both), and when a browser still blocks autoplay (iOS Low Power Mode) a centre play button appears so a tap can start it. The `webkit-playsinline` attribute is set for older iOS.
+- **The 2025 film's *Watch on YouTube* link now works.** It pointed at a Shorts URL that did not resolve; it now links the standard watch URL with the conference playlist.
 - **`/2019` was mislabelled the "2nd" Annual Conference.** It was the **3rd** (2017 inaugural, 2018 second, 2019 third), confirmed by the final programme and the 2019 call for papers, and consistent with the canonical ordinals in `conferences.js`. Corrected the page eyebrow and meta description.
 - **Removed personal chair email addresses from the 2022 panels data.** `src/_data/panels2022.js` carried `[at]`-obfuscated personal emails in the chair fields. They were already stripped from the rendered page, but sat in the committed source; they are now gone from the repository entirely (chair lines read "Chair: Name, Institution").
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -517,6 +517,37 @@ the CLI does not expose this. Issues are added manually via
 If more than ~20% of items in any view are `Done`, or new entries stop
 getting Effort tags, archive the Project rather than letting it drift.
 
+## 14. Ship-completeness: a green build is not "it works"
+
+`npx @11ty/eleventy` succeeding proves the templates *compile*, not that
+the feature *renders*. A whole feature can ship with complete markup,
+JS, and i18n strings and still be invisible or broken in the browser.
+The QA pass that added this rule found two such cases live on the site:
+the **press kit** and the **site-search modal** had every class name in
+their markup but **not one of those classes was defined in
+`site.css`**, so the search overlay rendered as an unstyled block and
+the press-kit logos spilled full-width. Both had passed CI and shipped
+"done" (this is the same failure mode the NetSec sister repo hit with
+its undefined `.grid-2`).
+
+Before calling any UI work done:
+
+- **Grep that every new class the markup references is actually defined**
+  in `site.css`. New `.foo` in a `.njk` with zero hits in the stylesheet
+  is the tell. A cheap CI lint could assert this (tracked separately).
+- **Render it.** Build, serve, and check the component in the preview at
+  desktop *and* a phone width. For JS-driven UI (modals, video, menus),
+  exercise the interaction, don't just confirm the element exists.
+- **Test the actual device class the user reported**, not a proxy.
+  iOS Safari/Chrome autoplay, tap targets, and the collapsed mobile nav
+  behave differently from a desktop window resized narrow.
+- When a feature is built by a parallel/worktree workflow, treat its CSS
+  and its render state as the first things to verify on merge: a fan-out
+  agent that wrote the markup may never have written the styles.
+
+The lesson generalises: verification must target the user-visible
+behaviour the change promises, on the surface the user actually uses.
+
 ---
 
 *This file is short on purpose. If you need to add a rule, add it

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -88,13 +88,13 @@
     "src/past.njk": {
       "fr": {
         "file": "src/past.fr.njk",
-        "source_sha1": "bb9ac797479550899f3cc0a2cecd2f9903747478",
+        "source_sha1": "164b6180671e1ea86f1f082fe851cc2373eebfcc",
         "translated_on": "2026-06-01",
         "status": "beta"
       },
       "de": {
         "file": "src/past.de.njk",
-        "source_sha1": "bb9ac797479550899f3cc0a2cecd2f9903747478",
+        "source_sha1": "164b6180671e1ea86f1f082fe851cc2373eebfcc",
         "translated_on": "2026-06-01",
         "status": "beta"
       }

--- a/src/2019.njk
+++ b/src/2019.njk
@@ -28,9 +28,47 @@ status: archive
   </div>
 </section>
 
+<section class="section">
+  <div class="container">
+    <article class="card" style="padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8));">
+      <div class="featured-eyebrow">Programme highlights</div>
+      <h2>Keynote &amp; introductory remarks</h2>
+      <p><strong>Introductory remarks:</strong> Hugo Meijer and Alain Dieckhoff, Sciences Po CERI.</p>
+      <p><strong>Keynote:</strong> Stephen Brooks (Dartmouth College) and Barry Posen (Massachusetts Institute of Technology).</p>
+      <p style="margin-top: var(--space-5); margin-bottom: 0;">
+        <a class="btn btn-secondary btn-sm"
+           href="/assets/files/Programme2019.pdf"
+           target="_blank" rel="noopener">
+          Download full programme (PDF)
+        </a>
+      </p>
+    </article>
+  </div>
+</section>
+
+{# Final programme, rendered in the SAME grid UI as the live ESSC 2026
+   programme (archive-programme.njk + archiveProgrammes.js). #}
+{% set archiveSlug = "2019" %}
+{% include "archive-programme.njk" %}
+
+<section class="section-tight" aria-labelledby="recordings-2019-title">
+  <div class="container">
+    <h2 id="recordings-2019-title" style="margin-bottom: var(--space-5);">Session recordings</h2>
+    <p class="muted" style="max-width: 44rem; margin-bottom: var(--space-5);">
+      Selected sessions from EISS 2019 are available on the EISS YouTube channel
+      (<a href="https://www.youtube.com/@eiss-europe/" target="_blank" rel="noopener">@eiss-europe</a>).
+      Clicking play loads the YouTube iframe; before that, no YouTube cookies are set.
+    </p>
+    {%- set youtubeId = "PLkI2R8FsFqV4_TVOCV5qfPFAmZn1KbWGv" -%}
+    {%- set youtubeIsList = true -%}
+    {%- set youtubeTitle = "EISS 2019 — Paris, session recordings" -%}
+    {% include "youtube-embed.njk" %}
+  </div>
+</section>
+
 <section class="section-tight">
   <div class="container">
-    <h2 style="margin-bottom: var(--space-5);">Photos from the conference</h2>
+    <h2 style="margin-bottom: var(--space-5);">Conference gallery</h2>
     <div class="photo-gallery">
       <figure>
         <img src="/assets/images/dsc-263-900x596.jpg" alt="EISS 2019 conference scene." loading="lazy">
@@ -65,63 +103,6 @@ status: archive
     </div>
   </div>
 </section>
-
-<section class="section">
-  <div class="container">
-    <article class="card" style="padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8));">
-      <div class="featured-eyebrow">Programme highlights</div>
-      <h2>Keynote &amp; introductory remarks</h2>
-      <p><strong>Introductory remarks:</strong> Hugo Meijer and Alain Dieckhoff, Sciences Po CERI.</p>
-      <p><strong>Keynote:</strong> Stephen Brooks (Dartmouth College) and Barry Posen (Massachusetts Institute of Technology).</p>
-      <p style="margin-top: var(--space-5); margin-bottom: 0;">
-        <a class="btn btn-secondary btn-sm"
-           href="/assets/files/Programme2019.pdf"
-           target="_blank" rel="noopener">
-          Download full programme (PDF)
-        </a>
-      </p>
-    </article>
-  </div>
-</section>
-
-<section class="section-tight" aria-labelledby="recordings-2019-title">
-  <div class="container">
-    <h2 id="recordings-2019-title" style="margin-bottom: var(--space-5);">Session recordings</h2>
-    <p class="muted" style="max-width: 44rem; margin-bottom: var(--space-5);">
-      Selected sessions from EISS 2019 are available on the EISS YouTube channel
-      (<a href="https://www.youtube.com/@eiss-europe/" target="_blank" rel="noopener">@eiss-europe</a>).
-      Clicking play loads the YouTube iframe; before that, no YouTube cookies are set.
-    </p>
-    {%- set youtubeId = "PLkI2R8FsFqV4_TVOCV5qfPFAmZn1KbWGv" -%}
-    {%- set youtubeIsList = true -%}
-    {%- set youtubeTitle = "EISS 2019 — Paris, session recordings" -%}
-    {% include "youtube-embed.njk" %}
-  </div>
-</section>
-
-<section class="section-tight">
-  <div class="container">
-    <article class="prose">
-      <h2>Open and closed panels</h2>
-      <p>The EISS Conference features both "closed" and "open" panels.</p>
-      <p>
-        <strong>"Closed" panels</strong> focus on themes decided by the EISS. Each panel includes
-        four papers and the chair serves as discussant.
-      </p>
-      <p>
-        <strong>"Open" panels:</strong> participants propose a panel's title, a chair, and four
-        speakers. The chair serves as discussant. The "open" panels are meant to broaden the range
-        of existing themes in the EISS and to provide greater latitude to the participants to
-        contribute to the definition of the conference content.
-      </p>
-    </article>
-  </div>
-</section>
-
-{# Final programme, rendered in the SAME grid UI as the live ESSC 2026
-   programme (archive-programme.njk + archiveProgrammes.js). #}
-{% set archiveSlug = "2019" %}
-{% include "archive-programme.njk" %}
 
 <section class="section">
   <div class="container">

--- a/src/2021.njk
+++ b/src/2021.njk
@@ -84,16 +84,3 @@ status: archive
     </article>
   </div>
 </section>
-
-<section class="section-tight">
-  <div class="container">
-    <article class="card" style="padding: clamp(var(--space-6), 2vw + 1rem, var(--space-8));">
-      <div class="featured-eyebrow">About</div>
-      <h2>Read more about the EISS Board</h2>
-      <p class="muted">The Initiative is steered by an international and diverse board.</p>
-      <p style="margin-top: var(--space-4);">
-        <a class="btn btn-secondary" href="/board.html">See the people behind EISS</a>
-      </p>
-    </article>
-  </div>
-</section>

--- a/src/2025.njk
+++ b/src/2025.njk
@@ -44,7 +44,7 @@ status: archive
       </div>
       {%- set filmSrc = "https://github.com/EISSeuropa/EISSeuropa.github.io/releases/download/media-assets/essc-2025.mp4" -%}
       {%- set filmPoster = "/assets/images/2025/essc-2025-film-poster.jpg" -%}
-      {%- set filmYoutube = "https://youtube.com/shorts/CFtUrpwgYXY" -%}
+      {%- set filmYoutube = "https://www.youtube.com/watch?v=CFtUrpwgYXY&list=PLkI2R8FsFqV5cFsuE4s-A_0RHQMo2yq0_" -%}
       {%- set filmCaption = "ESSC 2025, Thessaloniki." -%}
       {% include "film-embed.njk" %}
     </div>

--- a/src/_data/i18n.js
+++ b/src/_data/i18n.js
@@ -106,6 +106,7 @@ const locales = {
       tapForSound: "Tap for sound",
       toggleSound: "Toggle sound",
       watchOnYouTube: "Watch on YouTube",
+      play: "Play the film",
     },
 
     pressKit: {
@@ -203,6 +204,7 @@ const locales = {
         sitemap: "Site map",
         roadmap: "Roadmap",
         licensing: "Licensing",
+        pressKit: "Press kit",
       },
       // Authorship credit shown on the very last line of the footer, next
       // to the legal-links row. The name itself links to the author's
@@ -468,6 +470,7 @@ const locales = {
       tapForSound: "Touchez pour le son",
       toggleSound: "Activer ou couper le son",
       watchOnYouTube: "Voir sur YouTube",
+      play: "Lire le film",
     },
 
     pressKit: {
@@ -565,6 +568,7 @@ const locales = {
         sitemap: "Plan du site",
         roadmap: "Feuille de route",
         licensing: "Licences",
+        pressKit: "Kit presse",
       },
       authorship: {
         prefix: "Site conçu et développé par",
@@ -778,6 +782,7 @@ const locales = {
       tapForSound: "Für Ton tippen",
       toggleSound: "Ton ein- oder ausschalten",
       watchOnYouTube: "Auf YouTube ansehen",
+      play: "Film abspielen",
     },
 
     pressKit: {
@@ -875,6 +880,7 @@ const locales = {
         sitemap: "Sitemap",
         roadmap: "Roadmap",
         licensing: "Lizenzen",
+        pressKit: "Pressekit",
       },
       authorship: {
         prefix: "Website konzipiert und entwickelt von",

--- a/src/_includes/film-embed.njk
+++ b/src/_includes/film-embed.njk
@@ -16,10 +16,13 @@
 {%- set t = i18n[_lang] -%}
 <figure class="film">
   <div class="film-frame">
-    <video class="film-video" playsinline muted loop preload="none"
+    <video class="film-video" playsinline webkit-playsinline muted loop preload="none"
            poster="{{ filmPoster | bust }}"
            data-film="{{ filmSrc }}"
            {% if filmCaption %}aria-label="{{ filmCaption }}"{% endif %}></video>
+    <button class="film-play" type="button" data-film-play hidden aria-label="{{ t.film.play }}">
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>
+    </button>
     <span class="film-hint" data-film-hint>{{ icon("volume-2") }} {{ t.film.tapForSound }}</span>
     <button class="film-sound" type="button" data-film-sound aria-pressed="false" aria-label="{{ t.film.toggleSound }}">
       <span class="film-sound-muted" aria-hidden="true">{{ icon("volume-x") }}</span>

--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -88,7 +88,8 @@
           <a href="{{ '/accessibility.html' | localizedHref(lang) }}">{{ t.footer.legalLinks.accessibility }}</a> ·
           <a href="{{ '/sitemap.html' | localizedHref(lang) }}">{{ t.footer.legalLinks.sitemap }}</a> ·
           <a href="{{ '/licensing.html' | localizedHref(lang) }}">{{ t.footer.legalLinks.licensing }}</a> ·
-          <a href="{{ '/roadmap.html' | localizedHref(lang) }}">{{ t.footer.legalLinks.roadmap }}</a>
+          <a href="{{ '/roadmap.html' | localizedHref(lang) }}">{{ t.footer.legalLinks.roadmap }}</a> ·
+          <a href="{{ '/press-kit.html' | localizedHref(lang) }}">{{ t.footer.legalLinks.pressKit }}</a>
         </span>
         {# Authorship credit. The name links to the author's board card
            via the slug from src/_data/board.json. Keep this discreet —

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -3327,6 +3327,30 @@ h4 { font-size: var(--fs-lg); }
 .film-sound-on { display: none; }
 .film-sound[aria-pressed="true"] .film-sound-muted { display: none; }
 .film-sound[aria-pressed="true"] .film-sound-on { display: inline-flex; }
+/* Centre play affordance. Hidden while the video autoplays; theme.js
+   reveals it when muted autoplay is blocked (iOS Low Power Mode, Safari
+   autoplay policy) so there is always a clear tap target to start the
+   film. A tap is a user gesture, which iOS always honours. */
+.film-play {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: grid;
+  place-items: center;
+  width: 4rem;
+  height: 4rem;
+  padding: 0;
+  border: 1px solid hsl(0 0% 100% / 0.3);
+  border-radius: var(--radius-full);
+  background: hsl(0 0% 0% / 0.55);
+  color: #fff;
+  cursor: pointer;
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+}
+.film-play[hidden] { display: none; }
+.film-play svg { width: 1.75rem; height: 1.75rem; margin-left: 2px; }
 .film-caption { margin-top: var(--space-3); text-align: center; font-size: var(--fs-sm); }
 
 /* Subtle "tap for sound" hint, bottom-left so it never collides with the
@@ -3365,11 +3389,228 @@ h4 { font-size: var(--fs-lg); }
    column; the film holds a fixed portrait column and stays in view as
    the list scrolls. Single column on mobile (film below the cards). */
 .archive-layout { display: grid; gap: var(--space-6); align-items: start; }
+/* The film comes before the conference list on every breakpoint: stacked
+   on top on mobile, the left column on desktop. `order` reorders without
+   needing the markup swapped across the three locale pages. */
+.archive-film { order: -1; }
 @media (min-width: 56rem) {
-  .archive-layout { grid-template-columns: 1fr minmax(280px, 340px); }
+  .archive-layout { grid-template-columns: minmax(280px, 340px) 1fr; }
   .archive-film { position: sticky; top: 6rem; }
   .archive-film .film { margin: 0; }
   .archive-film .film-caption { text-align: left; }
+}
+
+/* ---------- site search modal ----------
+   The markup (search-modal.njk) and search.js shipped without any CSS,
+   so the overlay rendered as an unstyled block. search.js toggles
+   `overlay.hidden` and adds `body.search-open`. The [hidden] guard below
+   is essential: the base `display: flex` would otherwise defeat the
+   native `hidden` attribute and leave the dialog permanently visible. */
+.search-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: clamp(var(--space-4), 8vh, var(--space-8)) var(--space-4);
+  background: rgba(8, 12, 20, 0.55);
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
+  overflow-y: auto;
+}
+.search-overlay[hidden] { display: none; }
+body.search-open { overflow: hidden; }
+.search-dialog {
+  width: 100%;
+  max-width: 40rem;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-2);
+  overflow: hidden;
+}
+.search-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border);
+}
+.search-bar-icon { display: inline-flex; flex: none; color: var(--text-muted); }
+.search-bar-icon svg { width: 1.25rem; height: 1.25rem; }
+.search-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  padding: var(--space-2) 0;
+  font-family: inherit;
+  font-size: var(--fs-md);
+  color: var(--text);
+}
+.search-input:focus { outline: none; }
+.search-input::-webkit-search-cancel-button { -webkit-appearance: none; }
+.search-close { flex: none; }
+.search-status {
+  padding: var(--space-3) var(--space-4) 0;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+}
+.search-status:empty { display: none; }
+.search-results {
+  list-style: none;
+  margin: 0;
+  padding: var(--space-2);
+  max-height: min(60vh, 28rem);
+  overflow-y: auto;
+}
+.search-results:empty { padding: 0; }
+.search-result { margin: 0; }
+.search-result-link {
+  display: block;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  color: inherit;
+}
+.search-result-link:hover,
+.search-result-link:focus-visible {
+  background: var(--bg-tinted);
+  outline: none;
+}
+.search-result-title {
+  display: block;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 2px;
+}
+.search-result-excerpt {
+  display: block;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  line-height: var(--lh-snug);
+}
+.search-result-excerpt mark {
+  background: rgba(115, 202, 255, 0.28);
+  color: inherit;
+  border-radius: 2px;
+  padding: 0 2px;
+}
+.search-hint {
+  margin: 0;
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--border);
+  font-size: var(--fs-xs);
+  color: var(--text-subtle);
+}
+/* Full-screen sheet on phones; the keyboard hint is irrelevant on touch. */
+@media (max-width: 32rem) {
+  .search-overlay { padding: 0; }
+  .search-dialog {
+    max-width: none;
+    min-height: 100%;
+    border: 0;
+    border-radius: 0;
+  }
+  .search-results { max-height: none; }
+  .search-hint { display: none; }
+}
+
+/* ---------- press kit ----------
+   Like the search modal, the press-kit markup shipped referencing class
+   names that were never defined, so logos rendered at native size and
+   the page had no grid structure. */
+.press-logo-grid,
+.press-swatch-grid {
+  list-style: none;
+  margin: var(--space-5) 0 var(--space-7);
+  padding: 0;
+  display: grid;
+  gap: var(--space-5);
+}
+.press-logo-grid { grid-template-columns: repeat(auto-fit, minmax(min(16rem, 100%), 1fr)); }
+.press-swatch-grid { grid-template-columns: repeat(auto-fit, minmax(min(12rem, 100%), 1fr)); }
+.press-logo-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-5);
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-1);
+}
+.press-logo-preview {
+  display: grid;
+  place-items: center;
+  aspect-ratio: 16 / 9;
+  padding: var(--space-5);
+  background: var(--bg-tinted);
+  border-radius: var(--radius-sm);
+}
+.press-logo-preview svg,
+.press-logo-preview img {
+  display: block;
+  width: auto;
+  height: auto;
+  max-width: 100%;
+  max-height: 8rem;
+}
+.press-logo-card h3 { margin: 0; font-size: var(--fs-md); }
+.press-logo-card p { margin: 0; flex: 1 1 auto; color: var(--text-muted); font-size: var(--fs-sm); }
+.press-logo-card .btn { align-self: flex-start; }
+.press-swatch {
+  overflow: hidden;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+.press-swatch-chip { display: block; width: 100%; height: 5rem; }
+.press-swatch h3 { margin: var(--space-3) var(--space-4) 0; font-size: var(--fs-md); }
+.press-swatch code { display: block; margin: var(--space-1) var(--space-4) 0; font-size: var(--fs-sm); color: var(--text-muted); }
+.press-swatch p { margin: var(--space-2) var(--space-4) var(--space-4); font-size: var(--fs-sm); color: var(--text-muted); }
+.press-type-sample {
+  margin: var(--space-4) 0 var(--space-7);
+  font-size: clamp(3rem, 10vw, 6rem);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: var(--tracking-tight);
+}
+.press-dodont {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(18rem, 100%), 1fr));
+  gap: var(--space-5);
+  margin: var(--space-5) 0 var(--space-7);
+}
+.press-do,
+.press-dont {
+  padding: var(--space-5);
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+.press-do { border-left: 3px solid #1a8754; }
+.press-dont { border-left: 3px solid #c02929; }
+.press-do h3,
+.press-dont h3 { margin: 0 0 var(--space-3); font-size: var(--fs-md); }
+.press-dodont ul { margin: 0; padding-left: 1.1rem; color: var(--text-muted); font-size: var(--fs-sm); }
+.press-dodont li { margin-bottom: var(--space-2); }
+.press-attribution {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  margin: var(--space-4) 0 var(--space-7);
+}
+.press-attribution code {
+  flex: 1 1 18rem;
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-tinted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  font-size: var(--fs-sm);
+  word-break: break-word;
 }
 
 /* ---------- utilities ---------- */

--- a/src/assets/js/theme.js
+++ b/src/assets/js/theme.js
@@ -358,39 +358,69 @@
     if (!v) return;
     var btn = fig.querySelector("[data-film-sound]");
     var hint = fig.querySelector("[data-film-hint]");
+    var playBtn = fig.querySelector("[data-film-play]");
     var loaded = false;
-    function load() { if (loaded) return; loaded = true; v.src = v.getAttribute("data-film"); }
-    function tryPlay() { var p = v.play(); if (p && p.catch) p.catch(function () {}); }
+    // iOS only honours muted inline autoplay if `muted` is set as a
+    // property (not just the attribute) and the source is (re)loaded
+    // before play(). Setting src on a preload="none" element without a
+    // load() leaves Safari with nothing to play.
+    function load() {
+      if (loaded) return;
+      loaded = true;
+      v.muted = true;
+      v.setAttribute("muted", "");
+      v.src = v.getAttribute("data-film");
+      v.load();
+    }
+    function showPlay(on) { if (playBtn) playBtn.hidden = !on; }
+    function tryPlay() {
+      load();
+      var p = v.play();
+      // If the browser blocks muted autoplay (iOS Low Power Mode, Safari
+      // policy), surface the centre play button so a tap can start it.
+      if (p && p.then) { p.then(function () { showPlay(false); }, function () { showPlay(true); }); }
+    }
     function dropHint() { if (hint) hint.hidden = true; }
+    function toggle() { if (v.paused) { tryPlay(); } else { v.pause(); } dropHint(); }
 
     if (reduce) {
       load();
       v.controls = true;
       if (btn) btn.hidden = true;
+      showPlay(false);
       dropHint();
-    } else {
-      if ("IntersectionObserver" in window) {
-        new IntersectionObserver(function (entries) {
-          entries.forEach(function (e) {
-            if (e.isIntersecting) { load(); tryPlay(); }
-            else if (!v.paused) { v.pause(); }
-          });
-        }, { threshold: 0.4 }).observe(v);
-      } else {
-        load();
-        tryPlay();
-      }
-      v.addEventListener("click", function () { v.paused ? tryPlay() : v.pause(); dropHint(); });
-      if (btn) {
-        btn.addEventListener("click", function () {
-          v.muted = !v.muted;
-          if (!v.muted) tryPlay();
-          btn.setAttribute("aria-pressed", String(!v.muted));
-          dropHint();
-        });
-      }
-      // Fade the hint after a few seconds even without interaction.
-      if (hint) setTimeout(dropHint, 6000);
+      return;
     }
+
+    // Keep the overlay in sync with the real play state.
+    v.addEventListener("play", function () { showPlay(false); });
+    v.addEventListener("pause", function () { showPlay(true); });
+
+    if ("IntersectionObserver" in window) {
+      new IntersectionObserver(function (entries) {
+        entries.forEach(function (e) {
+          if (e.isIntersecting) { tryPlay(); }
+          else if (!v.paused) { v.pause(); }
+        });
+      }, { threshold: 0.4 }).observe(v);
+    } else {
+      tryPlay();
+    }
+
+    v.addEventListener("click", toggle);
+    if (playBtn) {
+      playBtn.addEventListener("click", function (e) { e.stopPropagation(); toggle(); });
+    }
+    if (btn) {
+      btn.addEventListener("click", function (e) {
+        e.stopPropagation();
+        v.muted = !v.muted;
+        if (!v.muted) tryPlay();
+        btn.setAttribute("aria-pressed", String(!v.muted));
+        dropHint();
+      });
+    }
+    // Fade the hint after a few seconds even without interaction.
+    if (hint) setTimeout(dropHint, 6000);
   });
 })();

--- a/src/past.de.njk
+++ b/src/past.de.njk
@@ -82,7 +82,7 @@ alternates:
     <div class="archive-film">
       {%- set filmSrc = "https://github.com/EISSeuropa/EISSeuropa.github.io/releases/download/media-assets/essc-2025.mp4" -%}
       {%- set filmPoster = "/assets/images/2025/essc-2025-film-poster.jpg" -%}
-      {%- set filmYoutube = "https://youtube.com/shorts/CFtUrpwgYXY" -%}
+      {%- set filmYoutube = "https://www.youtube.com/watch?v=CFtUrpwgYXY&list=PLkI2R8FsFqV5cFsuE4s-A_0RHQMo2yq0_" -%}
       {%- set filmCaption = "ESSC 2025 · Thessaloniki" -%}
       {% include "film-embed.njk" %}
     </div>

--- a/src/past.fr.njk
+++ b/src/past.fr.njk
@@ -82,7 +82,7 @@ alternates:
     <div class="archive-film">
       {%- set filmSrc = "https://github.com/EISSeuropa/EISSeuropa.github.io/releases/download/media-assets/essc-2025.mp4" -%}
       {%- set filmPoster = "/assets/images/2025/essc-2025-film-poster.jpg" -%}
-      {%- set filmYoutube = "https://youtube.com/shorts/CFtUrpwgYXY" -%}
+      {%- set filmYoutube = "https://www.youtube.com/watch?v=CFtUrpwgYXY&list=PLkI2R8FsFqV5cFsuE4s-A_0RHQMo2yq0_" -%}
       {%- set filmCaption = "ESSC 2025 · Thessaloniki" -%}
       {% include "film-embed.njk" %}
     </div>

--- a/src/past.njk
+++ b/src/past.njk
@@ -83,7 +83,7 @@ alternates:
     <div class="archive-film">
       {%- set filmSrc = "https://github.com/EISSeuropa/EISSeuropa.github.io/releases/download/media-assets/essc-2025.mp4" -%}
       {%- set filmPoster = "/assets/images/2025/essc-2025-film-poster.jpg" -%}
-      {%- set filmYoutube = "https://youtube.com/shorts/CFtUrpwgYXY" -%}
+      {%- set filmYoutube = "https://www.youtube.com/watch?v=CFtUrpwgYXY&list=PLkI2R8FsFqV5cFsuE4s-A_0RHQMo2yq0_" -%}
       {%- set filmCaption = "ESSC 2025 · Thessaloniki" -%}
       {% include "film-embed.njk" %}
     </div>


### PR DESCRIPTION
Deep QA pass across the four reported problem areas. **Visual change → auto-merge not armed (CLAUDE.md §2); please eyeball the deploy preview** (`/press-kit`, the header search modal, `/2025`, `/past`, `/2019`, `/2021`) on desktop and a phone width.

## 1. Press kit
- **Root cause: the page shipped with zero CSS.** Every class its markup referenced (`.press-logo-grid`, `.press-swatch`, `.press-dodont`, …) was undefined in `site.css`, so logos rendered at native size and the page had no structure. Wrote the missing CSS: logo grid with contained previews, colour-swatch grid, do/don't columns, typography sample, attribution row.
- **Footer link added** (legal-links row, EN/FR/DE) — it was only reachable from the visual sitemap before.
- Mobile: grids collapse to one column.

## 2. Site search
- **Same root cause: no CSS.** The overlay opened as an unstyled block. Wrote the modal CSS: centred scrollable dialog, styled input/results, highlighted `<mark>` excerpts, and a **full-screen sheet on phones**. The `.search-overlay[hidden]` guard keeps `display:flex` from defeating the native `hidden` attribute.
- Verified: `display:none` when closed, `flex` when opened (640px dialog).
- Follow-up (does not block): make individual board members searchable via Pagefind bio stubs (NetSec parity) — **#353**.

## 3. 2025 conference film
- **iOS playback:** set the `muted` *property* and `load()` the source before `play()` (Safari needs both), add `webkit-playsinline`, and reveal a **centre play button** when autoplay is blocked (iOS Low Power Mode) so a tap starts it.
- **YouTube link fixed:** the dead Shorts URL → the standard watch URL with the conference playlist (`/2025` + `/past` ×3 locales).
- **`/past` order:** the film now comes **before** the conference list (top on mobile, left column on desktop) via `order: -1`.

## 4. Archive consistency
- Removed the off-template **"EISS Board" signpost** from `/2021`.
- `/2019`: dropped a redundant open/closed-panels explainer (now on `/initiative`), moved the gallery below the programme, canonical section order.
- `/2022` already matched the intro-card → grid pattern; left as-is.

## i18n
`footer.legalLinks.pressKit` and `film.play` added in all three locales; `past` fr/de re-blessed after the YouTube-link change. `check-i18n-drift.py` clean. (Archive year pages are EN-only.)

## Lessons-learned (CLAUDE.md §14)
Both broken features had passed CI and shipped "done" — a green build proves templates *compile*, not that a feature *renders*. New rule: grep that every class new markup references is defined, render it in a preview at desktop + phone, and test the real device class the user reported. A multi-persona UX user-path audit (desktop + mobile) is running; its findings will come as a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)