### PR TITLE
css: single self-contained block for .programme-contrib-abstract

### DIFF
--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -3240,8 +3240,7 @@ a.programme-live-tag:focus-visible {
   border-bottom-color: var(--accent);
 }
 
-.programme-contrib-speakers,
-.programme-contrib-abstract {
+.programme-contrib-speakers {
   margin: 0 0 var(--space-2);
   font-size: var(--fs-sm);
   line-height: var(--lh-relaxed);
@@ -3267,6 +3266,9 @@ a.programme-live-tag:focus-visible {
 }
 
 .programme-contrib-abstract {
+  margin: 0 0 var(--space-2);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-relaxed);
   color: var(--text-muted);
 }
 


### PR DESCRIPTION
## What this does

Consolidates the two CSS rule blocks that styled `.programme-contrib-abstract`:

- it was in a **grouped layout rule** shared with `.programme-contrib-speakers` (margin / font-size / line-height), **and** in a separate abstract-only `color` rule lower down;
- now it's **one self-contained block** (all four properties), and `.programme-contrib-speakers` keeps the shared layout rule on its own.

One source of truth for the abstract; the speakers rule is untouched.

## Regression check (it's conference day — this was the priority)

Verified in the **live `/2026` grid** (expanded contributions), computed styles **before vs after**:

| selector | margin | font-size | line-height | color |
|---|---|---|---|---|
| `.programme-contrib-abstract` | `0 0 8px` | `15px` | `25.5px` | `rgb(168,175,189)` |
| `.programme-contrib-speakers` | `0 0 8px` | `15px` | `25.5px` | `rgb(168,175,189)` |

Identical before and after, all **50 abstracts still render**. The change is provably value-preserving (same tokens, no intervening override). build-sanity + a11y lint green. Internal refactor, no user-visible change → CHANGELOG-exempt.

**Auto-merge intentionally left off** given it's conference day and this touches programme CSS — it's verified-inert and safe to merge whenever you're ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
