### PR TITLE
fix(data): reconcile archive conference record (#230)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ audit trail. Same content, terser.
 
 #### Fixed
 
+- **Reconciled the archive conference record in `conferences.js` (the contradictions in #230).** 2020 is now recorded as **deferred to 2021** (held at ISCTE-IUL, Lisbon) rather than "3rd Annual Conference held online" — matching the `/2020` and `/2021` pages and the organisation's actual history; it carries a `deferred` flag and no ordinal. 2019 is corrected from the 2nd to the **3rd** Annual Conference (2017 inaugural, 2018 second, 2019 third). Placeholder sort-dates are replaced with the real ones: **2021 → 3–4 September 2021**, **2022 → 30 June – 1 July 2022**. A new `editionCount` export (9: 2017, 2018, 2019, 2021–2026; the deferred 2020 excluded) gives display counts a single source of truth. EN/FR/DE archive metadata updated in lockstep. Closes [#230](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/230).
+
 - **Site search indexed only the bio stubs, not the real pages.** Adding `data-pagefind-body` to the bio stubs (#366) silently triggered Pagefind's rule that *once any page declares `data-pagefind-body`, pages without it are dropped from the index* — so `/board`, `/initiative` and every real page fell out, and a query like "People" returned nothing. Declared `data-pagefind-body` on the layout `<main>` so every page is indexed again (scoped to content; the chrome stays `data-pagefind-ignore`).
 - (…)
 ```

--- a/src/_data/conferences.js
+++ b/src/_data/conferences.js
@@ -199,8 +199,8 @@ const conferences = [
     slug: "2022",
     year: 2022,
     ordinal: 5,
-    startDate: "2022-06-23",
-    endDate: "2022-06-24",
+    startDate: "2022-06-30",
+    endDate: "2022-07-01",
     city: "Berlin",
     country: "Germany",
     venue: {
@@ -220,8 +220,8 @@ const conferences = [
     slug: "2021",
     year: 2021,
     ordinal: 4,
-    startDate: "2021-06-24",
-    endDate: "2021-06-25",
+    startDate: "2021-09-03",
+    endDate: "2021-09-04",
     city: "Lisbon",
     country: "Portugal",
     venue: {
@@ -240,34 +240,39 @@ const conferences = [
   {
     slug: "2020",
     year: 2020,
-    ordinal: 3,
-    startDate: "2020-06-25",
-    endDate: "2020-06-26",
-    // Online edition due to COVID — keep city blank, use displayCity to
-    // surface the "Online edition" label in the archive heading slot.
+    // The 2020 conference was DEFERRED to 2021 due to COVID-19 — it is
+    // not a separate numbered edition. The deferred conference was held
+    // at ISCTE-IUL, Lisbon on 3–4 September 2021 and counts as the 4th
+    // (see the 2021 entry). `deferred: true` excludes it from the
+    // edition count (see `editionCount` below). No `ordinal`.
+    deferred: true,
+    // startDate kept in 2020 only so /past sorts this entry between 2019
+    // and 2021; the conference was actually held in September 2021.
+    startDate: "2020-09-03",
+    endDate: "2020-09-04",
     city: "",
-    country: "",
+    country: "Portugal",
     venue: {
-      en: "Online — held online due to the COVID-19 pandemic",
-      fr: "En ligne — tenue en ligne en raison de la pandémie de COVID-19",
-      de: "Online — aufgrund der COVID-19-Pandemie online abgehalten",
+      en: "Deferred to 2021 — held at ISCTE-IUL, Lisbon",
+      fr: "Reportée à 2021 — tenue à l'ISCTE-IUL, Lisbonne",
+      de: "Auf 2021 verschoben — abgehalten an der ISCTE-IUL, Lissabon",
     },
     archiveMeta: {
-      en: "3rd Annual Conference — held online due to the COVID-19 pandemic",
-      fr: "3e conférence annuelle — tenue en ligne en raison de la pandémie de COVID-19",
-      de: "3. Jahreskonferenz — aufgrund der COVID-19-Pandemie online abgehalten",
+      en: "Deferred to 2021 due to the COVID-19 pandemic · held at ISCTE-IUL, Lisbon",
+      fr: "Reportée à 2021 en raison de la pandémie de COVID-19 · tenue à l'ISCTE-IUL, Lisbonne",
+      de: "Wegen der COVID-19-Pandemie auf 2021 verschoben · abgehalten an der ISCTE-IUL, Lissabon",
     },
     displayCity: {
-      en: "Online edition",
-      fr: "Édition en ligne",
-      de: "Online-Ausgabe",
+      en: "Deferred to 2021",
+      fr: "Reportée à 2021",
+      de: "Auf 2021 verschoben",
     },
     hasOwnPage: true,
   },
   {
     slug: "2019",
     year: 2019,
-    ordinal: 2,
+    ordinal: 3,
     startDate: "2019-06-13",
     endDate: "2019-06-14",
     city: "Paris",
@@ -278,9 +283,9 @@ const conferences = [
       de: "Sciences Po CERI, Paris",
     },
     archiveMeta: {
-      en: "2nd Annual Conference · Sciences Po CERI, Paris",
-      fr: "2e conférence annuelle · Sciences Po CERI, Paris",
-      de: "2. Jahreskonferenz · Sciences Po CERI, Paris",
+      en: "3rd Annual Conference · Sciences Po CERI, Paris",
+      fr: "3e conférence annuelle · Sciences Po CERI, Paris",
+      de: "3. Jahreskonferenz · Sciences Po CERI, Paris",
     },
     displayCity: { en: "Paris", fr: "Paris", de: "Paris" },
     youtubePlaylist: "PLkI2R8FsFqV4_TVOCV5qfPFAmZn1KbWGv",
@@ -309,11 +314,19 @@ const past = conferences
 // src/_includes/registration-badge.njk pulls `conferences.byYear[year]`.
 const byYear = Object.fromEntries(conferences.map((c) => [String(c.year), c]));
 
+// Distinct numbered editions, for display counts like /initiative's
+// "N annual conferences" stat. Excludes the deferred 2020 (folded into
+// the 2021 edition, `deferred: true`) and adds the two founding-era
+// editions (2017, 2018) that have their own pages but predate this
+// array. Today: 2017, 2018, 2019, 2021, 2022, 2023, 2024, 2025, 2026 = 9.
+const editionCount = conferences.filter((c) => !c.deferred).length + 2;
+
 module.exports = {
   all: conferences,
   byYear,
   next: upcomingOrCurrent[0] || null,   // closest upcoming (or in-progress)
   upcoming: upcomingOrCurrent,
   past,
+  editionCount,
   today,
 };


### PR DESCRIPTION
Closes **#230** — the three contradictions across `conferences.js` and the per-year pages, reconciled in one pass (with your confirmed 2021 date).

| Field | Before | After |
|---|---|---|
| **2020** | "3rd Annual Conference · held online due to COVID" | **Deferred to 2021** (held at ISCTE-IUL, Lisbon); `deferred: true`, no ordinal |
| **2019** | ordinal 2 / "2nd Annual Conference" | **3rd** (2017 inaugural, 2018 second, 2019 third) — matches the `/2019` page |
| **2021 dates** | `2021-06-24` placeholder | **2021-09-03 / 04** (you confirmed 3–4 September) |
| **2022 dates** | `2022-06-23` placeholder | **2022-06-30 / 07-01** (the `/2022` page's 30 June – 1 July) |

Plus a new **`editionCount` export = 9** (2017, 2018, 2019, 2021–2026; the deferred 2020 excluded) as the single source of truth for display counts — consumed by `/initiative` in the #329 PR.

The `/2020` and `/2021` pages already state the deferred / 3–4 September narrative, so they're now consistent with the data. EN/FR/DE archive metadata updated in lockstep; drift + key-parity clean.

Visible change: the `/past` archive cards now read "3rd Annual Conference" for 2019 and "Deferred to 2021…" for 2020. Factual correction — please glance at `/past` in the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)