### PR TITLE
Restore the missing v2.24.0 release header in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,8 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 - **`/refund.html` no longer duplicates `/terms.html`.** The two pages shipped byte-identical and both indexable. `/refund.html` now redirects to `/terms.html` (rel=canonical + meta-refresh), and the footer's *Terms* link points straight at `/terms` — which, unlike `/refund`, has FR/DE variants, so the link is now localised. Resolves the duplicate-content finding from the June 2026 QA audit (seo-01, part of [#416](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/416)).
 
+## [2.24.0] · 2026-05-30 — Live programme depth and a print overhaul
+
 > ESSC 2026 opens in Stockholm on 11–12 June, and this release is built around the conference pages that carry it. The live programme on `/2026` now shows the full panel line-ups with every co-author and marks who is presenting, and printing it produces a clean handout rather than a stack of near-empty pages. Around it the archive fills out, the People page reflects who has moved on, and the English copy gets a consistent voice.
 
 ### The live ESSC 2026 programme


### PR DESCRIPTION
You were right — the **last release's header/title was missing**.

The v2.24.0 release block was fully present in `CHANGELOG.md` (its lede blockquote, the four themed `###` sub-sections, and the `### Index of changes` with `#### Added/Changed/Fixed/Security`), but the `## [2.24.0] · 2026-05-30 — …` heading line was gone. As a result the entire released section was rendering as a continuation of `[Unreleased]` — the file jumped straight from `[Unreleased]` to `[2.23.1]`.

## Fix

Restored the one missing line:

```
## [2.24.0] · 2026-05-30 — Live programme depth and a print overhaul
```

matched to the source of truth:
- GitHub Release: **"v2.24.0 — Live programme depth and a print overhaul"**, published 2026-05-30.
- `docs/roadmap-2026.md` release history: *"v2.24.0 · 30 May 2026 — Live programme depth and a print overhaul"*.

Section order is now `[Unreleased]` → `[2.24.0]` → `[2.23.1]`. No content changed, just the heading. Likely lost in a merge when `[Unreleased]` and the release section sat adjacent (the §4 concurrent-CHANGELOG hazard).

Non-visual docs fix, so auto-merge armed per §2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)