### PR TITLE
membership: name the Stripe billing-portal link instead of "here" (#472)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ### Fixed
 
+- **The "manage your membership" link no longer reads "here".** On `/membership` (EN + FR + DE) the link to the Stripe billing portal was the bare word "here" / "ici" / "hier", which carries no meaning out of its sentence (it is the text a screen reader announces when listing the page's links). It now reads "Stripe billing portal" / "portail de facturation Stripe" / "Stripe-Abrechnungsportal". Closes [#472](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/472).
 - **Inlined brand logos no longer produce duplicate element ids.** The brand SVGs carry internal ids (the `<title>`/`<desc>` pair referenced by `aria-labelledby`), and the same file is inlined more than once per page (the nav, the footer, and page content such as the press-kit previews), so `/initiative` and `/press-kit` shipped duplicate ids in the DOM. The `inlineSvg` shortcode now gives each inclusion a unique suffix on its ids and on the references to them, so every logo keeps its accessible name and every id on the page is unique. Caught by `scripts/a11y_lint.py`, which now runs as a gating CI check on every HTML-touching PR ([#602](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/602)).
 
 ## [2.25.0] · 2026-06-09 — Ready for Stockholm

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -32,14 +32,14 @@
     "src/membership.njk": {
       "fr": {
         "file": "src/membership.fr.njk",
-        "source_sha1": "5ddabe1b340a8c91409e3eca1752760fd1c62aa6",
-        "translated_on": "2026-05-22",
+        "source_sha1": "c4b95b6c27b78c6d9e1d19ee092d6a612b93d8a2",
+        "translated_on": "2026-06-10",
         "status": "beta"
       },
       "de": {
         "file": "src/membership.de.njk",
-        "source_sha1": "5ddabe1b340a8c91409e3eca1752760fd1c62aa6",
-        "translated_on": "2026-05-22",
+        "source_sha1": "c4b95b6c27b78c6d9e1d19ee092d6a612b93d8a2",
+        "translated_on": "2026-06-10",
         "status": "beta"
       }
     },

--- a/src/membership.de.njk
+++ b/src/membership.de.njk
@@ -130,8 +130,8 @@ alternates:
         auf dem neuesten Stand zu halten.
       </p>
       <p>
-        Sie können Ihre Mitgliedschaft jederzeit
-        <a href="https://billing.stripe.com/p/login/3cscOuaesfHceC4dQQ" target="_blank" rel="noopener">hier</a>
+        Sie können Ihre Mitgliedschaft jederzeit über das
+        <a href="https://billing.stripe.com/p/login/3cscOuaesfHceC4dQQ" target="_blank" rel="noopener">Stripe-Abrechnungsportal</a>
         verwalten. Da die Mitgliedsvorteile sofort beginnen, führt eine Kündigung zu einer
         <em>anteiligen</em> Belastung der hinterlegten Karte. Fehlgeschlagene Zahlungen führen nach
         15 Tagen zur Kündigung.

--- a/src/membership.fr.njk
+++ b/src/membership.fr.njk
@@ -129,8 +129,8 @@ alternates:
         avant le renouvellement par e-mail. Veillez à maintenir vos coordonnées et informations bancaires à jour.
       </p>
       <p>
-        Vous pouvez gérer votre adhésion à tout moment
-        <a href="https://billing.stripe.com/p/login/3cscOuaesfHceC4dQQ" target="_blank" rel="noopener">ici</a>.
+        Vous pouvez gérer votre adhésion à tout moment depuis le
+        <a href="https://billing.stripe.com/p/login/3cscOuaesfHceC4dQQ" target="_blank" rel="noopener">portail de facturation Stripe</a>.
         L'adhésion ouvrant droit à des avantages immédiats, son annulation entraînera un prélèvement
         <em>au prorata</em> sur la carte enregistrée. Les paiements échoués entraîneront une annulation
         après 15 jours.

--- a/src/membership.njk
+++ b/src/membership.njk
@@ -128,8 +128,8 @@ alternates:
         renewal by email. Please make sure to maintain your contact and banking details up-to-date.
       </p>
       <p>
-        You can manage your membership at any point
-        <a href="https://billing.stripe.com/p/login/3cscOuaesfHceC4dQQ" target="_blank" rel="noopener">here</a>.
+        You can manage your membership at any point in the
+        <a href="https://billing.stripe.com/p/login/3cscOuaesfHceC4dQQ" target="_blank" rel="noopener">Stripe billing portal</a>.
         Since membership benefits begin immediately, cancelling your membership will lead to a
         <em>pro-rata</em> charge on the card on file. Failed payments will lead to cancellation
         after 15 days.


### PR DESCRIPTION
## What this does

Closes #472. The "manage your membership" link on `/membership` (EN + FR + DE) was the bare word **here** / **ici** / **hier** pointing at the Stripe billing portal. Bare "here" link text is a WCAG 2.4.4 problem: out of its sentence it conveys nothing, and a screen reader's links list reads a row of identical "here"s.

Reworded to a self-describing label, with the surrounding sentence adjusted so it still reads naturally:

| | Before | After |
| --- | --- | --- |
| EN | …manage your membership at any point **here**. | …at any point in the **Stripe billing portal**. |
| FR | …gérer votre adhésion à tout moment **ici**. | …à tout moment depuis le **portail de facturation Stripe**. |
| DE | …Mitgliedschaft jederzeit **hier** verwalten. | …jederzeit über das **Stripe-Abrechnungsportal** verwalten. |

## Checks

Hand-translated (FR/DE), `i18n-state.json` re-stamped, zero drift. Build, build-sanity, and the a11y lint all green. Copy-only, no layout change — auto-merge armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
