### PR TITLE
Flip v2.25.0 roadmap card to shipped (post-release)

### DIFF
--- a/docs/roadmap-2026.md
+++ b/docs/roadmap-2026.md
@@ -49,7 +49,7 @@ other way round, so this is where a new release first appears.
 | Release | Target | Status | Headline |
 | --- | --- | --- | --- |
 | v2.24.0 | 30 May 2026 | **Shipped** | Live programme depth and a print overhaul |
-| v2.25.0 | 9 Jun 2026 | In progress | Ready for Stockholm (pre-conference release) |
+| v2.25.0 | 9 Jun 2026 | **Shipped** | Ready for Stockholm (pre-conference release) |
 | v2.26.0 | Sep 2026 | Planned | Post-conference: activation, content & feedback |
 | v2.27.0 | Dec 2026 | Planned | Polish and ESSC 2027 prep |
 

--- a/src/_data/roadmap.js
+++ b/src/_data/roadmap.js
@@ -113,9 +113,10 @@ const roadmap = {
           },
         },
         {
-          status: "planned",
+          status: "shipped",
           version: "v2.25.0",
-          milestone: "v2.25.0",
+          notesUrl: notes("v2.25.0"),
+          changes: 74,
           when: { en: "9 June 2026 · v2.25.0", fr: "9 juin 2026 · v2.25.0", de: "9. Juni 2026 · v2.25.0" },
           title: {
             en: "Ready for Stockholm",


### PR DESCRIPTION
## What this does

Standard post-release hygiene for **v2.25.0 "Ready for Stockholm"** (published today, 9 June 2026):

- `/roadmap.html` (EN + FR + DE): the v2.25.0 card flips from **planned** to **shipped** — drops `milestone` (so no progress bar renders), adds `notesUrl` to the GitHub Release and `changes: 74`, matching the other shipped cards. It becomes the most-recent shipped card, so it stays expanded while older ones collapse.
- `docs/roadmap-2026.md`: the At-a-glance row flips to **Shipped**.
- The v2.25.0 GitHub milestone is closed as complete (31 closed / 0 open).

`roadmap-progress.json` is left untouched — it's auto-generated and the workflow refreshes it; the card no longer carries `data-milestone` anyway.

Build, i18n drift (zero), and build-sanity all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
