### PR TITLE
refactor(archive): shared data-driven conference-media block (#358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ audit trail. Same content, terser.
 
 #### Changed
 
+- **Archive-page session recordings are a shared, data-driven block.** The near-identical hand-wired "Session recordings" sections on `/2019`, `/2023` and `/2024` are replaced by one `conference-media.njk` partial that reads the YouTube playlist + city from `conferences.js` (`youtubePlaylist` per year). Future archive pages only set the playlist in the data and include the partial — no per-page recordings markup to drift out of sync. Closes [#358](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/358).
+
 - **`/initiative` now links straight to the board.** A "Meet the people behind EISS" button joins the closing call-to-action strip (EN/FR/DE), so a visitor reading about the organisation can reach `/board` without returning to the menu. Acts on the UX audit ([#357](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/357)).
 - **The homepage now shows the next conference’s registration status, and `/2026` no longer dead-ends when registration closes.** The featured card on the homepage surfaces the registration badge (date + venue + status, so a quick check, especially on mobile, needs no click). On `/2026`, when registration is closed a short note under the hero reframes it (“you can still follow along: the programme below marks the livestreamed sessions”) instead of leaving “Registration closed” as a terminus. Hand-translated (EN/FR/DE). Acts on the UX audit ([#356](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/356)).
 - **The archive-page ribbon is shorter.** Trimmed to "This page documents a past EISS event. It may not be as complete as current pages." so it takes less vertical space on mobile.

--- a/src/2019.njk
+++ b/src/2019.njk
@@ -51,20 +51,9 @@ status: archive
 {% set archiveSlug = "2019" %}
 {% include "archive-programme.njk" %}
 
-<section class="section-tight" aria-labelledby="recordings-2019-title">
-  <div class="container">
-    <h2 id="recordings-2019-title" style="margin-bottom: var(--space-5);">Session recordings</h2>
-    <p class="muted" style="max-width: 44rem; margin-bottom: var(--space-5);">
-      Selected sessions from EISS 2019 are available on the EISS YouTube channel
-      (<a href="https://www.youtube.com/@eiss-europe/" target="_blank" rel="noopener">@eiss-europe</a>).
-      Clicking play loads the YouTube iframe; before that, no YouTube cookies are set.
-    </p>
-    {%- set youtubeId = "PLkI2R8FsFqV4_TVOCV5qfPFAmZn1KbWGv" -%}
-    {%- set youtubeIsList = true -%}
-    {%- set youtubeTitle = "EISS 2019 — Paris, session recordings" -%}
-    {% include "youtube-embed.njk" %}
-  </div>
-</section>
+{# Session recordings — shared, data-driven block (playlist in conferences.js). #}
+{% set mediaYear = "2019" %}
+{% include "conference-media.njk" %}
 
 <section class="section-tight">
   <div class="container">

--- a/src/2023.njk
+++ b/src/2023.njk
@@ -24,20 +24,9 @@ status: archive
 {% set archiveSlug = "2023" %}
 {% include "archive-programme.njk" %}
 
-<section class="section-tight" aria-labelledby="recordings-2023-title">
-  <div class="container">
-    <h2 id="recordings-2023-title" style="margin-bottom: var(--space-5);">Session recordings</h2>
-    <p class="muted" style="max-width: 44rem; margin-bottom: var(--space-5);">
-      Selected sessions from EISS 2023 are available on the EISS YouTube channel
-      (<a href="https://www.youtube.com/@eiss-europe/" target="_blank" rel="noopener">@eiss-europe</a>).
-      Clicking play loads the YouTube iframe. Before that, no YouTube cookies are set.
-    </p>
-    {%- set youtubeId = "PLkI2R8FsFqV4zwz12-ZFd_dV_ENX14--6" -%}
-    {%- set youtubeIsList = true -%}
-    {%- set youtubeTitle = "EISS 2023 — Barcelona, session recordings" -%}
-    {% include "youtube-embed.njk" %}
-  </div>
-</section>
+{# Session recordings — shared, data-driven block (playlist in conferences.js). #}
+{% set mediaYear = "2023" %}
+{% include "conference-media.njk" %}
 
 <section class="section">
   <div class="container">

--- a/src/2024.njk
+++ b/src/2024.njk
@@ -23,20 +23,9 @@ status: archive
 {% set archiveSlug = "2024" %}
 {% include "archive-programme.njk" %}
 
-<section class="section-tight" aria-labelledby="recordings-2024-title">
-  <div class="container">
-    <h2 id="recordings-2024-title" style="margin-bottom: var(--space-5);">Session recordings</h2>
-    <p class="muted" style="max-width: 44rem; margin-bottom: var(--space-5);">
-      Selected sessions from EISS 2024 are available on the EISS YouTube channel
-      (<a href="https://www.youtube.com/@eiss-europe/" target="_blank" rel="noopener">@eiss-europe</a>).
-      Clicking play loads the YouTube iframe. Before that, no YouTube cookies are set.
-    </p>
-    {%- set youtubeId = "PLkI2R8FsFqV6bNS0LmU-TxWNY7-fBXDOa" -%}
-    {%- set youtubeIsList = true -%}
-    {%- set youtubeTitle = "EISS 2024 — Prague, session recordings" -%}
-    {% include "youtube-embed.njk" %}
-  </div>
-</section>
+{# Session recordings — shared, data-driven block (playlist in conferences.js). #}
+{% set mediaYear = "2024" %}
+{% include "conference-media.njk" %}
 
 <section class="section">
   <div class="container">

--- a/src/_data/conferences.js
+++ b/src/_data/conferences.js
@@ -169,6 +169,7 @@ const conferences = [
       de: "7. Jahreskonferenz · 27. — 28. Juni 2024 · Karls-Universität, Prag",
     },
     displayCity: { en: "Prague", fr: "Prague", de: "Prag" },
+    youtubePlaylist: "PLkI2R8FsFqV6bNS0LmU-TxWNY7-fBXDOa",
     hasOwnPage: true,
   },
   {
@@ -191,6 +192,7 @@ const conferences = [
       de: "6. Jahreskonferenz · Barcelona, Spanien",
     },
     displayCity: { en: "Barcelona", fr: "Barcelone", de: "Barcelona" },
+    youtubePlaylist: "PLkI2R8FsFqV4zwz12-ZFd_dV_ENX14--6",
     hasOwnPage: true,
   },
   {
@@ -281,6 +283,7 @@ const conferences = [
       de: "2. Jahreskonferenz · Sciences Po CERI, Paris",
     },
     displayCity: { en: "Paris", fr: "Paris", de: "Paris" },
+    youtubePlaylist: "PLkI2R8FsFqV4_TVOCV5qfPFAmZn1KbWGv",
     hasOwnPage: true,
   },
   // The 2017 and 2018 conferences are kept in the historical-image

--- a/src/_includes/conference-media.njk
+++ b/src/_includes/conference-media.njk
@@ -1,0 +1,31 @@
+{# Consistent "Session recordings" block for archive conference pages.
+   Data-driven: reads the YouTube playlist + city from conferences.js
+   (byYear[mediaYear]), so a future archive page only needs to set the
+   playlist in conferences.js and include this partial — no per-page
+   recordings markup to hand-write and drift out of sync.
+
+   Usage from a /YYYY archive page:
+     {% set mediaYear = "2024" %}
+     {% include "conference-media.njk" %}
+
+   Renders nothing when the year has no `youtubePlaylist` in
+   conferences.js, so it's safe to include unconditionally. The lazy,
+   cookieless player itself is youtube-embed.njk. EN-only, like the rest
+   of the archive pages. #}
+{%- set _cm = conferences.byYear[mediaYear] -%}
+{%- if _cm and _cm.youtubePlaylist %}
+<section class="section-tight" aria-labelledby="recordings-{{ mediaYear }}-title">
+  <div class="container">
+    <h2 id="recordings-{{ mediaYear }}-title" style="margin-bottom: var(--space-5);">Session recordings</h2>
+    <p class="muted" style="max-width: 44rem; margin-bottom: var(--space-5);">
+      Selected sessions from EISS {{ mediaYear }} are available on the EISS YouTube channel
+      (<a href="https://www.youtube.com/@eiss-europe/" target="_blank" rel="noopener">@eiss-europe</a>).
+      Clicking play loads the YouTube iframe. Before that, no YouTube cookies are set.
+    </p>
+    {%- set youtubeId = _cm.youtubePlaylist -%}
+    {%- set youtubeIsList = true -%}
+    {%- set youtubeTitle = "EISS " + mediaYear + " — " + _cm.city + ", session recordings" -%}
+    {% include "youtube-embed.njk" %}
+  </div>
+</section>
+{%- endif %}


### PR DESCRIPTION
Closes **#358** (UX audit — archive-researcher persona).

The "Session recordings" sections on `/2019`, `/2023` and `/2024` were hand-wired and near-identical, so coverage and wording drifted (the audit flagged it; in fact `/2023` already had recordings — that finding was stale post-#345 — but the *inconsistency* was real).

## Change
- New per-year `youtubePlaylist` field in `conferences.js` (2019/2023/2024).
- New `src/_includes/conference-media.njk`: reads the playlist + city from `conferences.byYear[mediaYear]` and renders the standard lazy, cookieless recordings block (via `youtube-embed.njk`). Renders nothing when a year has no playlist, so it's safe to include unconditionally.
- `/2019`, `/2023`, `/2024` now just `{% set mediaYear %}` + include — no per-page recordings markup.

Future archives need only set the playlist in the data and drop in the include — no hand-wiring to drift.

## Verification
Built; the correct playlist ID + auto-built title (`EISS YYYY — City, session recordings`) render on all three pages; a page without a playlist (`/2022`) renders nothing. EN-only (archive pages), no i18n drift. Near-identical output (only a minor punctuation normalisation on /2019), so low visual risk — a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)