### PR TITLE
Skip eur-lex.europa.eu in the link checker (anti-bot 403)

### DIFF
--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -103,6 +103,11 @@ SKIP_HOSTS = {
                                 # unrecognised User-Agent strings.
                                 # The transit-info page works for
                                 # visitors heading to ESSC 2022.
+    "eur-lex.europa.eu",        # EU's official law portal returns 403
+                                # to automated HEAD/GET regardless of
+                                # UA. The GDPR citation in the privacy
+                                # notice (all three locales) opens fine
+                                # in a browser.
 }
 
 internal_links = {}  # (file, target) for de-dupe display


### PR DESCRIPTION
## What's happening
The link checker's external pass fails on `https://eur-lex.europa.eu/eli/reg/2016/679/oj` (the GDPR citation in the privacy notice, all three locales) with **HTTP 403 Forbidden**. EUR-Lex, the EU's official law portal, blocks automated HEAD/GET regardless of User-Agent, the same anti-bot pattern `SKIP_HOSTS` already documents for `www.berlin-airport.de` and `shs.cairn.info`. The link opens fine in a browser.

This false red recurs on **every PR that builds the policy pages** and masks genuine link failures (it's how the stale board-link errors hid behind a red check until #521). Surfaced again on #524.

## Fix
Add `eur-lex.europa.eu` to `SKIP_HOSTS` in `scripts/check-links.sh`, with a comment matching the existing entries.

Not adding `www.su.se` (the other host seen failing on #518): that was a transient `Network is unreachable` runner blip, not a consistent anti-bot block, so skipping it would mask real future breakage.

## Scope
Internal CI tooling, no site/user-visible change (CHANGELOG-exempt per §4). Auto-merge armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)