### PR TITLE
Wire the a11y lint into CI and fix the duplicate-id findings it gates on

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -44,9 +44,28 @@ module.exports = function (eleventyConfig) {
   // Path is relative to src/. Errors are intentionally thrown — a
   // missing brand asset should fail the build loudly, not silently
   // emit empty markup that ships to production.
-  eleventyConfig.addShortcode("inlineSvg", (relPath) =>
-    fs.readFileSync(path.join("src", relPath), "utf-8")
-  );
+  //
+  // The id rewrite: the brand SVGs carry internal ids (<title id="t-…">
+  // referenced by aria-labelledby), and the same file is inlined more
+  // than once per page (nav + footer + page content), so verbatim bytes
+  // produce duplicate ids in the DOM (flagged by scripts/a11y_lint.py).
+  // Each inclusion gets a unique "-iN" suffix on every id and on the
+  // same-file references to it (aria-labelledby tokens, #fragment hrefs,
+  // url(#…) paint refs).
+  let inlineSvgCount = 0;
+  eleventyConfig.addShortcode("inlineSvg", (relPath) => {
+    let svg = fs.readFileSync(path.join("src", relPath), "utf-8");
+    const n = ++inlineSvgCount;
+    const ids = [...svg.matchAll(/\bid="([^"]+)"/g)].map((m) => m[1]);
+    for (const id of new Set(ids)) {
+      const esc = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      svg = svg.replace(
+        new RegExp(`(?<=["#\\s(])${esc}(?=["\\s)])`, "g"),
+        `${id}-i${n}`
+      );
+    }
+    return svg;
+  });
 
   // {{ "/2025.html" | localizedHref(lang) }} — given an internal
   // page href + a target locale, return the localised URL if a

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -23,6 +23,7 @@ on:
     paths:
       - 'src/**'
       - 'scripts/check-build-sanity.mjs'
+      - 'scripts/a11y_lint.py'
       - '.github/workflows/sanity-check.yml'
       - 'package.json'
       - 'package-lock.json'
@@ -54,3 +55,10 @@ jobs:
 
       - name: Run build-sanity check
         run: node scripts/check-build-sanity.mjs
+
+      # Static a11y lint over the built site (duplicate ids, missing
+      # alt/labels/landmarks, heading gaps — see scripts/a11y_lint.py).
+      # Stdlib-only Python, no pip install needed. Gating: the script
+      # exits non-zero on any finding (issue #602).
+      - name: Run accessibility lint
+        run: python3 scripts/a11y_lint.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,10 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 - **The roadmap progress bars now say "so far".** The in-progress card's bar read "{closed} of {total} issues closed", which looked like a finished release whenever the count hit its total. But the total is only the work milestoned to that release so far, and it grows through the cycle. The label (EN + FR + DE, and the matching `aria-label`) now reads "{closed} of {total} issues closed so far", so the bar reads as a running tally rather than a completeness claim.
 
+### Fixed
+
+- **Inlined brand logos no longer produce duplicate element ids.** The brand SVGs carry internal ids (the `<title>`/`<desc>` pair referenced by `aria-labelledby`), and the same file is inlined more than once per page (the nav, the footer, and page content such as the press-kit previews), so `/initiative` and `/press-kit` shipped duplicate ids in the DOM. The `inlineSvg` shortcode now gives each inclusion a unique suffix on its ids and on the references to them, so every logo keeps its accessible name and every id on the page is unique. Caught by `scripts/a11y_lint.py`, which now runs as a gating CI check on every HTML-touching PR ([#602](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/602)).
+
 ## [2.25.0] · 2026-06-09 — Ready for Stockholm
 
 > ESSC 2026 opens in Stockholm on 11 - 12 June, and this release gets the site ready for it. Site-wide search, a public roadmap, a licensing page and a press kit make the site easier to navigate and to reuse. The whole interface is pulled onto one brand blue, with redesigned landscape share cards. The phone experience is markedly better and kinder to assistive tech. And the conference itself is everywhere you look: a countdown on the homepage, downloadable programmes for every recent edition, add-to-calendar links on synced events, and the 2025 conference film now playing.

--- a/scripts/a11y_lint.py
+++ b/scripts/a11y_lint.py
@@ -260,6 +260,11 @@ def main():
         for f in bucketed["legacy_skipped"]:
             print(f"  - {f}")
 
+    # Gate: non-zero exit when any page has findings, so CI can fail
+    # the PR. Local runs see the same behaviour (there is no warn-only
+    # mode; a finding is a finding).
+    return 1 if pages_with_issues else 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
## What this does

Closes #602 (from tonight's repo audit). Two halves:

**The gate.** `scripts/a11y_lint.py` now exits non-zero when any page has findings, and runs as a step in the existing *Build sanity* workflow on every HTML-touching PR. Stdlib-only Python, so no pip install in CI.

**The findings it was sitting on.** Run against the current tree, the lint flagged duplicate element ids on `/initiative` and `/press-kit` (all three locales): the brand SVGs carry internal `<title>`/`<desc>` ids referenced by `aria-labelledby`, and the same file is inlined more than once per page (nav + footer + page content). The `inlineSvg` shortcode now suffixes each inclusion's ids (and the references to them) with a unique `-iN`, fixing it at the source for every current and future page.

## Verification

- All 83 built pages lint clean (exit 0); a synthetic bad page makes the gate exit 1.
- The inlined SVG bytes are byte-identical to the source modulo the id suffixes (checked programmatically), and every `aria-labelledby` token pairs 1:1 with an id on the page, so the logos keep their accessible names.
- i18n drift zero, build-sanity green.

No visual change (ids only), so auto-merge is armed per §2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
