### PR TITLE
Skip eui.eu + twitter.com in the link checker (recurring CI false-reds)

### DIFF
--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -96,6 +96,10 @@ SKIP_HOSTS = {
                                 # profile URLs (board cards) work for
                                 # any logged-out visitor with a
                                 # browser.
+    "twitter.com",              # X/Twitter 403s unauthenticated bots
+                                # (same class as LinkedIn). The EISS
+                                # profile link in the footer resolves
+                                # fine for visitors.
     "shs.cairn.info",           # Cairn (academic publisher hosting
                                 # the Champs de Mars article in /
                                 # initiative) returns 403 to anonymous
@@ -119,6 +123,14 @@ SKIP_HOSTS = {
                                 # CI verification of this one link to stop
                                 # the recurring false-red; re-check the
                                 # link by hand if the venue URL changes.
+    "europeangovernanceandpolitics.eui.eu",
+                                # EUI's European Governance and Politics
+                                # programme (the Global Risks report,
+                                # linked from /GlobalRisks). Repeatedly
+                                # times out from GitHub's runners (same
+                                # CI-side reachability class as su.se, a
+                                # timeout not a 4xx). Loads for visitors;
+                                # skipping stops the recurring false-red.
 }
 
 internal_links = {}  # (file, target) for de-dupe display


### PR DESCRIPTION
Two externals keep reddening the link check without being broken:

- **`europeangovernanceandpolitics.eui.eu`** (the EUI Global Risks report, linked from `/GlobalRisks`) — **times out** from GitHub's runners on most runs (same CI-reachability class as `su.se` in #558; a timeout, not a 4xx). It failed the check on **#564, #569 and #573**.
- **`twitter.com`** (the EISS footer profile link) — **403s** unauthenticated bots, the same anti-bot class as the already-skipped `www.linkedin.com`.

Both resolve fine for visitors. Added to `SKIP_HOSTS`. Full local run after the change: **2293 internal + 169 external all resolve**. Internal CI tooling, no site change (CHANGELOG-exempt §4). Auto-merge per your go-ahead.