### PR TITLE
feat(initiative): link to the board from the closing CTA (UX audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ audit trail. Same content, terser.
 - (one-line pointer bullets, what not why)
 
 #### Changed
+
+- **`/initiative` now links straight to the board.** A "Meet the people behind EISS" button joins the closing call-to-action strip (EN/FR/DE), so a visitor reading about the organisation can reach `/board` without returning to the menu. Acts on the UX audit ([#357](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/357)).
 - (…)
 
 #### Fixed

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -18,13 +18,13 @@
     "src/initiative.njk": {
       "fr": {
         "file": "src/initiative.fr.njk",
-        "source_sha1": "f55bf059af6f6dbffb19fed45ff070586143e773",
+        "source_sha1": "9965664d9d353606417fe1040d63821953bc197b",
         "translated_on": "2026-06-01",
         "status": "beta"
       },
       "de": {
         "file": "src/initiative.de.njk",
-        "source_sha1": "f55bf059af6f6dbffb19fed45ff070586143e773",
+        "source_sha1": "9965664d9d353606417fe1040d63821953bc197b",
         "translated_on": "2026-06-01",
         "status": "beta"
       }

--- a/src/initiative.de.njk
+++ b/src/initiative.de.njk
@@ -512,6 +512,7 @@ alternates:
     <h2 id="cta-title" class="sr-only">In Kontakt bleiben</h2>
     <div class="cta-strip">
       <a class="btn btn-primary" href="/membership.de.html">{{ icon("user-plus") }} Mitglied werden</a>
+      <a class="btn btn-secondary" href="/board.de.html">{{ icon("users-round") }} Das Team kennenlernen</a>
       <a class="btn btn-secondary" href="{{ site.newsletterUrl }}" target="_blank" rel="noopener">
         {{ icon("mail") }} Newsletter
       </a>

--- a/src/initiative.fr.njk
+++ b/src/initiative.fr.njk
@@ -510,6 +510,7 @@ alternates:
     <h2 id="cta-title" class="sr-only">Restons en contact</h2>
     <div class="cta-strip">
       <a class="btn btn-primary" href="/membership.fr.html">{{ icon("user-plus") }} Devenir membre</a>
+      <a class="btn btn-secondary" href="/board.fr.html">{{ icon("users-round") }} Découvrir l’équipe</a>
       <a class="btn btn-secondary" href="{{ site.newsletterUrl }}" target="_blank" rel="noopener">
         {{ icon("mail") }} Newsletter
       </a>

--- a/src/initiative.njk
+++ b/src/initiative.njk
@@ -521,6 +521,7 @@ alternates:
     <h2 id="cta-title" class="sr-only">Stay in touch</h2>
     <div class="cta-strip">
       <a class="btn btn-primary" href="/membership.html">{{ icon("user-plus") }} Become a member</a>
+      <a class="btn btn-secondary" href="/board.html">{{ icon("users-round") }} Meet the people behind EISS</a>
       <a class="btn btn-secondary" href="{{ site.newsletterUrl }}" target="_blank" rel="noopener">
         {{ icon("mail") }} Newsletter
       </a>


### PR DESCRIPTION
Acts on the actionable part of **#357** (UX audit, partner-institution + person-search personas): there was no in-page link from `/initiative` to `/board`, so a visitor reading about EISS had to return to the menu to find the people/governance.

## Change
Adds a **"Meet the people behind EISS"** secondary button to the closing CTA strip on `/initiative` (EN/FR/DE → `/board`, `/board.fr`, `/board.de`). Translations re-blessed, drift clean.

## Deliberately not done (with reasoning)
- **Press kit in primary nav:** a press kit conventionally lives in the footer (linked since #355) and the visual sitemap. Adding it to the already 7-item nav would crowd it. Footer + sitemap is the right convention.
- **Rename "People" nav label:** the board page titles itself "The People" / "L'équipe" / "Die Personen", so a "People & Board" nav label would mismatch the page. The in-page link above fixes the org→governance discoverability more directly.

Happy to revisit either if you'd prefer them — they're one-liners.

Visual change → auto-merge not armed; please glance at the `/initiative` CTA in the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)