### PR TITLE
feat(search): individually searchable board members + search docs (#353, #359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The themed sections above are the story; the index below is the
 audit trail. Same content, terser.
 
 #### Added
+
+- **Board members are individually searchable.** Site search indexed `/board` as one page, so a name query returned the whole board rather than the person. Now `src/_data/searchBios.js` + `src/search-bios.njk` emit a lightweight Pagefind index stub per person per locale at `/search/bios/<lang>/<slug>.html` (noindex; redirects a click to the canonical `/board[.lang].html#<slug>` anchor). Every board / support card gains a stable `#<slug>` anchor (deep-linkable), rendered by `person-card.njk` from a slug derived in `boardSorted.js`. The stubs are excluded from the sitemap. NetSec parity ([#353](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/353)); search architecture documented in `docs/search.md`, including the post-deploy verification ([#359](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/359)).
 - (one-line pointer bullets, what not why)
 
 #### Changed

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,0 +1,62 @@
+# Site search (Pagefind)
+
+How the site-wide search works, and why it looks "broken" locally.
+
+## Architecture
+
+- **UI**: the header search button (`[data-search-trigger]`) and the
+  shortcuts Cmd/Ctrl-K and `/` open the modal in
+  `src/_includes/search-modal.njk`. Behaviour + result rendering live in
+  `src/assets/js/search.js`; styling is in `site.css` under
+  `/* site search modal */`.
+- **Index**: [Pagefind](https://pagefind.app). The index
+  (`/pagefind/pagefind.js` + wasm shards) is generated **at deploy
+  time** by `npx pagefind --site _site` in
+  `.github/workflows/deploy.yml`, after the Eleventy build. It is **not**
+  committed and is **not** produced by the local `eleventy` build.
+- **Scope**: site chrome carries `data-pagefind-ignore` (the
+  sticky-chrome in `base.njk`, the footer, the search modal), so only
+  `<main>` content is indexed.
+
+## Why local search shows "unavailable"
+
+`search.js` lazy-imports `/pagefind/pagefind.js` on first open. That file
+only exists on the deployed site, so on a local `eleventy --serve` the
+import fails and the modal shows the "available on the published site"
+notice instead of erroring. **This is expected.** The modal chrome,
+keyboard shortcuts, and open/close still work locally for layout checks;
+only results need the deployed index.
+
+## Per-person search (bio stubs)
+
+`/board` is one page, so indexing it whole means a name search returns
+the board page, not the person. To make individual people searchable
+(NetSec parity), `src/_data/searchBios.js` flattens `board.json`
+(members + support) into one record per person per locale, and
+`src/search-bios.njk` emits a minimal stub at
+`/search/bios/<lang>/<slug>.html` for each. Pagefind indexes the stub's
+body (name, role, affiliation, themes); the stub is `noindex` for search
+engines and redirects a human click to the canonical board anchor
+`/board[.lang].html#<slug>`. The anchor id is rendered by
+`person-card.njk` from the same slug (`boardSorted.js`), so the two
+always line up — keep the two `slugify` copies identical.
+
+Stubs are `eleventyExcludeFromCollections`, so they never reach
+`sitemap.xml` or the visual sitemap.
+
+## Verifying after deploy (issue #359)
+
+The bio-stub indexing can only be confirmed on the deployed site (the
+index isn't built locally). After a deploy, check on
+<https://eiss-europa.com>:
+
+1. Searching a board member's name (e.g. "Hugo Meijer") returns that
+   person as a top result, and clicking it lands on their card on
+   `/board`.
+2. Searching a research theme (e.g. "deterrence") surfaces the relevant
+   people.
+3. The same holds on the FR and DE sites (the per-locale stubs).
+
+If results don't appear, confirm the deploy ran `pagefind --site _site`
+after the build and that `/search/bios/` is present in the published
+output.

--- a/src/_data/boardSorted.js
+++ b/src/_data/boardSorted.js
@@ -101,6 +101,17 @@ function buildTierMap() {
 // build-time signal to decide whether to render the toggle button
 // at all, so short bios don't get a pointless "Read more" they
 // can't expand into anything new.
+// Name → URL slug for #anchors and Pagefind bio stubs. Deterministic;
+// keep identical to the copy in src/_data/searchBios.js.
+function slugify(s) {
+  return (s || "")
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
 const BIO_LONG_THRESHOLD = 180;
 
 // Time-bound roles (interns, visiting fellows, fixed-term contracts)
@@ -161,6 +172,10 @@ module.exports = function () {
     const bio = (person.bio || "").trim();
     return {
       ...person,
+      // Slug for the per-card #anchor (person-card.njk renders id="{{ slug }}")
+      // and for the Pagefind bio-search stubs (src/_data/searchBios.js).
+      // Keep this slugify in sync with searchBios.js.
+      slug: person.slug || slugify(person.name),
       tier: tierByRole[person.role] ?? 999,
       isEsscActive: esscNames.has(identityKey(person.name)),
       bioIsLong: bio.length > BIO_LONG_THRESHOLD,

--- a/src/_data/searchBios.js
+++ b/src/_data/searchBios.js
@@ -1,0 +1,52 @@
+// Flattens board.json (members + support) into one record per person
+// per locale, consumed by src/search-bios.njk to emit lightweight
+// Pagefind index stubs at /search/bios/<lang>/<slug>.html. Each stub is
+// noindex (search engines skip it) but Pagefind indexes its body, so a
+// name/affiliation/theme query returns the individual person rather than
+// the whole /board page. The stub redirects to the canonical board
+// anchor (/board[.lang].html#<slug>), whose id is rendered by
+// person-card.njk from the same slug (boardSorted.js).
+//
+// The slugify here is deliberately identical to the one in
+// boardSorted.js — keep the two in sync so the stub's canonical anchor
+// always matches the rendered card id.
+const board = require("./board.json");
+
+function slugify(s) {
+  return (s || "")
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+const LOCALES = [
+  { lang: "en", board: "/board.html" },
+  { lang: "fr", board: "/board.fr.html" },
+  { lang: "de", board: "/board.de.html" },
+];
+
+module.exports = function () {
+  const people = [...(board.members || []), ...(board.support || [])].filter(
+    (p) => p && p.name
+  );
+  const out = [];
+  for (const loc of LOCALES) {
+    for (const p of people) {
+      const slug = p.slug || slugify(p.name);
+      out.push({
+        lang: loc.lang,
+        slug,
+        name: p.name,
+        role: p.role || "",
+        position: p.position || "",
+        institution: p.institution || "",
+        country: p.country || "",
+        themes: p.themes || "",
+        canonical: loc.board + "#" + slug,
+      });
+    }
+  }
+  return out;
+};

--- a/src/search-bios.njk
+++ b/src/search-bios.njk
@@ -1,0 +1,36 @@
+---
+# Pagefind index stubs: one minimal HTML page per board/support person
+# per locale. Pagefind (built at deploy) indexes each stub's body, so a
+# search for a person's name / institution / themes returns that person
+# rather than the whole /board page. The stub is noindex for search
+# engines and redirects a human click to the canonical board anchor.
+# Excluded from collections so it never appears in sitemap.xml or the
+# visual sitemap. See docs/search.md and issues #353 / #359.
+pagination:
+  data: searchBios
+  size: 1
+  alias: bio
+permalink: "/search/bios/{{ bio.lang }}/{{ bio.slug }}.html"
+eleventyExcludeFromCollections: true
+---
+<!doctype html>
+<html lang="{{ bio.lang }}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url={{ bio.canonical }}">
+  <link rel="canonical" href="{{ bio.canonical }}">
+  <title>{{ bio.name }} — EISS</title>
+</head>
+<body data-pagefind-body>
+  <main>
+    <h1 data-pagefind-meta="title">{{ bio.name }}</h1>
+    <p>{{ bio.role }}{% if bio.position %} — {{ bio.position }}{% endif %}{% if bio.institution %}, {{ bio.institution }}{% endif %}{% if bio.country %} ({{ bio.country }}){% endif %}</p>
+    {%- if bio.themes %}
+    <p>{{ bio.themes }}</p>
+    {%- endif %}
+    <p><a href="{{ bio.canonical }}">View on the EISS board page</a></p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Addresses **#353** (Pagefind bio stubs, NetSec parity) and **#359** (search docs + post-deploy verification).

## Problem
Site search indexed `/board` as a single page, so a name query (e.g. "Hugo Meijer") returned the whole board, not the person.

## Change
- **`src/_data/searchBios.js`** flattens `board.json` (members + support) into one record per person per locale.
- **`src/search-bios.njk`** emits a lightweight Pagefind index stub per person per locale at `/search/bios/<lang>/<slug>.html`. Pagefind indexes the stub body (name, role, affiliation, themes); the stub is `noindex` for search engines and **redirects a human click to the canonical `/board[.lang].html#<slug>` anchor**. `eleventyExcludeFromCollections`, so it never reaches `sitemap.xml` or the visual sitemap.
- **`boardSorted.js`** now derives a `slug` for every person, so `person-card.njk` (which already renders `id="{{ slug }}"`) gives every board/support card a stable, **deep-linkable anchor** — and the stub redirect target resolves to the right person. The two `slugify` copies are kept identical (commented on both sides).
- **`docs/search.md`** documents the architecture, why local search is intentionally "unavailable" (the index only builds at deploy), the bio-stub mechanism, and the post-deploy verification checklist (#359).

## Verification
- 138 stubs (46 people × 3 locales) build cleanly.
- Board cards now carry matching `id` anchors, verified on `/board`, `/board.fr`, `/board.de` — so the `#slug` redirects land on the right card and the internal-link checker resolves the fragments.
- No i18n drift (data + new files only; no page-source changes).

**Pagefind indexing itself can only be confirmed on the deployed site** (the index isn't built locally — per my own CLAUDE.md §14, I'm flagging what I couldn't verify here). `docs/search.md` has the post-deploy checks (#359). The change is safe to ship regardless: stubs are noindex + sitemap-excluded + additive — if Pagefind doesn't pick them up, search behaves exactly as before; nothing breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)