### PR TITLE
docs(branch-protection): cross-reference Phase 3 issue #501

### DIFF
--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -43,6 +43,8 @@ checks continue to gate the normal merge path.
 
 ## What's deferred to Phase 3, and why
 
+_Tracked in [#501](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/501)._
+
 **Required status checks are intentionally *not* enforced yet.** On this
 repo they would strand the daily automation:
 


### PR DESCRIPTION
Adds a tracked-in link from the Phase 3 section of `docs/branch-protection.md` to #501, closing the §3 audit-trail loop. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)