### PR TITLE
Harden auto-merge step against transient GitHub API failures

### DIFF
--- a/.github/workflows/roadmap-progress.yml
+++ b/.github/workflows/roadmap-progress.yml
@@ -102,7 +102,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr merge \
-            "${{ steps.create-pr.outputs.pull-request-number }}" \
-            --squash --auto \
-            --repo "${{ github.repository }}"
+          # Arm auto-merge, retrying transient GitHub API hiccups (e.g. a
+          # 504 Gateway Timeout on the enable-auto-merge call, which has
+          # failed the job and left a dangling un-merged auto-PR). Treat
+          # "already merged" / "auto-merge already enabled" as success so a
+          # partial first attempt doesn't then fail the retry.
+          pr="${{ steps.create-pr.outputs.pull-request-number }}"
+          repo="${{ github.repository }}"
+          for attempt in 1 2 3 4 5; do
+            if gh pr merge "$pr" --squash --auto --repo "$repo"; then
+              echo "Auto-merge armed (attempt $attempt)."
+              exit 0
+            fi
+            state=$(gh pr view "$pr" --repo "$repo" \
+              --json state,autoMergeRequest \
+              -q '.state + " auto=" + ((.autoMergeRequest != null) | tostring)' || true)
+            echo "Attempt $attempt failed; PR state: $state"
+            case "$state" in
+              MERGED*)    echo "Already merged."; exit 0 ;;
+              *auto=true) echo "Auto-merge already enabled."; exit 0 ;;
+            esac
+            sleep 15
+          done
+          echo "::error::Could not arm auto-merge after 5 attempts."
+          exit 1

--- a/.github/workflows/sync-roadmap.yml
+++ b/.github/workflows/sync-roadmap.yml
@@ -137,7 +137,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr merge \
-            "${{ steps.create-pr.outputs.pull-request-number }}" \
-            --squash --auto \
-            --repo "${{ github.repository }}"
+          # Arm auto-merge, retrying transient GitHub API hiccups (e.g. a
+          # 504 Gateway Timeout on the enable-auto-merge call, which has
+          # failed the job and left a dangling un-merged auto-PR). Treat
+          # "already merged" / "auto-merge already enabled" as success so a
+          # partial first attempt doesn't then fail the retry.
+          pr="${{ steps.create-pr.outputs.pull-request-number }}"
+          repo="${{ github.repository }}"
+          for attempt in 1 2 3 4 5; do
+            if gh pr merge "$pr" --squash --auto --repo "$repo"; then
+              echo "Auto-merge armed (attempt $attempt)."
+              exit 0
+            fi
+            state=$(gh pr view "$pr" --repo "$repo" \
+              --json state,autoMergeRequest \
+              -q '.state + " auto=" + ((.autoMergeRequest != null) | tostring)' || true)
+            echo "Attempt $attempt failed; PR state: $state"
+            case "$state" in
+              MERGED*)    echo "Already merged."; exit 0 ;;
+              *auto=true) echo "Auto-merge already enabled."; exit 0 ;;
+            esac
+            sleep 15
+          done
+          echo "::error::Could not arm auto-merge after 5 attempts."
+          exit 1


### PR DESCRIPTION
## Context — answering "are workflows blocked by branch protection?"
The **Sync roadmap progress** job failed. I traced it: the create-PR step succeeded (opened #545), then `gh pr merge --squash --auto` returned a **`504 Gateway Timeout`** from GitHub's API. That's a transient infrastructure error — **not** a branch-protection block.

### Full audit of every workflow's write-to-master path
| Workflow | Writes to master via | Branch-protection status |
|---|---|---|
| `sync-indico` | ~~direct `git push`~~ → no-op (fixed in #542); substantive path opens a PR | ✅ OK |
| `sync-board` | `create-pull-request` (review, no auto-merge) | ✅ OK |
| `sync-roadmap` (autostamp) | `create-pull-request` + `gh pr merge --auto` | ✅ OK — **merged successfully** at 09:56 today under the ruleset |
| `roadmap-progress` | `create-pull-request` + `gh pr merge --auto` | ✅ allowed; failed only on the transient 504 |
| `deploy`, `i18n-drift`, `link-check`, `sanity-check`, `scheduled-rebuild`, `probe-indico-api` | no write to master | ✅ OK |

**Conclusion: no workflow is blocked by branch protection.** The only direct push to master (sync-indico's timestamp path) was already fixed in #542; everything else uses the PR path, and the bot can open + merge its own PRs (proven by the autostamp job merging fine at the same moment the progress job 504'd).

## This PR
Makes the two auto-merging jobs resilient to the transient hiccup so it stops painting them red and leaving dangling PRs. The single `gh pr merge --squash --auto` becomes a 5-attempt retry (15s backoff) that treats "already merged" / "auto-merge already enabled" as success. A genuine persistent failure still surfaces after 5 attempts.

Already cleaned up: the dangling #545 from the 504 has been merged.

## Verification
- Both workflow YAMLs validate.
- Logic: on a transient failure the step retries instead of exiting 1; on success it exits immediately; idempotent against a partial first attempt.

Internal CI tooling, no site change (CHANGELOG-exempt §4). Auto-merge armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)