### PR TITLE
Fix Indico sync: stop direct-pushing to protected master

### DIFF
--- a/.github/workflows/sync-indico.yml
+++ b/.github/workflows/sync-indico.yml
@@ -11,13 +11,17 @@
 #     co-authors, times, rooms, and abstracts added / removed / changed.
 #     The maintainer sees precisely what a sync will alter before it goes
 #     live, and merges with one click.
-#   - Timestamp only      → direct-commit the refreshed `syncedAt` to
-#     master so the "Last refreshed" line on the site stays current,
-#     without opening a noisy empty PR.
+#   - Timestamp only      → nothing to commit. `syncedAt` is internal
+#     metadata that nothing on the site renders, so a daily timestamp
+#     bump isn't worth a commit. If a "Last refreshed" line is ever
+#     surfaced, derive it from the daily scheduled-rebuild's build time
+#     rather than committing a timestamp every day.
 #
-# (Earlier this workflow always direct-committed. The PR path was added
-# so programme changes in the run-up to a conference are visible and
-# reviewable rather than landing silently.)
+# (History: this path used to direct-commit the timestamp to master, and
+# earlier still the whole workflow direct-committed. The PR path was added
+# so programme changes near a conference are reviewable; the timestamp
+# direct-commit was then dropped when branch protection began requiring
+# PRs for every change to master — a daily no-op push only failed the job.)
 #
 # Failure handling
 # ----------------
@@ -73,19 +77,14 @@ jobs:
           SYNC_INDICO_BODY_FILE: /tmp/indico-pr-body.md
         run: python3 scripts/sync-indico.py
 
-      - name: Direct-commit timestamp-only refresh
+      - name: Timestamp-only change — nothing to commit
         if: steps.sync.outputs.substantive != 'true'
         run: |
-          if [[ -n "$(git status --porcelain src/_data/indico.json)" ]]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add src/_data/indico.json
-            git commit -m "data: sync events from Indico ($(date -u +%Y-%m-%d)) [timestamp refresh]"
-            git push
-            echo "Pushed timestamp-only indico.json refresh to master."
-          else
-            echo "No change — indico.json already up to date."
-          fi
+          echo "No substantive programme change; only the syncedAt timestamp moved."
+          echo "syncedAt is internal metadata that nothing on the site renders, so a"
+          echo "daily timestamp bump is not worth a commit — and master is protected"
+          echo "(direct pushes are rejected; real changes go through the PR path"
+          echo "above). Leaving master untouched."
 
       - name: Open detailed PR for substantive changes
         if: steps.sync.outputs.substantive == 'true'


### PR DESCRIPTION
## What's happening
The daily **Sync events from Indico** job has been failing (e.g. [run 27002864204](https://github.com/EISSeuropa/EISSeuropa.github.io/actions/runs/27002864204)) with:

```
remote: error: GH013: Repository rule violations found for refs/heads/master.
remote: - Changes must be made through a pull request.
 ! [remote rejected] master -> master (push declined due to repository rule violations)
```

It's fallout from the branch-protection ruleset. The workflow has two paths:
- **Substantive programme change** → opens a reviewable PR on `indico-sync/auto` (unaffected — pushing to a feature branch + opening a PR is allowed).
- **Timestamp-only run** → *direct-committed* the moved `syncedAt` to `master`. The ruleset now requires every change to master to go through a PR, so this push is rejected and the job goes red **every day**.

## Fix
Drop the timestamp-only direct commit. `syncedAt` is internal metadata that **nothing on the site renders** (the `lastSynced` / "Last refreshed" i18n string is defined but unused), so the daily timestamp bump committed nothing visible. The path now no-ops with a log line; `master` is left untouched. The substantive-change PR path — which updates `syncedAt` whenever real programme changes land — is unchanged.

`sync-indico.yml` was the only workflow doing a direct `git push` to master; `sync-board`, `sync-roadmap` and `roadmap-progress` already use `create-pull-request`.

## Note for later
If a "Last refreshed" line is ever surfaced on the site, derive it from the daily scheduled-rebuild's **build time** rather than re-introducing a committed timestamp.

## Verification
- YAML validates.
- Logic: on a timestamp-only run the job now logs and exits 0 instead of attempting a rejected push. I'll trigger a `workflow_dispatch` run after this merges to confirm green.

Internal CI tooling, no site change (CHANGELOG-exempt §4). Auto-merge armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)