### PR TITLE
CI: build-sanity guard (duplicate data keys + empty/junk href·src)

### DIFF
--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -1,0 +1,56 @@
+# Build-sanity guard.
+#
+# Runs scripts/check-build-sanity.mjs, which fails the build on:
+#   - duplicate keys in an object literal in src/_data/*.js (JS silently
+#     keeps the last, dropping a value — this broke /2026's programme-PDF
+#     buttons, issue #479)
+#   - empty or junk href="" / src="" (and literal undefined / null /
+#     [object Object]) in the built _site/ (looks interactive but does
+#     nothing, or a template read a missing/wrong-typed value — issue #478)
+#
+# These slip past Eleventy (builds duplicate-key objects without error)
+# and the link checker (an empty href is a no-op, not a broken link).
+#
+# Status: gating. The script exits non-zero on any finding. It passes
+# clean on the current tree, so it only ever fires on a real regression.
+#
+# Mirrors the build + Node setup of link-check.yml. SHA-pinned actions
+# per CLAUDE.md §2.
+name: Build sanity
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'scripts/check-build-sanity.mjs'
+      - '.github/workflows/sanity-check.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.eleventy.js'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sanity:
+    name: Duplicate data keys + empty href/src
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Build site
+        run: npm run build
+
+      - name: Run build-sanity check
+        run: node scripts/check-build-sanity.mjs

--- a/scripts/check-build-sanity.mjs
+++ b/scripts/check-build-sanity.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Build-sanity guard. Catches the class of bug that the link checker and
+ * Eleventy build both miss, and that bit /2026's programme-PDF buttons
+ * (issues #478, #479):
+ *
+ *   1. Duplicate keys in an object literal in src/_data/*.js. JavaScript
+ *      silently keeps the last duplicate, so a key declared twice (e.g.
+ *      `programmePdf` as both an object and a string) drops one value
+ *      with no error anywhere. Parsed with acorn (already a locked dep).
+ *
+ *   2. Empty or junk href / src attributes in the built _site/. An
+ *      `href=""` looks like a link but only reloads the page ("reactive
+ *      but not clickable"); a literal `undefined` / `[object Object]`
+ *      in an attribute means a template read a missing or wrong-typed
+ *      value. The link checker treats an empty href as a no-op, not a
+ *      broken link, so it slips through.
+ *
+ * Exit 0 when clean, 1 (with a report) on any finding. Run after the
+ * build so _site/ exists; the data-key check works without a build.
+ *
+ * Usage: node scripts/check-build-sanity.mjs
+ */
+import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import * as acorn from "acorn";
+
+const problems = [];
+const lineOf = (src, idx) => src.slice(0, idx).split("\n").length;
+
+// ── 1. Duplicate object keys in src/_data/*.js ──────────────────────────
+function checkDataKeys() {
+  const dir = "src/_data";
+  if (!existsSync(dir)) return;
+  for (const f of readdirSync(dir).filter((n) => n.endsWith(".js"))) {
+    const file = join(dir, f);
+    const src = readFileSync(file, "utf8");
+    let ast;
+    try {
+      ast = acorn.parse(src, { ecmaVersion: "latest", sourceType: "module" });
+    } catch (e) {
+      problems.push(`${file}: could not parse (${e.message})`);
+      continue;
+    }
+    const walk = (node) => {
+      if (!node || typeof node !== "object") return;
+      if (node.type === "ObjectExpression") {
+        const seen = new Map();
+        for (const p of node.properties) {
+          if (p.type !== "Property" || p.computed) continue;
+          const key = p.key.name ?? p.key.value;
+          if (seen.has(key)) {
+            problems.push(
+              `${file}:${lineOf(src, p.start)}: duplicate key "${key}" ` +
+                `(first defined on line ${lineOf(src, seen.get(key))}) — ` +
+                `JS keeps only the last, silently dropping a value`
+            );
+          } else {
+            seen.set(key, p.start);
+          }
+        }
+      }
+      for (const k in node) {
+        const v = node[k];
+        if (Array.isArray(v)) v.forEach(walk);
+        else if (v && typeof v === "object" && v.type) walk(v);
+      }
+    };
+    walk(ast);
+  }
+}
+
+// ── 2. Empty / junk href|src in built HTML ──────────────────────────────
+function htmlFiles(dir, out = []) {
+  if (!existsSync(dir)) return out;
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const s = statSync(p);
+    if (s.isDirectory()) htmlFiles(p, out);
+    else if (name.endsWith(".html")) out.push(p);
+  }
+  return out;
+}
+
+function checkBuiltHtml() {
+  const files = htmlFiles("_site");
+  if (!files.length) {
+    console.warn("note: _site/ not found — skipping built-HTML checks (run `npm run build` first)");
+    return;
+  }
+  // Empty href/src, and literal undefined / null / [object Object] / NaN
+  // landing in a URL-ish attribute. None of these is ever legitimate.
+  const empty = /\s(href|src)=""/g;
+  const junk = /\s(href|src|srcset|poster|action|content)="(undefined|null|NaN|\[object Object\])"/g;
+  const objObj = /\[object Object\]/g;
+  for (const file of files) {
+    const txt = readFileSync(file, "utf8");
+    const rel = file.replace(/^_site\//, "");
+    for (const m of txt.matchAll(empty)) problems.push(`${rel}:${lineOf(txt, m.index)}: empty ${m[1]}="" (looks interactive, does nothing)`);
+    for (const m of txt.matchAll(junk)) problems.push(`${rel}:${lineOf(txt, m.index)}: ${m[1]}="${m[2]}" (template read a missing/wrong-typed value)`);
+    for (const m of txt.matchAll(objObj)) problems.push(`${rel}:${lineOf(txt, m.index)}: "[object Object]" in output (an object rendered where a string was expected)`);
+  }
+}
+
+checkDataKeys();
+checkBuiltHtml();
+
+if (problems.length) {
+  console.error(`\n✗ build-sanity check failed (${problems.length} problem${problems.length > 1 ? "s" : ""}):\n`);
+  for (const p of problems) console.error("  - " + p);
+  console.error("");
+  process.exit(1);
+}
+console.log("✓ build-sanity check passed (no duplicate data keys, no empty/junk href/src).");


### PR DESCRIPTION
Closes #479 and #478 — two quick-win guards for the bug class that broke `/2026`'s programme-PDF buttons and slipped past every existing gate.

## What it catches
`scripts/check-build-sanity.mjs` fails the build on:
1. **Duplicate keys in a `src/_data/*.js` object literal** (#479) — JS keeps the last duplicate and silently drops the other value (exactly the `programmePdf` object-vs-string collision behind #476). Parsed with **acorn**, already locked in `package-lock.json` via Eleventy, so **no new dependency**.
2. **Empty `href=""` / `src=""`**, plus literal `undefined` / `null` / `[object Object]` in URL-ish attributes, in the built `_site/` (#478) — an empty `href` looks interactive but only reloads the page (the "reactive but not clickable" class from #459/#476). Eleventy builds these without error and the link checker treats an empty `href` as a no-op, so neither catches them.

## Why it's safe to land now
- **Passes clean on the current tree** (verified locally), so it only ever fires on a genuine regression — it won't block the in-flight conference PRs.
- **Zero false-positive surface**: duplicate object keys and empty/junk href·src are never legitimate.
- Negative-tested: confirmed it fails (exit 1, with `file:line`) on an injected duplicate key and an injected `href=""`.
- New workflow mirrors `link-check.yml`'s build + Node setup, **SHA-pinned** per §2, `permissions: contents: read`, runs on PRs touching `src/**`, the script, or build config.

CI tooling, so no CHANGELOG entry (§4). Non-visual, so auto-merge armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)