### PR TITLE
Fix people hovercards showing the wrong person (re-apply lost fix)

### DIFF
--- a/src/assets/js/people-hovercards.js
+++ b/src/assets/js/people-hovercards.js
@@ -170,9 +170,9 @@
         a.href = profileUrl(person);
         a.textContent = m[1];
         a._person = person;
-        a.addEventListener("mouseenter", function () { show(a); });
+        a.addEventListener("mouseenter", function () { show(this); });
         a.addEventListener("mouseleave", scheduleHide);
-        a.addEventListener("focus", function () { show(a); });
+        a.addEventListener("focus", function () { show(this); });
         a.addEventListener("blur", scheduleHide);
         frag.appendChild(a);
         last = m.index + m[1].length;


### PR DESCRIPTION
**Live bug on the conference site.** Hovering any name in a multi-name paragraph shows the *last* person's card — e.g. on /euroswamos, Gilli and Henke both show Meijer (reported on macOS Safari).

## Cause
The name-wrap loop's `mouseenter`/`focus` handlers call `show(a)`, but `a` is a `var` (function-scoped), so when several names share one text node every handler closes over the **last** link created. Fix: resolve the trigger from the event target (`this`); the per-element `_person` was always correct.

## Why it's live despite being 'fixed' before
I made this exact fix during #573's review, but pushed it to the PR branch *after* the PR opened — #573's squash-merge shipped only the original commit, so the fix was orphaned and the bug reached master (the §2 frozen-branch trap). Re-applied here on a **fresh branch off master**, the correct way.

## Verification
Built clean; build-sanity clean; JS `node --check` passes. Live on /euroswamos: **all 7 names show their own card** (Gilli→Gilli, Henke→Henke, Meijer→Meijer).

One-line JS change, no markup/CSS change. Given it's a live conference-site bug, requesting prompt merge.