### PR TITLE
Skip www.su.se in the link checker (unreachable from CI runners)

### DIFF
--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -76,11 +76,13 @@ GET_HOSTS = {
     "docs.google.com", "forms.google.com",
 }
 
-# Hosts we deliberately skip. Two categories collapse here. (a)
+# Hosts we deliberately skip. Three categories collapse here. (a)
 # Auth-gated services that require login (the form/page works for
 # real visitors but returns 4xx to anonymous HEAD/GET). (b) Anti-bot
 # filters that block automated requests regardless of method, the
-# destination still works fine for human visitors.
+# destination still works fine for human visitors. (c) Hosts that the
+# GitHub Actions runners cannot reach on a persistent network route
+# (the URL is valid and resolves for visitors; CI just can't connect).
 SKIP_HOSTS = {
     "docs.google.com",          # Google Forms require user auth. The
                                 # form works for real visitors but
@@ -108,6 +110,15 @@ SKIP_HOSTS = {
                                 # UA. The GDPR citation in the privacy
                                 # notice (all three locales) opens fine
                                 # in a browser.
+    "www.su.se",                # Stockholm University (the ESSC 2026
+                                # venue, linked from /2026). Persistently
+                                # "Network is unreachable" from GitHub's
+                                # runners — a CI-side routing/firewall
+                                # issue, not a 4xx; the URL is valid and
+                                # loads for visitors. Skipping trades away
+                                # CI verification of this one link to stop
+                                # the recurring false-red; re-check the
+                                # link by hand if the venue URL changes.
 }
 
 internal_links = {}  # (file, target) for de-dupe display


### PR DESCRIPTION
## What's happening
The Stockholm University link (`https://www.su.se/`, the ESSC 2026 venue on /2026) **persistently** fails the CI link check with `Network is unreachable [Errno 101]` — a GitHub-runner-side routing/firewall issue, not a 4xx. It's reddened the link check on several recent PRs.

## Fix
Add `www.su.se` to `SKIP_HOSTS` in `scripts/check-links.sh`, as a third documented category (runner-unreachable) alongside the existing auth-gated and anti-bot hosts. The URL is valid and loads for visitors; the failure is purely CI-side, so the recurring red was false-positive noise that masks real link failures.

**Trade-off (noted in the comment):** CI no longer verifies this one link, so re-check it by hand if the venue URL ever changes. (I'd earlier left it out because a single "network unreachable" looked transient; you've confirmed it's persistent, which is the evidence for skipping.)

## Verification
Clean rebuild + `check-links.sh`: **2293 internal links resolve, 0 external broken**. (Also confirmed an apparent `prof-moritz-weiss` bios-anchor break was a stale local `_site` artifact — a clean build is consistent.)

Internal CI tooling, no site change (CHANGELOG-exempt §4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)