### PR TITLE
docs(claude): codify four verification/hygiene lessons from NetSec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,6 +340,11 @@ is being edited anyway.
   substantively changed their entry. If you see the workflow trip an
   apparently-empty PR, that's a regression. Open an issue and
   investigate before silencing.
+- **Delete scratch / probe files before staging.** One-off probe pages
+  (`jprobe.html`, `rmm.html`, `swatch.html`, and the like) and throwaway
+  scripts get swept into a commit by `git add -A` / `git add -u`. Remove
+  them (or keep them outside the repo) and eyeball `git status` before
+  every commit, rather than trusting `.gitignore` to catch each one.
 
 ## 9. Accessibility & i18n cadence
 
@@ -547,6 +552,40 @@ Before calling any UI work done:
 
 The lesson generalises: verification must target the user-visible
 behaviour the change promises, on the surface the user actually uses.
+
+### Standing verification habits
+
+Carried over from the NetSec sister repo, where the same gotchas were
+re-derived more than once. These are **default behaviour, not
+on-request**:
+
+- **Grep for the bug's siblings before closing.** When you fix a bug,
+  search the codebase for the same pattern and fix every instance in the
+  same pass. Don't wait to be asked "check elsewhere too". This has
+  recurred: the deep-link-scroll and sticky-chrome scroll-padding fixes
+  both had siblings, as did the dead YouTube-Shorts URL and the
+  GitHub-Release `octet-stream` video content-type (both needed fixing
+  on `/2025` *and* `/past` ×3).
+- **A sitewide change ripples into the CI gates, so trace it first.** A
+  change touching every page (a chrome include, a shared CSS class, the
+  `bust` filter's `?v=` cache-buster) flows into the i18n drift checker
+  and the link checker. The `?v=` cache-buster once silently tripped the
+  drift checker until it was normalised. Before pushing anything
+  sitewide, run `check-i18n-drift.py` and the build locally and reason
+  about which gates it touches.
+- **Trust the Preview MCP's computed reads, not its screenshots.**
+  `preview_screenshot` can return blank or dark (e.g. when the page is
+  `visibilityState: hidden`, or before first paint) and doesn't reliably
+  scroll-to-fragment or settle layout. `preview_eval` reads —
+  `getComputedStyle`, `getBoundingClientRect`, element / attribute
+  checks — are reliable, and are how the search modal, press-kit grids,
+  iOS film playback, gallery crop, and `/past` ordering were all
+  verified. Prefer them; treat a screenshot as a loose sanity check, not
+  proof. (NetSec hit the raw-headless-Chrome equivalents:
+  `--screenshot` / `--dump-dom` don't fire `requestAnimationFrame` or
+  scroll to a fragment, and backgrounded stdout doesn't flush — read the
+  dumped DOM file instead; `--force-prefers-reduced-motion=reduce` and
+  computed-style reads are the dependable parts.)
 
 ---
 


### PR DESCRIPTION
You asked whether the four NetSec lessons-learned apply to EISS. **All four do** — EISS shares the relevant tooling (the i18n drift checker, the `bust` cache-buster, the Preview MCP, `git add -A` habits) — so I've codified them. My per-lesson read:

1. **Grep for the bug's siblings before closing** — *highly relevant, now default.* It has recurred here (you asked "check elsewhere" on the scroll-padding + deep-link bugs; this session the dead Shorts URL and the `octet-stream` content-type both needed fixing on `/2025` *and* `/past` ×3). → §14.
2. **Trace sitewide changes through the CI gates** — *highly relevant.* The `?v=` cache-buster tripping the drift checker is EISS's own history; any chrome-include / shared-class / `bust` change ripples into drift + link gates. → §14.
3. **Headless-Chrome verification blind spots** — *relevant, adapted.* EISS verifies via the **Preview MCP**, not raw `--screenshot`/`--dump-dom`, so I translated it: screenshots can come back blank/dark (hit this session — `visibilityState: hidden`), so prefer `preview_eval` computed reads. The raw-Chrome specifics are noted as the NetSec origin. → §14.
4. **Scratch files leak into commits** — *relevant, weakest (overlaps §2/§8).* The new bit is the "delete scratch first + eyeball `git status`" habit. → §8.

Docs-only; no site change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)