### PR TITLE
2025 film: silent + intro leads with the Tsoukalis keynote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ audit trail. Same content, terser.
 
 #### Changed
 
+- **The conference film is now silent, and the 2025 intro leads with the keynote.** The 2025 film (on `/2025` and `/past`) drops the sound toggle, the “tap for sound” hint and the “Watch on YouTube” link. It plays muted, with a tap or the keyboard (Space / Enter) to play or pause. The `/2025` intro beside the film now opens with Loukas Tsoukalis's keynote, *“Will Putin and Trump finally force Europe to behave as a political adult?”*, and the European-strategic-autonomy context it set.
 - **Search results for people now show a headshot and a role pill.** The bio stubs expose the photo, role, and functional responsibility as Pagefind metadata; `search.js` renders a thumbnail and a role pill (e.g. "Board Member · Technology Coordinator") beside the name and excerpt. Non-person results are unchanged.
 
 - **Archive-page session recordings are a shared, data-driven block.** The near-identical hand-wired "Session recordings" sections on `/2019`, `/2023` and `/2024` are replaced by one `conference-media.njk` partial that reads the YouTube playlist + city from `conferences.js` (`youtubePlaylist` per year). Future archive pages only set the playlist in the data and include the partial — no per-page recordings markup to drift out of sync. Closes [#358](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/358).

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -88,13 +88,13 @@
     "src/past.njk": {
       "fr": {
         "file": "src/past.fr.njk",
-        "source_sha1": "510f88fbe575f6fd4c9ccfb0cfdb0514cedc485a",
+        "source_sha1": "f7684c1094f02051e0f4d823478e93833ad44611",
         "translated_on": "2026-06-02",
         "status": "beta"
       },
       "de": {
         "file": "src/past.de.njk",
-        "source_sha1": "510f88fbe575f6fd4c9ccfb0cfdb0514cedc485a",
+        "source_sha1": "f7684c1094f02051e0f4d823478e93833ad44611",
         "translated_on": "2026-06-02",
         "status": "beta"
       }

--- a/src/2025.njk
+++ b/src/2025.njk
@@ -28,7 +28,8 @@ status: archive
    sets the src and muted-autoplays it ONLY when it scrolls into view, so
    nothing downloads for visitors who never reach it; it pauses
    off-screen. prefers-reduced-motion gets native controls and no
-   autoplay. A tap toggles play/pause; the button toggles sound. #}
+   autoplay. The film is silent (muted, no sound control). A tap or the
+   keyboard (Space / Enter) toggles play and pause. #}
 <section class="section" aria-labelledby="intro-2025-title">
   <div class="container">
     <div class="film-feature">
@@ -37,17 +38,21 @@ status: archive
         <h2 id="intro-2025-title">Two days in Thessaloniki</h2>
         <p>
           The 8th EISS Annual Conference brought the community to the University of
-          Macedonia for two days of panels and roundtables, opened by a keynote from
-          Loukas Tsoukalis.
+          Macedonia for two days of panels and roundtables.
+        </p>
+        <p>
+          It opened with a keynote from <strong>Loukas Tsoukalis</strong>, President of the
+          Hellenic Foundation for European and Foreign Policy (ELIAMEP) and a professor at
+          Sciences Po, who asked <em>“Will Putin and Trump finally force Europe to behave as
+          a political adult?”</em>. His provocation on European strategic autonomy set the
+          tone for the two days that followed.
         </p>
         <p class="muted">
-          A short film, shot and edited on site, captures the atmosphere across the
-          venue. Tap it for sound, or watch the full cut on YouTube.
+          A short film, shot and edited on site, captures the atmosphere across the venue.
         </p>
       </div>
       {%- set filmSrc = "/assets/video/essc-2025.mp4" -%}
       {%- set filmPoster = "/assets/images/2025/essc-2025-film-poster.jpg" -%}
-      {%- set filmYoutube = "https://www.youtube.com/watch?v=CFtUrpwgYXY&list=PLkI2R8FsFqV5cFsuE4s-A_0RHQMo2yq0_" -%}
       {%- set filmCaption = "ESSC 2025, Thessaloniki." -%}
       {% include "film-embed.njk" %}
     </div>

--- a/src/_includes/film-embed.njk
+++ b/src/_includes/film-embed.njk
@@ -6,13 +6,12 @@
                    iOS (GitHub Release assets are application/octet-stream
                    + attachment, which iOS refuses to play inline)
      filmPoster  — poster image path
-     filmYoutube — link to the full Short (optional)
      filmCaption — already-localised caption line (optional)
 
    theme.js sets the src and muted-autoplay-loops it only when it scrolls
-   into view (nothing downloads otherwise; pauses off-screen). A tap
-   toggles play/pause; the button toggles sound; a subtle "tap for sound"
-   hint shows while muted and is dismissed on first interaction.
+   into view (nothing downloads otherwise; pauses off-screen). The film is
+   silent — muted, no sound control. A tap or the keyboard (Space / Enter)
+   toggles play/pause; a centre play button appears if autoplay is blocked.
    prefers-reduced-motion: native controls, no autoplay. #}
 {% from "icons.njk" import icon %}
 {%- set _lang = lang or "en" -%}
@@ -26,15 +25,8 @@
     <button class="film-play" type="button" data-film-play hidden aria-label="{{ t.film.play }}">
       <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>
     </button>
-    <span class="film-hint" data-film-hint>{{ icon("volume-2") }} {{ t.film.tapForSound }}</span>
-    <button class="film-sound" type="button" data-film-sound aria-pressed="false" aria-label="{{ t.film.toggleSound }}">
-      <span class="film-sound-muted" aria-hidden="true">{{ icon("volume-x") }}</span>
-      <span class="film-sound-on" aria-hidden="true">{{ icon("volume-2") }}</span>
-    </button>
   </div>
-  {%- if filmCaption or filmYoutube %}
-  <figcaption class="film-caption muted">
-    {{ filmCaption }}{% if filmYoutube %} <a href="{{ filmYoutube }}" target="_blank" rel="noopener">{{ t.film.watchOnYouTube }} {{ icon("external-link") }}</a>{% endif %}
-  </figcaption>
+  {%- if filmCaption %}
+  <figcaption class="film-caption muted">{{ filmCaption }}</figcaption>
   {%- endif %}
 </figure>

--- a/src/assets/js/theme.js
+++ b/src/assets/js/theme.js
@@ -355,15 +355,14 @@
    (and muted-autoplay started) when the video scrolls into view, so the
    ~20 MB file never downloads for visitors who don't reach it; it pauses
    off-screen. prefers-reduced-motion: no autoplay, native controls instead.
-   A tap toggles play/pause; the sound button toggles mute. */
+   The film is muted (no sound control). A tap or the keyboard (Space /
+   Enter) toggles play/pause. */
 (function () {
   "use strict";
   var reduce = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   Array.prototype.forEach.call(document.querySelectorAll(".film"), function (fig) {
     var v = fig.querySelector(".film-video[data-film]");
     if (!v) return;
-    var btn = fig.querySelector("[data-film-sound]");
-    var hint = fig.querySelector("[data-film-hint]");
     var playBtn = fig.querySelector("[data-film-play]");
     var loaded = false;
     // iOS only honours muted inline autoplay if `muted` is set as a
@@ -386,15 +385,12 @@
       // policy), surface the centre play button so a tap can start it.
       if (p && p.then) { p.then(function () { showPlay(false); }, function () { showPlay(true); }); }
     }
-    function dropHint() { if (hint) hint.hidden = true; }
-    function toggle() { if (v.paused) { tryPlay(); } else { v.pause(); } dropHint(); }
+    function toggle() { if (v.paused) { tryPlay(); } else { v.pause(); } }
 
     if (reduce) {
       load();
       v.controls = true;
-      if (btn) btn.hidden = true;
       showPlay(false);
-      dropHint();
       return;
     }
 
@@ -426,16 +422,5 @@
     if (playBtn) {
       playBtn.addEventListener("click", function (e) { e.stopPropagation(); toggle(); });
     }
-    if (btn) {
-      btn.addEventListener("click", function (e) {
-        e.stopPropagation();
-        v.muted = !v.muted;
-        if (!v.muted) tryPlay();
-        btn.setAttribute("aria-pressed", String(!v.muted));
-        dropHint();
-      });
-    }
-    // Fade the hint after a few seconds even without interaction.
-    if (hint) setTimeout(dropHint, 6000);
   });
 })();

--- a/src/past.de.njk
+++ b/src/past.de.njk
@@ -82,7 +82,6 @@ alternates:
     <div class="archive-film">
       {%- set filmSrc = "/assets/video/essc-2025.mp4" -%}
       {%- set filmPoster = "/assets/images/2025/essc-2025-film-poster.jpg" -%}
-      {%- set filmYoutube = "https://www.youtube.com/watch?v=CFtUrpwgYXY&list=PLkI2R8FsFqV5cFsuE4s-A_0RHQMo2yq0_" -%}
       {%- set filmCaption = "ESSC 2025 · Thessaloniki" -%}
       {% include "film-embed.njk" %}
     </div>

--- a/src/past.fr.njk
+++ b/src/past.fr.njk
@@ -82,7 +82,6 @@ alternates:
     <div class="archive-film">
       {%- set filmSrc = "/assets/video/essc-2025.mp4" -%}
       {%- set filmPoster = "/assets/images/2025/essc-2025-film-poster.jpg" -%}
-      {%- set filmYoutube = "https://www.youtube.com/watch?v=CFtUrpwgYXY&list=PLkI2R8FsFqV5cFsuE4s-A_0RHQMo2yq0_" -%}
       {%- set filmCaption = "ESSC 2025 · Thessaloniki" -%}
       {% include "film-embed.njk" %}
     </div>

--- a/src/past.njk
+++ b/src/past.njk
@@ -83,7 +83,6 @@ alternates:
     <div class="archive-film">
       {%- set filmSrc = "/assets/video/essc-2025.mp4" -%}
       {%- set filmPoster = "/assets/images/2025/essc-2025-film-poster.jpg" -%}
-      {%- set filmYoutube = "https://www.youtube.com/watch?v=CFtUrpwgYXY&list=PLkI2R8FsFqV5cFsuE4s-A_0RHQMo2yq0_" -%}
       {%- set filmCaption = "ESSC 2025 · Thessaloniki" -%}
       {% include "film-embed.njk" %}
     </div>


### PR DESCRIPTION
Two requested changes to the 2025 conference film.

**Silent film, no YouTube (item 1).** The film (on `/2025` and `/past`, all locales) loses:
- the **sound toggle** button and the *"tap for sound"* hint — it now plays **muted** with no sound control;
- the **"Watch on YouTube"** link (`filmYoutube` removed from `/2025`, `/past`, `/past.fr`, `/past.de`).

Play/pause stays available by tap/click and by keyboard (Space / Enter), and reduced-motion users keep native controls. (The footer's EISS-channel YouTube social icon is unrelated and untouched.)

**Intro leads with the keynote (item 2).** The `/2025` text beside the film now opens with Loukas Tsoukalis's keynote — *"Will Putin and Trump finally force Europe to behave as a political adult?"* — and the European-strategic-autonomy context it set, replacing the old "tap for sound / YouTube" sentence.

Verified in-browser: sound button + hint gone, video muted, **Space toggled play/pause**, caption intact, no console errors. i18n drift clean (`past` FR/DE re-stamped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)