### PR TITLE
Surface the ESSC 2026 livestream (Zoom webinar) on /2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,10 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ## [Unreleased]
 
+### Added
+
+- **The ESSC 2026 livestream link is live on `/2026`.** A single Zoom webinar (view-only, so remote viewers can watch the plenary spine without interrupting the room) is surfaced two ways while the conference is current: a "Watch the livestream" button in the hero, which becomes the primary call to action and carries a pulsing live dot, and the signpost above the programme grid, where the existing "Join online" link now points at the stream instead of the Indico event. The programme grid already tags each streamed session with a "Livestream" pill. The link is a plain outbound link (no Zoom embed, nothing loads from Zoom until you click, cf. `/policy` §5) and is gated to the current edition, so it disappears on its own once the conference is over, with the hero's "View programme" button returning to primary. EN + FR + DE. The address lives in a new `livestreamUrl` field on the conference in `conferences.js`.
+
 ### Changed
 
 - **The roadmap progress bars now say "so far".** The in-progress card's bar read "{closed} of {total} issues closed", which looked like a finished release whenever the count hit its total. But the total is only the work milestoned to that release so far, and it grows through the cycle. The label (EN + FR + DE, and the matching `aria-label`) now reads "{closed} of {total} issues closed so far", so the bar reads as a running tally rather than a completeness claim.

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -116,14 +116,14 @@
     "src/2026.njk": {
       "fr": {
         "file": "src/2026.fr.njk",
-        "source_sha1": "775e5e99b37c755983f70829d1e603d88d3d03e8",
-        "translated_on": "2026-06-05",
+        "source_sha1": "4600c0a02f3e4d4a24c2353953b6e6b110c439dd",
+        "translated_on": "2026-06-09",
         "status": "beta"
       },
       "de": {
         "file": "src/2026.de.njk",
-        "source_sha1": "775e5e99b37c755983f70829d1e603d88d3d03e8",
-        "translated_on": "2026-06-05",
+        "source_sha1": "4600c0a02f3e4d4a24c2353953b6e6b110c439dd",
+        "translated_on": "2026-06-09",
         "status": "beta"
       }
     },
@@ -158,14 +158,14 @@
     "src/policy.njk": {
       "fr": {
         "file": "src/policy.fr.njk",
-        "source_sha1": "cf7f1922a6639349e5dddfc8988199ace4516fce",
-        "translated_on": "2026-06-01",
+        "source_sha1": "e20965126f5071c2ad58c9f52e2dd985b94d4007",
+        "translated_on": "2026-06-09",
         "status": "beta"
       },
       "de": {
         "file": "src/policy.de.njk",
-        "source_sha1": "cf7f1922a6639349e5dddfc8988199ace4516fce",
-        "translated_on": "2026-06-01",
+        "source_sha1": "e20965126f5071c2ad58c9f52e2dd985b94d4007",
+        "translated_on": "2026-06-09",
         "status": "beta"
       }
     },

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -131,6 +131,15 @@ SKIP_HOSTS = {
                                 # CI-side reachability class as su.se, a
                                 # timeout not a 4xx). Loads for visitors;
                                 # skipping stops the recurring false-red.
+    "stockholmuniversity.zoom.us",
+                                # The ESSC 2026 livestream (Zoom webinar,
+                                # linked from /2026 while the conference
+                                # is live). Zoom join links 403 anonymous
+                                # bots (anti-bot, same class as Twitter);
+                                # the link opens the webinar fine for
+                                # visitors. The link auto-hides once the
+                                # edition is past, so this skip is moot
+                                # after the conference.
 }
 
 internal_links = {}  # (file, target) for de-dupe display

--- a/src/2026.de.njk
+++ b/src/2026.de.njk
@@ -33,8 +33,15 @@ alternates:
       Gemeinsam organisiert von der COST-Aktion NetSec, der Europäischen Initiative für
       Sicherheitsstudien (EISS) und der Universität Stockholm.
     </p>
+    {%- set _live2026 = conferences.byYear["2026"] -%}
+    {%- set _liveShown = _live2026 and _live2026.livestreamUrl and _live2026.endDate >= conferences.today -%}
     <div class="hero-actions reveal reveal-delay-3">
-      <a class="btn btn-primary" href="#programme">{{ icon("file-text") }} Programm ansehen</a>
+      {%- if _liveShown %}
+      <a class="btn btn-primary hero-watch-live" href="{{ _live2026.livestreamUrl }}" target="_blank" rel="noopener">
+        <span class="hero-watch-live__dot" aria-hidden="true"></span>{{ icon("video") }} Den Livestream ansehen
+      </a>
+      {%- endif %}
+      <a class="btn {{ 'btn-ghost' if _liveShown else 'btn-primary' }}" href="#programme">{{ icon("file-text") }} Programm ansehen</a>
       <a class="btn btn-ghost" href="#venue">{{ icon("map-pin") }} Veranstaltungsort</a>
     </div>
     <p class="reveal reveal-delay-3" style="margin-top: var(--space-6); font-size: var(--fs-sm); color: hsl(0 0% 100% / 0.9);">

--- a/src/2026.fr.njk
+++ b/src/2026.fr.njk
@@ -33,8 +33,15 @@ alternates:
       Organisée conjointement par l'Action COST NetSec, l'Initiative européenne pour les études de
       sécurité (EISS) et l'Université de Stockholm.
     </p>
+    {%- set _live2026 = conferences.byYear["2026"] -%}
+    {%- set _liveShown = _live2026 and _live2026.livestreamUrl and _live2026.endDate >= conferences.today -%}
     <div class="hero-actions reveal reveal-delay-3">
-      <a class="btn btn-primary" href="#programme">{{ icon("file-text") }} Voir le programme</a>
+      {%- if _liveShown %}
+      <a class="btn btn-primary hero-watch-live" href="{{ _live2026.livestreamUrl }}" target="_blank" rel="noopener">
+        <span class="hero-watch-live__dot" aria-hidden="true"></span>{{ icon("video") }} Regarder la diffusion en direct
+      </a>
+      {%- endif %}
+      <a class="btn {{ 'btn-ghost' if _liveShown else 'btn-primary' }}" href="#programme">{{ icon("file-text") }} Voir le programme</a>
       <a class="btn btn-ghost" href="#venue">{{ icon("map-pin") }} Hôte et lieu</a>
     </div>
     <p class="reveal reveal-delay-3" style="margin-top: var(--space-6); font-size: var(--fs-sm); color: hsl(0 0% 100% / 0.9);">

--- a/src/2026.njk
+++ b/src/2026.njk
@@ -32,8 +32,15 @@ alternates:
       Jointly organised by the COST Action NetSec, the European Initiative for Security Studies (EISS),
       and Stockholm University.
     </p>
+    {%- set _live2026 = conferences.byYear["2026"] -%}
+    {%- set _liveShown = _live2026 and _live2026.livestreamUrl and _live2026.endDate >= conferences.today -%}
     <div class="hero-actions reveal reveal-delay-3">
-      <a class="btn btn-primary" href="#programme">{{ icon("file-text") }} View programme</a>
+      {%- if _liveShown %}
+      <a class="btn btn-primary hero-watch-live" href="{{ _live2026.livestreamUrl }}" target="_blank" rel="noopener">
+        <span class="hero-watch-live__dot" aria-hidden="true"></span>{{ icon("video") }} Watch the livestream
+      </a>
+      {%- endif %}
+      <a class="btn {{ 'btn-ghost' if _liveShown else 'btn-primary' }}" href="#programme">{{ icon("file-text") }} View programme</a>
       <a class="btn btn-ghost" href="#venue">{{ icon("map-pin") }} Host &amp; venue</a>
     </div>
     <p class="reveal reveal-delay-3" style="margin-top: var(--space-6); font-size: var(--fs-sm); color: hsl(0 0% 100% / 0.9);">

--- a/src/_data/conferences.js
+++ b/src/_data/conferences.js
@@ -124,6 +124,14 @@ const conferences = [
     // chairing?" note on /YYYY points here. Per-year because a future
     // edition may host its FAQ elsewhere.
     faqUrl: "https://netsec-cost.eu/faq.html#conference",
+    // Public livestream for the conference. ONE Zoom webinar link, reused
+    // for every plenary session (a webinar, so it's view-only: remote
+    // attendees can watch but can't interrupt the room). Surfaced on
+    // /2026 as a plain outbound link, never embedded (no Zoom JS or IP
+    // leak on page load, cf. /policy §5). The link is shown only while
+    // the edition is current (endDate >= today) and auto-hides once the
+    // conference is over; the recordings take over after that.
+    livestreamUrl: "https://stockholmuniversity.zoom.us/j/62445444403",
     hasOwnPage: true,
   },
   {

--- a/src/_data/i18n.js
+++ b/src/_data/i18n.js
@@ -294,6 +294,7 @@ const locales = {
       livestreamPill: "Livestream",
       livestreamNote: "The plenary sessions are livestreamed, tagged below.",
       livestreamNoteCta: "Join online on Indico",
+      watchLivestreamCta: "Watch the livestream",
       // Static PDF block — surfaces the polished designer-made
       // programme when the operator has uploaded one (see
       // conferences.js `programmePdf` field). The grid above is
@@ -643,6 +644,7 @@ const locales = {
       livestreamPill: "En direct",
       livestreamNote: "Les sessions plénières sont diffusées en direct, signalées ci-dessous.",
       livestreamNoteCta: "Suivre en ligne sur Indico",
+      watchLivestreamCta: "Regarder la diffusion en direct",
       pdfHeading: "Programme final — PDF imprimable",
       pdfHeadingDraft: "Programme provisoire — PDF imprimable (susceptible de changer)",
       pdfDescription: "Une version mise en page et imprimable du programme.",
@@ -962,6 +964,7 @@ const locales = {
       livestreamPill: "Livestream",
       livestreamNote: "Die Plenarsitzungen werden live übertragen, unten gekennzeichnet.",
       livestreamNoteCta: "Online auf Indico teilnehmen",
+      watchLivestreamCta: "Den Livestream ansehen",
       pdfHeading: "Endgültiges Programm — druckbares PDF",
       pdfHeadingDraft: "Arbeitsversion des Programms — druckbares PDF (Änderungen vorbehalten)",
       pdfDescription: "Eine gestaltete und druckfreundliche Version des Programms.",

--- a/src/_includes/programme-grid.njk
+++ b/src/_includes/programme-grid.njk
@@ -44,10 +44,13 @@
        dedicated "Livestreamed sessions" block. Shown only when the year
        has sessions tagged for livestream. #}
     {%- if _conf.livestreamed and _conf.livestreamed.length %}
+    {%- set _confMeta = conferences.byYear[year] -%}
+    {%- set _liveUrl = _confMeta.livestreamUrl if (_confMeta and _confMeta.livestreamUrl and _confMeta.endDate >= conferences.today) else null -%}
     <p class="programme-livestream-note">
       <span class="programme-live-tag">{{ icon("video") }} {{ t.programme.livestreamPill }}</span>
       {{ t.programme.livestreamNote }}
-      {%- if _conf.url %} <a href="{{ _conf.url }}" target="_blank" rel="noopener">{{ t.programme.livestreamNoteCta }} {{ icon("external-link") }}</a>{% endif %}
+      {%- if _liveUrl %} <a href="{{ _liveUrl }}" target="_blank" rel="noopener">{{ t.programme.watchLivestreamCta }} {{ icon("external-link") }}</a>
+      {%- elif _conf.url %} <a href="{{ _conf.url }}" target="_blank" rel="noopener">{{ t.programme.livestreamNoteCta }} {{ icon("external-link") }}</a>{% endif %}
     </p>
     {%- endif %}
 

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -3301,6 +3301,22 @@ h4 { font-size: var(--fs-lg); }
   100% { box-shadow: 0 0 0 0 hsl(0 100% 68% / 0); }
 }
 
+/* Hero "Watch the livestream" CTA on /YYYY: a live-red pulsing dot
+   before the label, marking it as the live action while the conference
+   is current (the button itself only renders in that window). Reuses
+   the registration-badge pulse keyframe; the global prefers-reduced-
+   motion rule stills it for visitors who ask. */
+.hero-watch-live__dot {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  margin-inline-end: 0.1rem;
+  border-radius: 50%;
+  background: #ff5b5b;
+  box-shadow: 0 0 0 0 hsl(0 100% 68% / 0.7);
+  animation: registrationBadgePulse 1.6s infinite;
+}
+
 .registration-badge--upcoming .registration-badge__dot {
   background: #5bff8a;
 }

--- a/src/policy.de.njk
+++ b/src/policy.de.njk
@@ -143,7 +143,8 @@ alternates:
         Wenn Sie auf einen ausgehenden Link dieser Website klicken — z. B. zu
         <strong>Stripe</strong> (Mitgliedschaftsverwaltung), <strong>Indico</strong>
         (<a href="https://indico.eiss-europa.com/" target="_blank" rel="noopener">indico.eiss-europa.com</a>,
-        unsere Veranstaltungsplattform), <strong>YouTube</strong>, die <strong>COST</strong>-Vereinigung
+        unsere Veranstaltungsplattform), <strong>Zoom</strong> (der Livestream der Konferenz),
+        <strong>YouTube</strong>, die <strong>COST</strong>-Vereinigung
         oder eine Partnerinstitution — verlassen Sie diese Website und unterliegen der eigenen
         Datenschutzerklärung des jeweiligen Dienstes. Keiner dieser Dienste ist in die Seiten dieser
         Website eingebettet; sie sehen Sie nur, wenn Sie sich entscheiden, sie zu besuchen.

--- a/src/policy.fr.njk
+++ b/src/policy.fr.njk
@@ -144,7 +144,8 @@ alternates:
         Lorsque vous cliquez sur un lien sortant de ce site — par exemple vers
         <strong>Stripe</strong> (gestion d'adhésion), <strong>Indico</strong>
         (<a href="https://indico.eiss-europa.com/" target="_blank" rel="noopener">indico.eiss-europa.com</a>,
-        notre plateforme d'événements), <strong>YouTube</strong>, l'Association <strong>COST</strong>,
+        notre plateforme d'événements), <strong>Zoom</strong> (la diffusion en direct de la conférence),
+        <strong>YouTube</strong>, l'Association <strong>COST</strong>,
         ou toute institution partenaire — vous quittez ce site et devenez soumis à la politique de
         confidentialité propre à ce service. Aucun de ces services n'est intégré aux pages de ce
         site ; ils ne vous voient que lorsque vous choisissez de les visiter.

--- a/src/policy.njk
+++ b/src/policy.njk
@@ -136,7 +136,8 @@ alternates:
         When you click an outbound link on this site, for example to
         <strong>Stripe</strong> (membership management), <strong>Indico</strong>
         (<a href="https://indico.eiss-europa.com/" target="_blank" rel="noopener">indico.eiss-europa.com</a>,
-        our events platform), <strong>YouTube</strong>, the
+        our events platform), <strong>Zoom</strong> (the conference livestream),
+        <strong>YouTube</strong>, the
         <strong>COST</strong> Association, or any partner institution, you leave this
         website and become subject to that service's own privacy policy. None of those
         services are embedded on the pages of this site. They only see you when you choose


### PR DESCRIPTION
## What this does

Surfaces the **ESSC 2026 livestream** on `/2026` (EN + FR + DE), using the single Zoom webinar link you provided. One link, reused for every plenary session (a webinar, so remote viewers watch without interrupting the room).

It rides on the livestream scaffold from v2.24.0 rather than adding a new system:

- **Hero CTA** — a **"Watch the livestream"** button that becomes the primary call to action while the conference is current (demoting "View programme" to a ghost button), with a pulsing live dot reusing the registration-badge pulse.
- **Programme-grid signpost** — the existing "Join online" link above the grid now points at the stream instead of the Indico event. The grid still tags each streamed session with its "Livestream" pill.

### Design choices (per our discussion)

- **No embed.** A plain outbound link — nothing loads from Zoom until a visitor clicks, keeping the site's no-third-party-on-load privacy stance (cf. `/policy` §5, where Zoom is now named in the outbound-links paragraph in all three locales).
- **Auto-expires.** Gated on `endDate >= today`, so the link shows now and through 11–12 June, then disappears on its own once the edition is past (the hero's "View programme" returns to primary). No manual removal needed.
- **Neutral wording** ("Watch the livestream", not "live now") so it's accurate before and during, since the build can lag the start moment by up to a day.
- One new `livestreamUrl` field on the 2026 conference in `conferences.js` is the single source.

### Housekeeping

- EN/FR/DE hand-translated (new `watchLivestreamCta` string + hero button text), `i18n-state.json` re-stamped, **zero drift**.
- Zoom host added to the link-checker skip list (Zoom join links 403 anonymous bots — same false-red class as Twitter/su.se).
- Build + build-sanity green. `[Unreleased]` bullet added.

## Please review the deploy preview before merging

This is a **visible, above-the-fold, day-of-conference** change, so per CLAUDE.md §2 I've left auto-merge **off**. Could you eyeball the `/2026` hero (EN/FR/DE) and the programme signpost on the Cloudflare/Netlify preview, then merge? I did **not** open or test the Zoom link myself — it's wired through verbatim as you supplied it, so a quick click-through on the preview to confirm it lands in the right webinar would be worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
