### PR TITLE
fix(search): index real pages again + headshot/role in results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ audit trail. Same content, terser.
 
 #### Changed
 
+- **Search results for people now show a headshot and a role pill.** The bio stubs expose the photo, role, and functional responsibility as Pagefind metadata; `search.js` renders a thumbnail and a role pill (e.g. "Board Member · Technology Coordinator") beside the name and excerpt. Non-person results are unchanged.
+
 - **Archive-page session recordings are a shared, data-driven block.** The near-identical hand-wired "Session recordings" sections on `/2019`, `/2023` and `/2024` are replaced by one `conference-media.njk` partial that reads the YouTube playlist + city from `conferences.js` (`youtubePlaylist` per year). Future archive pages only set the playlist in the data and include the partial — no per-page recordings markup to drift out of sync. Closes [#358](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/358).
 
 - **`/initiative` now links straight to the board.** A "Meet the people behind EISS" button joins the closing call-to-action strip (EN/FR/DE), so a visitor reading about the organisation can reach `/board` without returning to the menu. Acts on the UX audit ([#357](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/357)).
@@ -50,6 +52,8 @@ audit trail. Same content, terser.
 - (…)
 
 #### Fixed
+
+- **Site search indexed only the bio stubs, not the real pages.** Adding `data-pagefind-body` to the bio stubs (#366) silently triggered Pagefind's rule that *once any page declares `data-pagefind-body`, pages without it are dropped from the index* — so `/board`, `/initiative` and every real page fell out, and a query like "People" returned nothing. Declared `data-pagefind-body` on the layout `<main>` so every page is indexed again (scoped to content; the chrome stays `data-pagefind-ignore`).
 - (…)
 ```
 

--- a/src/_data/searchBios.js
+++ b/src/_data/searchBios.js
@@ -40,6 +40,8 @@ module.exports = function () {
         slug,
         name: p.name,
         role: p.role || "",
+        functionalResponsibility: p.functionalResponsibility || "",
+        photo: p.photoOverride || p.photo || "",
         position: p.position || "",
         institution: p.institution || "",
         country: p.country || "",

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -183,7 +183,13 @@
     {% include "nav.njk" %}
   </div>
 
-  <main id="main" role="main">
+  {# data-pagefind-body scopes the Pagefind index to page content (the
+     chrome above/below is data-pagefind-ignore). REQUIRED: the bio-search
+     stubs (search-bios.njk) carry data-pagefind-body, and Pagefind's rule
+     is that once *any* page has it, pages *without* it are dropped from
+     the index — so every real page must declare it here too, or only the
+     stubs get indexed. See docs/search.md. #}
+  <main id="main" role="main" data-pagefind-body>
     {{ content | safe }}
   </main>
 

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -3472,7 +3472,9 @@ body.search-open { overflow: hidden; }
 .search-results:empty { padding: 0; }
 .search-result { margin: 0; }
 .search-result-link {
-  display: block;
+  display: flex;
+  gap: var(--space-3);
+  align-items: flex-start;
   padding: var(--space-3) var(--space-4);
   border-radius: var(--radius-md);
   text-decoration: none;
@@ -3483,11 +3485,30 @@ body.search-open { overflow: hidden; }
   background: var(--bg-tinted);
   outline: none;
 }
+.search-result-thumb {
+  flex: none;
+  width: 2.5rem;
+  height: 3.125rem; /* 4:5, matching the board cards */
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  background: var(--bg-tinted);
+}
+.search-result-body { min-width: 0; }
 .search-result-title {
   display: block;
   font-weight: 600;
   color: var(--text);
   margin-bottom: 2px;
+}
+.search-result-role {
+  display: inline-block;
+  margin-bottom: 2px;
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-full);
+  background: var(--bg-tinted);
+  border: 1px solid var(--border);
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
 }
 .search-result-excerpt {
   display: block;

--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -84,17 +84,42 @@
       a.className = "search-result-link";
       a.href = d.url;
 
+      const meta = d.meta || {};
+
+      // People results (bio stubs) carry a headshot + role as Pagefind
+      // metadata; render a thumbnail and a role pill. Other pages have
+      // neither and render as before.
+      if (meta.image) {
+        const img = document.createElement("img");
+        img.className = "search-result-thumb";
+        img.src = meta.image;
+        img.alt = "";
+        img.loading = "lazy";
+        a.appendChild(img);
+      }
+
+      const body = document.createElement("span");
+      body.className = "search-result-body";
+
       const title = document.createElement("span");
       title.className = "search-result-title";
-      title.textContent = d.meta && d.meta.title ? d.meta.title : d.url;
+      title.textContent = meta.title ? meta.title : d.url;
+      body.appendChild(title);
+
+      if (meta.role) {
+        const role = document.createElement("span");
+        role.className = "search-result-role";
+        role.textContent = meta.responsibility ? `${meta.role} · ${meta.responsibility}` : meta.role;
+        body.appendChild(role);
+      }
 
       const excerpt = document.createElement("span");
       excerpt.className = "search-result-excerpt";
       // Pagefind returns excerpt HTML with <mark> around the hit terms.
       excerpt.innerHTML = d.excerpt;
+      body.appendChild(excerpt);
 
-      a.appendChild(title);
-      a.appendChild(excerpt);
+      a.appendChild(body);
       li.appendChild(a);
       frag.appendChild(li);
     });

--- a/src/search-bios.njk
+++ b/src/search-bios.njk
@@ -26,6 +26,12 @@ eleventyExcludeFromCollections: true
 <body data-pagefind-body>
   <main>
     <h1 data-pagefind-meta="title">{{ bio.name }}</h1>
+    {# Pagefind metadata for richer search results: headshot + role pill,
+       rendered by search.js. Hidden spans so they don't pollute the
+       indexed body text / excerpt. #}
+    {%- if bio.photo %}<span hidden data-pagefind-meta="image:{{ bio.photo }}"></span>{% endif %}
+    {%- if bio.role %}<span hidden data-pagefind-meta="role:{{ bio.role }}"></span>{% endif %}
+    {%- if bio.functionalResponsibility %}<span hidden data-pagefind-meta="responsibility:{{ bio.functionalResponsibility }}"></span>{% endif %}
     <p>{{ bio.role }}{% if bio.position %} — {{ bio.position }}{% endif %}{% if bio.institution %}, {{ bio.institution }}{% endif %}{% if bio.country %} ({{ bio.country }}){% endif %}</p>
     {%- if bio.themes %}
     <p>{{ bio.themes }}</p>


### PR DESCRIPTION
Two fixes to the now-live Pagefind search (from your screenshots).

## 1. \"People\" / the board page found nothing — **indexing bug**
Adding \`data-pagefind-body\` to the bio stubs (#366) silently triggered Pagefind's rule: **once any page declares \`data-pagefind-body\`, every page *without* it is excluded from the index.** So only the 138 stubs were indexed — \`/board\` (title \"The People\"), \`/initiative\`, and every real page fell out, and \"People\" returned nothing.

**Fix:** declare \`data-pagefind-body\` on the layout \`<main>\` (the chrome is already \`data-pagefind-ignore\`). Every page is indexed again, scoped to its content. Verified `/board` now carries the body marker and title \"The People\".

## 2. People results now show a headshot + role pill
The bio stubs expose photo / role / functional-responsibility as Pagefind metadata; \`search.js\` renders a thumbnail (4:5, matching the board cards) and a role pill (e.g. *Board Member · Technology Coordinator*) beside the name + excerpt. Non-person results are unchanged.

## Verification note
Pagefind builds **at deploy**, so the index behaviour can only be confirmed on the deployed site — markup (body marker on every page; image/role/responsibility meta on stubs), \`search.js\`, and CSS verified locally. Once deployed, please re-check: \"People\" → the board page; a name → that person with their headshot + role pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)