### PR TITLE
ci(link-check): skip gess.ethz.ch (transient 503 false-red)

### DIFF
--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -140,6 +140,15 @@ SKIP_HOSTS = {
                                 # visitors. The link auto-hides once the
                                 # edition is past, so this skip is moot
                                 # after the conference.
+    "gess.ethz.ch",             # ETH Zürich's GESS department person page
+                                # (a board member's profile, linked from
+                                # the board cards). Intermittently 503s
+                                # under automated load: returns 200 from a
+                                # browser and on a manual re-probe, but
+                                # flaked a PR's link-check with a transient
+                                # 503. Same intermittent-5xx class as the
+                                # academic hosts above; skipping stops the
+                                # recurring false-red.
 }
 
 internal_links = {}  # (file, target) for de-dupe display


### PR DESCRIPTION
## What

Add `gess.ethz.ch` to the link checker's `SKIP_HOSTS` allow-list in `scripts/check-links.sh`.

## Why

ETH Zürich's GESS department person page (a board member's profile, linked from the board cards) intermittently returns `HTTP 503` under the whole-site link checker's automated load. It resolves `200` in a browser and on a manual re-probe (confirmed three times in a row), so the link is valid: the 503 is transient server-side throttling, not a broken link.

A 503 from that host red-flagged the link-check gate on an unrelated PR. This is the same intermittent / anti-bot class already covered for other academic and institutional hosts in the list (`www.su.se`, `europeangovernanceandpolitics.eui.eu`, `www.berlin-airport.de`). Skipping it stops the recurring false-red.

The trade-off matches the existing entries: CI no longer verifies this one external link, so re-check it by hand if the board member's profile URL changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)