### PR TITLE
fix(seo): redirect /refund → /terms; repoint footer Terms link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,8 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 - **Search result thumbnails only show for people.** Bio-stub results carry a `kind: person` marker; other results (the board page, `/YYYY` pages) no longer show whatever image Pagefind auto-extracts first (a board member's face on `/board`, a speaker headshot, a logo), which read as wrong.
 - **Pinned Pagefind to 1.5.2 at deploy.** The unpinned `npx pagefind` could fetch a different version per deploy, and the index format / content-hashed shard names differ between versions, so back-to-back deploys could leave the CDN serving a mix of shards from two versions — surfacing as some queries (e.g. "board", "netsec") returning no results. Pinning keeps every build's index identical.
 
+- **`/refund.html` no longer duplicates `/terms.html`.** The two pages shipped byte-identical and both indexable. `/refund.html` now redirects to `/terms.html` (rel=canonical + meta-refresh), and the footer's *Terms* link points straight at `/terms` — which, unlike `/refund`, has FR/DE variants, so the link is now localised. Resolves the duplicate-content finding from the June 2026 QA audit (seo-01, part of [#416](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/416)).
+
 > ESSC 2026 opens in Stockholm on 11–12 June, and this release is built around the conference pages that carry it. The live programme on `/2026` now shows the full panel line-ups with every co-author and marks who is presenting, and printing it produces a clean handout rather than a stack of near-empty pages. Around it the archive fills out, the People page reflects who has moved on, and the English copy gets a consistent voice.
 
 ### The live ESSC 2026 programme

--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -83,7 +83,7 @@
       </p>
       <p class="footer-meta">
         <span class="footer-meta-links">
-          <a href="{{ '/refund.html' | localizedHref(lang) }}">{{ t.footer.legalLinks.terms }}</a> ·
+          <a href="{{ '/terms.html' | localizedHref(lang) }}">{{ t.footer.legalLinks.terms }}</a> ·
           <a href="{{ '/policy.html' | localizedHref(lang) }}">{{ t.footer.legalLinks.privacy }}</a> ·
           <a href="{{ '/accessibility.html' | localizedHref(lang) }}">{{ t.footer.legalLinks.accessibility }}</a> ·
           <a href="{{ '/sitemap.html' | localizedHref(lang) }}">{{ t.footer.legalLinks.sitemap }}</a> ·

--- a/src/refund.njk
+++ b/src/refund.njk
@@ -2,9 +2,10 @@
 layout: base.njk
 permalink: /refund.html
 title: Terms & Conditions
-description: Terms and conditions covering registration, membership, withdrawals and mailings for EISS.
-metaImage: /assets/images/refund-meta.jpg
+description: This page has moved to /terms.html.
+redirectTo: /terms.html
+redirectLabel: Terms & conditions
 navKey: ""
 ---
 
-{% include "terms-body.njk" %}
+{% include "redirect-body.njk" %}


### PR DESCRIPTION
Resolves the duplicate-content finding **seo-01** from the June 2026 QA audit (#416): `/refund.html` and `/terms.html` shipped **byte-identical and both indexable**.

- `/refund.html` now **redirects to `/terms.html`** (rel=canonical + 3s meta-refresh, via the site's existing `redirectTo` convention — same as `/conferencepast`).
- The footer's **"Terms" link** previously pointed at `/refund.html`; it now targets `/terms.html`, which (unlike `/refund`) has FR/DE variants — so the footer link is now **localised** (`/terms.fr.html` etc.) instead of always English.
- Left the sitemap's "(also at /refund.html)" note alone to avoid clashing with #425's sitemap edit; it's still accurate (refund resolves via redirect).

Verified: `/refund.html` emits the canonical + refresh to `/terms.html`, footer link localises, i18n drift clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)