### PR TITLE
feat(ux): registration status on homepage + /2026 follow-along note (#356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ audit trail. Same content, terser.
 - (one-line pointer bullets, what not why)
 
 #### Changed
+
+- **The homepage now shows the next conference’s registration status, and `/2026` no longer dead-ends when registration closes.** The featured card on the homepage surfaces the registration badge (date + venue + status, so a quick check, especially on mobile, needs no click). On `/2026`, when registration is closed a short note under the hero reframes it (“you can still follow along: the programme below marks the livestreamed sessions”) instead of leaving “Registration closed” as a terminus. Hand-translated (EN/FR/DE). Acts on the UX audit ([#356](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/356)).
 - (…)
 
 #### Fixed

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -4,13 +4,13 @@
     "src/index.njk": {
       "fr": {
         "file": "src/index.fr.njk",
-        "source_sha1": "0442f1b82d31a89f31734a32e6de5cde81651a2a",
+        "source_sha1": "0dbf22b3cb6176059dffd833d7abf9418214228b",
         "translated_on": "2026-06-01",
         "status": "beta"
       },
       "de": {
         "file": "src/index.de.njk",
-        "source_sha1": "0442f1b82d31a89f31734a32e6de5cde81651a2a",
+        "source_sha1": "0dbf22b3cb6176059dffd833d7abf9418214228b",
         "translated_on": "2026-06-01",
         "status": "beta"
       }
@@ -116,13 +116,13 @@
     "src/2026.njk": {
       "fr": {
         "file": "src/2026.fr.njk",
-        "source_sha1": "4e45bdaf14f34eaeaa9d0e3fadd93fc872d8bee5",
+        "source_sha1": "e7b49d6d73d77f94ca27fd83a68a39f216bf6d78",
         "translated_on": "2026-06-01",
         "status": "beta"
       },
       "de": {
         "file": "src/2026.de.njk",
-        "source_sha1": "4e45bdaf14f34eaeaa9d0e3fadd93fc872d8bee5",
+        "source_sha1": "e7b49d6d73d77f94ca27fd83a68a39f216bf6d78",
         "translated_on": "2026-06-01",
         "status": "beta"
       }

--- a/src/2026.de.njk
+++ b/src/2026.de.njk
@@ -47,6 +47,12 @@ alternates:
       {% include "registration-badge.njk" %}
       {% include "countdown.njk" %}
     </div>
+    {%- set _reg2026 = conferences.byYear["2026"] -%}
+    {%- if _reg2026 and _reg2026.registrationStatus == "closed" -%}
+    <p class="reveal reveal-delay-3" style="margin-top: var(--space-4); font-size: var(--fs-sm); color: hsl(0 0% 100% / 0.9); max-width: 42rem;">
+      Die Anmeldung ist geschlossen. Sie können trotzdem dabei sein: Das <a href="#programme" style="color:#fff;text-decoration:underline;">Programm</a> unten kennzeichnet die live übertragenen Sitzungen.
+    </p>
+    {%- endif -%}
   </div>
 </section>
 

--- a/src/2026.fr.njk
+++ b/src/2026.fr.njk
@@ -47,6 +47,12 @@ alternates:
       {% include "registration-badge.njk" %}
       {% include "countdown.njk" %}
     </div>
+    {%- set _reg2026 = conferences.byYear["2026"] -%}
+    {%- if _reg2026 and _reg2026.registrationStatus == "closed" -%}
+    <p class="reveal reveal-delay-3" style="margin-top: var(--space-4); font-size: var(--fs-sm); color: hsl(0 0% 100% / 0.9); max-width: 42rem;">
+      Les inscriptions sont closes. Vous pouvez toujours suivre la conférence : le <a href="#programme" style="color:#fff;text-decoration:underline;">programme</a> ci-dessous signale les sessions diffusées en direct.
+    </p>
+    {%- endif -%}
   </div>
 </section>
 

--- a/src/2026.njk
+++ b/src/2026.njk
@@ -49,6 +49,12 @@ alternates:
       {% include "registration-badge.njk" %}
       {% include "countdown.njk" %}
     </div>
+    {%- set _reg2026 = conferences.byYear["2026"] -%}
+    {%- if _reg2026 and _reg2026.registrationStatus == "closed" -%}
+    <p class="reveal reveal-delay-3" style="margin-top: var(--space-4); font-size: var(--fs-sm); color: hsl(0 0% 100% / 0.9); max-width: 42rem;">
+      Registration has closed. You can still follow along: the <a href="#programme" style="color:#fff;text-decoration:underline;">programme</a> below marks the livestreamed sessions.
+    </p>
+    {%- endif -%}
   </div>
 </section>
 

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -1113,6 +1113,10 @@ h4 { font-size: var(--fs-lg); }
   margin-bottom: var(--space-5);
 }
 
+/* Registration-status badge surfaced on the homepage featured card, so a
+   visitor reads date + venue + status without clicking through. */
+.featured-registration { margin-bottom: var(--space-5); }
+
 .featured-meta strong {
   color: var(--text);
   font-weight: 600;

--- a/src/index.de.njk
+++ b/src/index.de.njk
@@ -64,6 +64,9 @@ alternates:
             {{ conf.venue.de }}
           </div>
         </div>
+        <div class="featured-registration">
+          {% include "registration-badge.njk" %}
+        </div>
         <div>
           <a class="btn btn-primary" href="/{{ conf.slug }}.de.html">Mehr über die ESSC&nbsp;{{ conf.year }} erfahren {{ icon("arrow-right") }}</a>
         </div>

--- a/src/index.fr.njk
+++ b/src/index.fr.njk
@@ -64,6 +64,9 @@ alternates:
             {{ conf.venue.fr }}
           </div>
         </div>
+        <div class="featured-registration">
+          {% include "registration-badge.njk" %}
+        </div>
         <div>
           <a class="btn btn-primary" href="/{{ conf.slug }}.fr.html">En savoir plus sur l'ESSC&nbsp;{{ conf.year }} {{ icon("arrow-right") }}</a>
         </div>

--- a/src/index.njk
+++ b/src/index.njk
@@ -66,6 +66,9 @@ alternates:
             {{ conf.venue.en }}
           </div>
         </div>
+        <div class="featured-registration">
+          {% include "registration-badge.njk" %}
+        </div>
         <div>
           <a class="btn btn-primary" href="/{{ conf.slug }}.html">Learn more about ESSC&nbsp;{{ conf.year }} {{ icon("arrow-right") }}</a>
         </div>


### PR DESCRIPTION
Acts on **#356** (UX audit, *blocker* — the mobile-next-conf and phd-applicant personas).

## Changes
1. **Homepage featured card shows registration status.** The `registration-badge.njk` include now renders on the homepage next-conference card, so a visitor reads **date + venue + status** without clicking through (the whole goal of the fast mobile check). Data already existed (`conf.registrationStatus`); reuses the same component as `/2026`.
2. **`/2026` no longer dead-ends at "Registration closed".** When registration is closed, a short note under the hero reframes it: *"You can still follow along: the programme below marks the livestreamed sessions."* It uses only facts already true on the page (the grid tags livestreamed sessions) — no fabricated participation options. Conditional on `registrationStatus == "closed"`, so it disappears when registration is open.

Hand-translated EN/FR/DE; `index` + `2026` fr/de re-blessed; drift clean.

## Note
The copy here is participation-facing — please tweak wording in the preview if you'd frame it differently (e.g. if in-person walk-ins or a livestream link should be named explicitly). Visual change → auto-merge not armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)