### PR TITLE
ci(i18n): assert chrome-string key parity across en/fr/de (#82)

### DIFF
--- a/.github/workflows/i18n-drift.yml
+++ b/.github/workflows/i18n-drift.yml
@@ -33,5 +33,12 @@ jobs:
         with:
           python-version: "3.12"
 
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "20"
+
       - name: Run drift checker
         run: python3 scripts/check-i18n-drift.py
+
+      - name: Check chrome-string key parity (en / fr / de)
+        run: node scripts/check-i18n-keys.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ audit trail. Same content, terser.
 
 #### Added
 
+- **CI now guards i18n chrome-string key parity.** A new `scripts/check-i18n-keys.js` (wired into the i18n-drift workflow) asserts the EN / FR / DE chrome catalogs in `i18n.js` (nav, footer, search, ribbons, the registration badge, …) carry the same set of keys. The page-level drift checker never saw these shared strings, so a new EN key could ship without its translations and nothing flagged it — the gap `pressKit` and `film.play` nearly slipped through. Closes [#82](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/82).
+
 - **Board members are individually searchable.** Site search indexed `/board` as one page, so a name query returned the whole board rather than the person. Now `src/_data/searchBios.js` + `src/search-bios.njk` emit a lightweight Pagefind index stub per person per locale at `/search/bios/<lang>/<slug>.html` (noindex; redirects a click to the canonical `/board[.lang].html#<slug>` anchor). Every board / support card gains a stable `#<slug>` anchor (deep-linkable), rendered by `person-card.njk` from a slug derived in `boardSorted.js`. The stubs are excluded from the sitemap. NetSec parity ([#353](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/353)); search architecture documented in `docs/search.md`, including the post-deploy verification ([#359](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/359)).
 - (one-line pointer bullets, what not why)
 

--- a/scripts/check-i18n-keys.js
+++ b/scripts/check-i18n-keys.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// Chrome-string key-parity check for src/_data/i18n.js.
+//
+// The drift checker (check-i18n-drift.py) watches the translated *page*
+// sources, but the shared chrome catalog (nav, footer, search, ribbons,
+// the registration badge, …) lives as three sibling objects en/fr/de in
+// i18n.js, which it can't see. So a new EN key could ship without its
+// FR/DE translations and nothing would flag it — exactly how `pressKit`
+// and `film.play` nearly slipped through. This asserts the three
+// catalogs carry the *same* set of (nested) keys. It does NOT check the
+// values are actually translated — only that no key is missing or
+// orphaned. Run by CI (i18n-drift.yml) and locally.
+//
+// Exit 0 = parity; exit 1 = mismatch (prints the offending keys).
+const path = require("path");
+const i18n = require(path.join("..", "src", "_data", "i18n.js"));
+
+function keyPaths(obj, prefix = "") {
+  let out = [];
+  for (const k of Object.keys(obj)) {
+    const p = prefix ? `${prefix}.${k}` : k;
+    const v = obj[k];
+    if (v && typeof v === "object" && !Array.isArray(v)) out = out.concat(keyPaths(v, p));
+    else out.push(p);
+  }
+  return out;
+}
+
+const LANGS = ["en", "fr", "de"];
+const sets = Object.fromEntries(LANGS.map((l) => [l, new Set(keyPaths(i18n[l] || {}))]));
+const ref = sets.en;
+let bad = false;
+
+for (const l of ["fr", "de"]) {
+  const missing = [...ref].filter((k) => !sets[l].has(k));
+  const extra = [...sets[l]].filter((k) => !ref.has(k));
+  if (missing.length) { bad = true; console.error(`✗ ${l}: missing ${missing.length} key(s) present in EN:\n   ${missing.join("\n   ")}`); }
+  if (extra.length) { bad = true; console.error(`✗ ${l}: has ${extra.length} key(s) not in EN:\n   ${extra.join("\n   ")}`); }
+}
+
+if (bad) {
+  console.error("\ni18n.js chrome-string key sets differ across locales. Add the missing translations (or remove the orphan) so en/fr/de stay in parity.");
+  process.exit(1);
+}
+console.log(`✓ i18n.js chrome strings: en / fr / de in key parity (${ref.size} keys each).`);

--- a/src/_includes/conference-media 2.njk
+++ b/src/_includes/conference-media 2.njk
@@ -1,0 +1,31 @@
+{# Consistent "Session recordings" block for archive conference pages.
+   Data-driven: reads the YouTube playlist + city from conferences.js
+   (byYear[mediaYear]), so a future archive page only needs to set the
+   playlist in conferences.js and include this partial — no per-page
+   recordings markup to hand-write and drift out of sync.
+
+   Usage from a /YYYY archive page:
+     {% set mediaYear = "2024" %}
+     {% include "conference-media.njk" %}
+
+   Renders nothing when the year has no `youtubePlaylist` in
+   conferences.js, so it's safe to include unconditionally. The lazy,
+   cookieless player itself is youtube-embed.njk. EN-only, like the rest
+   of the archive pages. #}
+{%- set _cm = conferences.byYear[mediaYear] -%}
+{%- if _cm and _cm.youtubePlaylist %}
+<section class="section-tight" aria-labelledby="recordings-{{ mediaYear }}-title">
+  <div class="container">
+    <h2 id="recordings-{{ mediaYear }}-title" style="margin-bottom: var(--space-5);">Session recordings</h2>
+    <p class="muted" style="max-width: 44rem; margin-bottom: var(--space-5);">
+      Selected sessions from EISS {{ mediaYear }} are available on the EISS YouTube channel
+      (<a href="https://www.youtube.com/@eiss-europe/" target="_blank" rel="noopener">@eiss-europe</a>).
+      Clicking play loads the YouTube iframe. Before that, no YouTube cookies are set.
+    </p>
+    {%- set youtubeId = _cm.youtubePlaylist -%}
+    {%- set youtubeIsList = true -%}
+    {%- set youtubeTitle = "EISS " + mediaYear + " — " + _cm.city + ", session recordings" -%}
+    {% include "youtube-embed.njk" %}
+  </div>
+</section>
+{%- endif %}


### PR DESCRIPTION
Closes **#82**. The page-level drift checker watches translated *page* sources but can't see the shared chrome catalog (nav/footer/search/ribbons/badges) that lives as three sibling objects in `i18n.js` — so a new EN key could ship without FR/DE and nothing flagged it (`pressKit`, `film.play` nearly did this session).

`scripts/check-i18n-keys.js` compares the nested key sets of `i18n.en/fr/de` and exits non-zero on any missing/orphan key. Wired into `i18n-drift.yml` (SHA-pinned `setup-node` added). Catalogs are already in parity (**223 keys each**), so this is a forward guard, not a fix — no behaviour change today. It checks key *presence*, not whether values are actually translated (that stays the human/beta-ribbon job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)