### PR TITLE
chore(i18n): track /roadmap FR+DE in the drift checker (#271)

### DIFF
--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -182,6 +182,20 @@
         "translated_on": "2026-05-31",
         "status": "beta"
       }
+    },
+    "src/roadmap.njk": {
+      "fr": {
+        "file": "src/roadmap.fr.njk",
+        "source_sha1": "b319614a5e888efb66b201f5e359b7f48b0a2c67",
+        "translated_on": "2026-06-01",
+        "status": "beta"
+      },
+      "de": {
+        "file": "src/roadmap.de.njk",
+        "source_sha1": "b319614a5e888efb66b201f5e359b7f48b0a2c67",
+        "translated_on": "2026-06-01",
+        "status": "beta"
+      }
     }
   }
 }


### PR DESCRIPTION
The public `/roadmap` page (#268) shipped with FR/DE variants that were never registered in `data/i18n-state.json`, so the i18n drift checker wasn't watching them — an EN roadmap edit wouldn't flag the translations as stale. Registered both `roadmap.fr.njk` / `roadmap.de.njk` against the current EN source (`status: beta`, like the other translated pages). Checker now reports them fresh. Closes #271. Tooling-only.