### PR TITLE
Alarm issue on scheduled-workflow failure (#56)

### DIFF
--- a/.github/workflows/failure-alarm.yml
+++ b/.github/workflows/failure-alarm.yml
@@ -1,0 +1,76 @@
+# Scheduled-workflow failure alarm (issue #56).
+#
+# The site's data freshness rides on unattended cron workflows (the
+# Indico sync, the board-bios sync, the daily rebuild, the roadmap
+# autostamp + progress refresh) plus the on-push deploy. A failed run
+# used to be discoverable only by reading the Actions tab, so the
+# programme could quietly go stale. This workflow turns any failure
+# into a tracking issue the maintainer actually sees.
+#
+# Mechanics: `workflow_run` fires when a listed workflow completes (it
+# only triggers for runs on the default branch, which is exactly the
+# scheduled/deploy population). On `conclusion == failure` it opens an
+# issue titled after the failed workflow, or comments on the existing
+# open one so repeat failures thread instead of spamming. Issues carry
+# the `automated` + `bug` labels and the "Backlog — Under watch"
+# milestone (rule §10: no open issue without a milestone); close the
+# issue once the underlying cause is fixed.
+#
+# No third-party actions, so nothing to SHA-pin: the steps use the
+# preinstalled gh CLI with the runner's GITHUB_TOKEN.
+name: Workflow failure alarm
+
+on:
+  workflow_run:
+    workflows:
+      - Sync events from Indico
+      - Sync board bios from Google Form
+      - Scheduled rebuild
+      - Sync roadmap autostamp
+      - Sync roadmap progress
+      - Build and deploy site
+    types: [completed]
+
+permissions:
+  issues: write
+
+jobs:
+  alarm:
+    name: Open or update the alarm issue
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: File or thread the failure
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WF_NAME: ${{ github.event.workflow_run.name }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_STARTED: ${{ github.event.workflow_run.run_started_at }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: |
+          set -euo pipefail
+          title="CI alarm: \"${WF_NAME}\" failed"
+          body="The **${WF_NAME}** workflow failed.
+
+          - Run: ${RUN_URL} (attempt ${RUN_ATTEMPT})
+          - Started: ${RUN_STARTED}
+
+          Filed automatically by the failure-alarm workflow (#56). Close this issue once the underlying cause is fixed; a later failure of the same workflow reopens the conversation as a fresh issue."
+
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --state open --label automated \
+            --search "\"$title\" in:title" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
+              --body "Failed again: ${RUN_URL} (attempt ${RUN_ATTEMPT}, started ${RUN_STARTED})."
+            echo "Threaded onto existing issue #$existing"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "$title" \
+              --body "$body" \
+              --label automated --label bug \
+              --milestone "Backlog — Under watch"
+            echo "Opened a new alarm issue"
+          fi


### PR DESCRIPTION
## What this does

Closes #56 (prioritised by tonight's repo audit). The site's data freshness rides on five cron workflows plus the on-push deploy, and until now a failed run was only discoverable by reading the Actions tab.

New `failure-alarm.yml`: a `workflow_run` trigger on the six workflows (`Sync events from Indico`, `Sync board bios from Google Form`, `Scheduled rebuild`, `Sync roadmap autostamp`, `Sync roadmap progress`, `Build and deploy site`). On `conclusion == failure` it:

- opens a **"CI alarm: \"<workflow>\" failed"** issue with a link to the failed run, labelled `automated` + `bug`, milestoned **Backlog — Under watch** (rule §10), or
- comments on the already-open alarm issue for that workflow, so repeat failures thread instead of spamming the tracker.

Close the issue once the cause is fixed; a later failure opens a fresh one.

### Notes

- Pure `gh` CLI with the runner's `GITHUB_TOKEN` — no third-party actions, so nothing to SHA-pin (§2).
- `workflow_run` only fires for runs on the default branch, which is exactly the scheduled/deploy population.
- Verified: YAML parses, the embedded shell passes `bash -n`. The live path can be exercised after merge by cancelling… rather, by a deliberate `workflow_dispatch` failure if you ever want to see it fire; otherwise the first real failure will be the test, which is the point.

CI tooling only (CHANGELOG-exempt), no visual change — auto-merge armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
