### PR TITLE
content(archive): shorten the archive-page ribbon for mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ audit trail. Same content, terser.
 - (one-line pointer bullets, what not why)
 
 #### Changed
+
+- **The archive-page ribbon is shorter.** Trimmed to "This page documents a past EISS event. It may not be as complete as current pages." so it takes less vertical space on mobile.
 - (…)
 
 #### Fixed

--- a/src/_includes/archive-ribbon.njk
+++ b/src/_includes/archive-ribbon.njk
@@ -18,7 +18,7 @@
   <div class="container archive-ribbon-inner">
     <span class="archive-ribbon-badge">Archive</span>
     <span class="archive-ribbon-text">
-      This page documents a past EISS event designed on the previous website. It may not be as complete or polished as our current pages.
+      This page documents a past EISS event. It may not be as complete as current pages.
     </span>
   </div>
 </div>


### PR DESCRIPTION
Trims the archive disclaimer ribbon (shown on the /YYYY archive pages) to:

> This page documents a past EISS event. It may not be as complete as current pages.

It was taking too much vertical space on mobile. Hardcoded EN (archive pages are EN-only, per the include's own note). No i18n drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)