### PR TITLE
initiative: add the 2025 film beside the "What we do" cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ audit trail. Same content, terser.
 
 #### Changed
 
+- **The 2025 conference film now sits in the `/initiative` “What we do” section.** It plays beside the four activity cards (film to the right on desktop, the cards in a 2×2 block aligned to its top; stacked below the cards on mobile), reusing the silent muted-autoplay player. EN + FR + DE.
 - **The conference film is now silent, and the 2025 intro leads with the keynote.** The 2025 film (on `/2025` and `/past`) drops the sound toggle, the “tap for sound” hint and the “Watch on YouTube” link. It plays muted, with a tap or the keyboard (Space / Enter) to play or pause. The `/2025` intro beside the film now opens with Loukas Tsoukalis's keynote, *“Will Putin and Trump finally force Europe to behave as a political adult?”*, and the European-strategic-autonomy context it set.
 - **Search results for people now show a headshot and a role pill.** The bio stubs expose the photo, role, and functional responsibility as Pagefind metadata; `search.js` renders a thumbnail and a role pill (e.g. "Board Member · Technology Coordinator") beside the name and excerpt. Non-person results are unchanged.
 

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -18,14 +18,14 @@
     "src/initiative.njk": {
       "fr": {
         "file": "src/initiative.fr.njk",
-        "source_sha1": "8ea5d1fe71be896362545d27557ade1976e8d36f",
-        "translated_on": "2026-06-01",
+        "source_sha1": "74cff4717922edced9255c745f5398773318255c",
+        "translated_on": "2026-06-02",
         "status": "beta"
       },
       "de": {
         "file": "src/initiative.de.njk",
-        "source_sha1": "8ea5d1fe71be896362545d27557ade1976e8d36f",
-        "translated_on": "2026-06-01",
+        "source_sha1": "74cff4717922edced9255c745f5398773318255c",
+        "translated_on": "2026-06-02",
         "status": "beta"
       }
     },

--- a/src/initiative.de.njk
+++ b/src/initiative.de.njk
@@ -63,7 +63,9 @@ alternates:
       Kalender von Netzwerk-Veranstaltungen.
     </p>
 
-    <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr)); margin-top: var(--space-5);">
+    <div class="film-feature" style="margin-top: var(--space-5);">
+      <div class="film-feature-body">
+        <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));">
       <article class="tile">
         <div class="tile-icon" aria-hidden="true">{{ icon("users") }}</div>
         <h3>Jahreskonferenz (ESSC)</h3>
@@ -112,6 +114,14 @@ alternates:
           <a class="link-arrow" href="/events.de.html">Netzwerk-Veranstaltungen {{ icon("arrow-right") }}</a>
         </p>
       </article>
+        </div>
+      </div>
+      {# 2025 conference film, beside the activity cards (silent, muted-autoplay
+         when it scrolls into view; shared partial + theme.js handler). #}
+      {%- set filmSrc = "/assets/video/essc-2025.mp4" -%}
+      {%- set filmPoster = "/assets/images/2025/essc-2025-film-poster.jpg" -%}
+      {%- set filmCaption = "ESSC 2025 · Thessaloniki" -%}
+      {% include "film-embed.njk" %}
     </div>
   </div>
 </section>

--- a/src/initiative.fr.njk
+++ b/src/initiative.fr.njk
@@ -63,7 +63,9 @@ alternates:
       d'événements du réseau.
     </p>
 
-    <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr)); margin-top: var(--space-5);">
+    <div class="film-feature" style="margin-top: var(--space-5);">
+      <div class="film-feature-body">
+        <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));">
       <article class="tile">
         <div class="tile-icon" aria-hidden="true">{{ icon("users") }}</div>
         <h3>Conférence annuelle (ESSC)</h3>
@@ -112,6 +114,14 @@ alternates:
           <a class="link-arrow" href="/events.fr.html">Événements du réseau {{ icon("arrow-right") }}</a>
         </p>
       </article>
+        </div>
+      </div>
+      {# 2025 conference film, beside the activity cards (silent, muted-autoplay
+         when it scrolls into view; shared partial + theme.js handler). #}
+      {%- set filmSrc = "/assets/video/essc-2025.mp4" -%}
+      {%- set filmPoster = "/assets/images/2025/essc-2025-film-poster.jpg" -%}
+      {%- set filmCaption = "ESSC 2025 · Thessaloniki" -%}
+      {% include "film-embed.njk" %}
     </div>
   </div>
 </section>

--- a/src/initiative.njk
+++ b/src/initiative.njk
@@ -68,7 +68,9 @@ alternates:
       Action, training the next generation, periodic surveys, and a rolling calendar of network events.
     </p>
 
-    <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr)); margin-top: var(--space-5);">
+    <div class="film-feature" style="margin-top: var(--space-5);">
+      <div class="film-feature-body">
+        <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));">
       <article class="tile">
         <div class="tile-icon" aria-hidden="true">{{ icon("users") }}</div>
         <h3>Annual Conference (ESSC)</h3>
@@ -116,6 +118,14 @@ alternates:
           <a class="link-arrow" href="/events.html">Network events {{ icon("arrow-right") }}</a>
         </p>
       </article>
+        </div>
+      </div>
+      {# 2025 conference film, beside the activity cards (silent, muted-autoplay
+         when it scrolls into view; shared partial + theme.js handler). #}
+      {%- set filmSrc = "/assets/video/essc-2025.mp4" -%}
+      {%- set filmPoster = "/assets/images/2025/essc-2025-film-poster.jpg" -%}
+      {%- set filmCaption = "ESSC 2025 · Thessaloniki" -%}
+      {% include "film-embed.njk" %}
     </div>
   </div>
 </section>


### PR DESCRIPTION
Item 3: adds the 2025 conference film to the **"What we do"** section on `/initiative` (EN + FR + DE), beside the activity cards.

- The section's tile-grid is wrapped in a `.film-feature`, so on desktop the **four activity cards sit as a 2×2 block on the left and the portrait film on the right**, tops aligned. On mobile it stacks (cards, then film).
- Reuses the **silent** muted-autoplay `film-embed` partial (the one updated in #441 — no sound, no YouTube link), caption "ESSC 2025 · Thessaloniki".

Verified in-browser at 1280px (film right of a 2×2 card block, tops aligned, no overflow) and 375px (stacked, no overflow). i18n drift re-stamped and clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)