### PR TITLE
Normalise profile-link schemes so a bare ORCID/domain can't 404 (#522)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -96,6 +96,33 @@ module.exports = function (eleventyConfig) {
     return href; // localised version doesn't exist; fall back to EN
   });
 
+  // {{ links.website | extLink }} -> a guaranteed-absolute external URL.
+  // Profile links on the board cards render straight into `href`, so a
+  // value stored without a scheme (a bare domain like "example.com", or
+  // a bare ORCID iD like "0000-0001-9311-6480") would resolve as a path
+  // on eiss-europa.com and 404. This filter normalises:
+  //   - already-absolute (http://, https://, //) -> unchanged
+  //   - bare ORCID iD (NNNN-NNNN-NNNN-NNNC)        -> https://orcid.org/<id>
+  //   - anything else                              -> "https://" + value
+  // It is a defensive backstop: sync-board.py normalises the same way at
+  // the source, and check-build-sanity.mjs fails the build on a
+  // scheme-less links value, so in practice this only ever fires on a
+  // hand-edit to board.json that slipped past both. Idempotent.
+  const ORCID_ID_RE = /^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$/;
+  eleventyConfig.addFilter("extLink", (value) => {
+    if (!value || typeof value !== "string") return value;
+    const v = value.trim();
+    if (
+      v.startsWith("http://") ||
+      v.startsWith("https://") ||
+      v.startsWith("//")
+    ) {
+      return v;
+    }
+    if (ORCID_ID_RE.test(v)) return `https://orcid.org/${v}`;
+    return `https://${v}`;
+  });
+
   eleventyConfig.addPassthroughCopy("src/assets");
   // Runtime-fetched data files live under src/data/ (NOT src/_data/,
   // which is Eleventy's build-time data cascade and never lands in

--- a/scripts/check-build-sanity.mjs
+++ b/scripts/check-build-sanity.mjs
@@ -16,8 +16,17 @@
  *      value. The link checker treats an empty href as a no-op, not a
  *      broken link, so it slips through.
  *
+ *   3. Scheme-less profile links in src/_data/board.json. The board card
+ *      template renders `links.*` straight into href, so a value without
+ *      a URL scheme (a bare domain, or a bare ORCID iD) resolves as a
+ *      path on eiss-europa.com and 404s (#522). The .eleventy.js
+ *      `extLink` filter and sync-board.py both normalise these, but this
+ *      asserts the stored data is already clean so a hand-edit can't
+ *      lean silently on the render-time backstop.
+ *
  * Exit 0 when clean, 1 (with a report) on any finding. Run after the
- * build so _site/ exists; the data-key check works without a build.
+ * build so _site/ exists; the data-key + board-link checks work without
+ * a build.
  *
  * Usage: node scripts/check-build-sanity.mjs
  */
@@ -102,7 +111,38 @@ function checkBuiltHtml() {
   }
 }
 
+// ── 3. Scheme-less profile links in src/_data/board.json ────────────────
+function checkBoardLinks() {
+  const file = "src/_data/board.json";
+  if (!existsSync(file)) return;
+  let data;
+  try {
+    data = JSON.parse(readFileSync(file, "utf8"));
+  } catch (e) {
+    problems.push(`${file}: could not parse (${e.message})`);
+    return;
+  }
+  const entries = [...(data.members ?? []), ...(data.support ?? [])];
+  for (const p of entries) {
+    const links = p.links;
+    if (!links || typeof links !== "object") continue;
+    for (const [key, value] of Object.entries(links)) {
+      // publicEmail is rendered as mailto: — not a URL with a scheme.
+      if (key === "publicEmail") continue;
+      if (typeof value !== "string" || !value) continue;
+      if (!/^(https?:)?\/\//.test(value)) {
+        problems.push(
+          `${file}: ${p.name ?? "?"} → links.${key} = "${value}" is missing a ` +
+            `URL scheme; it would render as a relative path and 404 ` +
+            `(use https://… , or for orcid the full https://orcid.org/<id>)`
+        );
+      }
+    }
+  }
+}
+
 checkDataKeys();
+checkBoardLinks();
 checkBuiltHtml();
 
 if (problems.length) {
@@ -111,4 +151,4 @@ if (problems.length) {
   console.error("");
   process.exit(1);
 }
-console.log("✓ build-sanity check passed (no duplicate data keys, no empty/junk href/src).");
+console.log("✓ build-sanity check passed (no duplicate data keys, no scheme-less board links, no empty/junk href/src).");

--- a/scripts/sync-board.py
+++ b/scripts/sync-board.py
@@ -344,6 +344,34 @@ LINK_FIELDS = {
     "mastodon": "mastodon",
 }
 
+# ORCID iDs are 16 characters in NNNN-NNNN-NNNN-NNNC form (the final
+# character is a checksum digit, occasionally "X").
+_ORCID_ID_RE = re.compile(r"^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$")
+
+
+def _normalize_link(out_key: str, value: str) -> str:
+    """Normalise a profile-link value to an absolute URL.
+
+    The board card template (`src/_includes/person-card.njk`) drops
+    `links.*` straight into `href`, so a value without a scheme (a bare
+    domain like "example.com", or a bare ORCID iD like
+    "0000-0001-9311-6480") would resolve as a path on eiss-europa.com and
+    404. A respondent typing either into the Form is the likely source.
+    Mirror of the `extLink` Nunjucks filter in .eleventy.js, applied here
+    so board.json is stored clean at the source rather than relying on
+    the render-time backstop.
+
+    `publicEmail` is left untouched (the template renders it as mailto:).
+    Idempotent: an already-absolute URL is returned unchanged."""
+    v = (value or "").strip()
+    if not v or out_key == "publicEmail":
+        return v
+    if v.startswith(("http://", "https://", "//")):
+        return v
+    if out_key == "orcid" and _ORCID_ID_RE.match(v):
+        return f"https://orcid.org/{v}"
+    return f"https://{v}"
+
 
 def build_from_row(row: dict, cols: dict, role_info: dict, prior: dict | None) -> dict:
     """Build a board.json entry from one form submission, falling back
@@ -431,7 +459,7 @@ def build_from_row(row: dict, cols: dict, role_info: dict, prior: dict | None) -
     for out_key, col_key in LINK_FIELDS.items():
         v = _cell(row, cols, col_key) or prior_links.get(out_key, "")
         if v:
-            links[out_key] = v
+            links[out_key] = _normalize_link(out_key, v)
     if links:
         person["links"] = links
 

--- a/src/_includes/person-card.njk
+++ b/src/_includes/person-card.njk
@@ -126,22 +126,22 @@
       <li><a href="mailto:{{ links.publicEmail }}" aria-label="Email {{ person.name }}">{{ icon("mail") }}</a></li>
       {%- endif %}
       {%- if links.website %}
-      <li><a href="{{ links.website }}" target="_blank" rel="noopener" aria-label="{{ person.name }}'s website">{{ icon("globe") }}</a></li>
+      <li><a href="{{ links.website | extLink }}" target="_blank" rel="noopener" aria-label="{{ person.name }}'s website">{{ icon("globe") }}</a></li>
       {%- endif %}
       {%- if links.orcid %}
-      <li><a href="{{ links.orcid }}" target="_blank" rel="noopener" aria-label="{{ person.name }}'s ORCID iD">{{ icon("orcid") }}</a></li>
+      <li><a href="{{ links.orcid | extLink }}" target="_blank" rel="noopener" aria-label="{{ person.name }}'s ORCID iD">{{ icon("orcid") }}</a></li>
       {%- endif %}
       {%- if links.linkedin %}
-      <li><a href="{{ links.linkedin }}" target="_blank" rel="noopener" aria-label="{{ person.name }} on LinkedIn">{{ icon("linkedin") }}</a></li>
+      <li><a href="{{ links.linkedin | extLink }}" target="_blank" rel="noopener" aria-label="{{ person.name }} on LinkedIn">{{ icon("linkedin") }}</a></li>
       {%- endif %}
       {%- if links.twitter %}
-      <li><a href="{{ links.twitter }}" target="_blank" rel="noopener" aria-label="{{ person.name }} on X / Twitter">{{ icon("twitter") }}</a></li>
+      <li><a href="{{ links.twitter | extLink }}" target="_blank" rel="noopener" aria-label="{{ person.name }} on X / Twitter">{{ icon("twitter") }}</a></li>
       {%- endif %}
       {%- if links.bluesky %}
-      <li><a href="{{ links.bluesky }}" target="_blank" rel="noopener" aria-label="{{ person.name }} on Bluesky">{{ icon("bluesky") }}</a></li>
+      <li><a href="{{ links.bluesky | extLink }}" target="_blank" rel="noopener" aria-label="{{ person.name }} on Bluesky">{{ icon("bluesky") }}</a></li>
       {%- endif %}
       {%- if links.mastodon %}
-      <li><a href="{{ links.mastodon }}" target="_blank" rel="noopener" aria-label="{{ person.name }} on Mastodon">{{ icon("mastodon") }}</a></li>
+      <li><a href="{{ links.mastodon | extLink }}" target="_blank" rel="noopener" aria-label="{{ person.name }} on Mastodon">{{ icon("mastodon") }}</a></li>
       {%- endif %}
     </ul>
     {%- endif %}


### PR DESCRIPTION
Closes #522. Structural follow-up to #521, which hand-fixed the two live broken board links. This closes the **class** so it can't recur.

## The bug class
`src/_includes/person-card.njk` renders `links.*` straight into `href`. A stored value without a URL scheme (a bare domain like `johnhelferich.com`, or a bare ORCID iD like `0000-0001-9311-6480`) is read by the browser as a relative path on `eiss-europa.com` and 404s. `board.json` is hand-edited today and a Google-Form sync is planned, so a respondent typing a bare value would reintroduce it.

## Three complementary guards
1. **`.eleventy.js` — `extLink` filter** (render-time backstop). Already-absolute → unchanged; bare ORCID iD → `https://orcid.org/<id>`; anything else → `https://` + value. Idempotent.
2. **`person-card.njk`** — the six raw-href links (website, orcid, linkedin, twitter, bluesky, mastodon) pass through `| extLink`. `publicEmail` (mailto:) untouched.
3. **`sync-board.py` — `_normalize_link`** mirrors the filter in `build_from_row`, so the future Form sync writes absolute URLs into `board.json` at the source.
4. **`check-build-sanity.mjs`** — a third check fails the build on any scheme-less `links.*` value (publicEmail exempt), so a hand-edit can't silently rely on the backstop.

## Verification
- `npx @11ty/eleventy` clean; rendered board hrefs unchanged for current (clean) data.
- `_normalize_link` unit-tested across 9 cases (bare iD, full ORCID URL, bare domain, http/https pass-through, email exemption, empty).
- **Negative test:** injecting `website: "example.com"` makes build-sanity exit 1 with a clear message; restored → passes.
- **Backstop proof:** with a bare `johnhelferich.com` in `board.json`, the build still emits `href="https://johnhelferich.com"`.

## Scope
Defensive infrastructure (filter + sync + CI) plus a template render-path change that is a **no-op for current clean data**, so no user-visible delta beyond what #521 already shipped — hence no CHANGELOG bullet (internal hardening, §4). Auto-merge armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)