### PR TITLE
docs: bring README + architecture + design-system current

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ src/
                          locales)
 .eleventy.js             Eleventy config (passthrough rules, year filter,
                          inlineSvg shortcode, localizedHref filter)
-.github/workflows/       CI: build, deploy, link check, i18n drift, roadmap
-                         autostamp, scheduled rebuild, Indico + board sync
+.github/workflows/       CI: build, deploy, link check, i18n drift, build
+                         sanity (+ a11y lint), roadmap autostamp, scheduled
+                         rebuild, Indico + board sync, scheduled-workflow
+                         failure alarm
 scripts/                 dev helpers (a11y_lint.py, sync-board.py,
                          sync-indico.py, sync-roadmap.py, release.sh,
                          check-links.sh, derive-logo-variants.py, etc.),
@@ -73,7 +75,7 @@ Push to `master` to deploy. GitHub Actions runs the build and publishes via GitH
 
 ### Accessibility lint
 
-`scripts/a11y_lint.py` walks every built HTML file and checks for missing landmarks, alt-less images, heading-hierarchy gaps, duplicate IDs, accessible-name absence, etc. Run after any template change:
+`scripts/a11y_lint.py` walks every built HTML file and checks for missing landmarks, alt-less images, heading-hierarchy gaps, duplicate IDs, accessible-name absence, etc. It runs as a **gating CI check** (in the Build sanity workflow, exiting non-zero on any finding), so a regression fails the PR. Run it locally after any template change:
 
 ```bash
 npm run build

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,6 +65,14 @@ src/*.njk (pages)  +  src/_includes/*.njk (components)  +  src/_data/* (data)
 Each sync opens an auto-PR (auto-merge armed, CI-gated) rather than
 pushing to `master`.
 
+**`failure-alarm.yml`** watches those scheduled workflows plus the
+deploy: on a `failure` conclusion it opens (or threads a comment onto)
+a `CI alarm` tracking issue, labelled `automated` + `bug`, so a silent
+cron failure surfaces instead of going unnoticed. It ignores
+`cancelled` (the sync workflows use `cancel-in-progress` concurrency,
+so supersession is normal). Pure `gh` CLI, no third-party actions
+(#56).
+
 ## CI gates (on PRs)
 
 | Workflow | Gate |
@@ -73,6 +81,8 @@ pushing to `master`.
 | `link-check.yml` → `check-links.sh` | Every internal/external link + `#fragment` in `_site/` resolves. |
 | `i18n-drift.yml` → `check-i18n-drift.py` | Every FR/DE page matches its EN source hash (`data/i18n-state.json`). |
 | `i18n-drift.yml` → `check-i18n-keys.js` | EN/FR/DE chrome catalogs have identical key sets. |
+| `sanity-check.yml` → `check-build-sanity.mjs` | No duplicate `_data` object keys, no empty/junk `href`/`src`, no scheme-less `board.json` links, and no markup class left undefined in `site.css` (§14 unstyled-feature guard). |
+| `sanity-check.yml` → `a11y_lint.py` | No accessibility findings (missing landmarks / alt / labels, heading-hierarchy gaps, duplicate IDs, accessible-name absence). |
 | CodeQL | Static analysis. |
 
 `CHANGELOG.md` is pinned `merge=union` in `.gitattributes` so concurrent

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -16,8 +16,10 @@ know what exists and where to look before building something new.
 
 - **`nav.njk`** — primary nav. Items come from `site.js` `nav[]`; labels
   resolve from `t.nav[key]`. Collapses behind `.menu-toggle` (hamburger)
-  on mobile. Carries the theme toggle, language switcher, and search
-  trigger (`[data-search-trigger]`).
+  on mobile. Carries the theme toggle, the language switcher (EN/FR/DE
+  `.lang-chip`s led by a decorative `.lang-switcher-globe` so the group
+  reads as a language control), and the search trigger
+  (`[data-search-trigger]`).
 - **`footer.njk`** — co-branding, funding-style credit, legal-links row
   (terms / privacy / accessibility / sitemap / licensing / roadmap /
   press kit), socials. `data-pagefind-ignore`.
@@ -49,6 +51,19 @@ know what exists and where to look before building something new.
   `youtube-embed.njk`. Renders nothing without a playlist.
 - **`joint-orgs.njk`**, **`speaking-chairing.njk`**, **`livestream-list.njk`**,
   **`programme-pdf.njk`** — the `/2026` supporting strips.
+- **Livestream link** — when the upcoming conference has a `livestreamUrl`
+  in `conferences.js` and is still current (`endDate >= today`), the
+  "Livestream" pills become links to it (the `.programme-live-tag`
+  signpost and each streamed session's `.programme-slot-live`, each with
+  an external-link icon), the hero gains a `.hero-watch-live` button
+  (pulsing live dot), and the homepage featured card shows the pill.
+  Plain outbound link, no embed; reverts to plain markers once the
+  edition is past.
+- **`event-jsonld.njk`** — schema.org `Event` structured data built from
+  `conferences.byYear[year]` (dates, `Place`, a `VirtualLocation` for the
+  livestream, organiser). Currently on `/2026`; included in the page body
+  (valid for JSON-LD). The event name stays English on every locale with
+  `inLanguage` per page.
 
 ## People
 
@@ -72,6 +87,11 @@ know what exists and where to look before building something new.
   conference photos (fixes ragged mixed-dimension crops).
 - **`map-embed.njk`** — address card + OpenStreetMap link (no Google
   Maps iframe, for privacy).
+- **Hero image** — the full-bleed `/index` + `/2026` hero (the LCP,
+  `loading="eager"` + `fetchpriority="high"`) carries a `srcset` with an
+  800w variant + `sizes="100vw"` so phones fetch ~half the bytes. The
+  width variants are pre-generated (`sips`) and committed as static
+  assets — there is no build-time image pipeline yet (#554).
 
 ## Search
 


### PR DESCRIPTION
## What this does

Documentation-currency pass (CLAUDE.md §11) covering the changes merged since v2.25.0. Docs-only — `docs/` and `README.md` aren't part of the Eleventy input, so there's no site or build change.

**README**
- The accessibility lint is now described as a **gating CI check** (it was written up as a manual-only step before #602 made it gate).
- The repo-layout workflows line now lists the **Build sanity** workflow and the **scheduled-workflow failure alarm**.

**docs/architecture.md**
- The **CI-gates table** gains the `sanity-check.yml` rows — `check-build-sanity.mjs` (duplicate `_data` keys, empty/junk `href`/`src`, scheme-less board links, and the new undefined-CSS-class guard) and the `a11y_lint.py` gate. The Build sanity workflow was missing from the table entirely.
- A note on **`failure-alarm.yml`** in the sync-pipelines section (opens a `CI alarm` issue on a scheduled-workflow failure; ignores `cancelled`).

**docs/design-system.md**
- The language-switcher **globe** cue.
- The **livestream** surfacing: pills-as-links + `.hero-watch-live` button + homepage card, gated to the current edition.
- The new **`event-jsonld.njk`** structured-data partial.
- The responsive **hero `srcset`** (pre-generated variants, no build pipeline yet).

No CHANGELOG entry — docs refresh is §4-exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
