### PR TITLE
docs(roadmap): resync v2.26.0/v2.27.0 to the milestone rebalance

### DIFF
--- a/docs/roadmap-2026.md
+++ b/docs/roadmap-2026.md
@@ -92,10 +92,11 @@ any patch.
 
 The first release after ESSC 2026. It turns conference-week feedback
 into fixes and builds out the public-content surfaces (a news feed, an
-outputs list, the working groups), plus the one hard-dated infra item.
-The polish and brand-card work that the old v2.25.0 plan held moved to
-v2.27.0, and the Indico-data and NetSec-coordination items moved to
-*Under watch*, so this release stays focused. The full, current list
+outputs list, the working groups). The polish and brand-card work that
+the old v2.25.0 plan held moved to v2.27.0, and the Indico-data and
+NetSec-coordination items moved to *Under watch*, so this release stays
+focused. (The Node-24 Actions pin the plan once tracked was resolved
+early by Dependabot, closing #76.) The full, current list
 lives on the
 [v2.26.0 milestone](https://github.com/EISSeuropa/EISSeuropa.github.io/milestone/9);
 the headline items:
@@ -103,9 +104,6 @@ the headline items:
 - **Conference-week QA pass** — work the ESSC 2026 feedback checklist
   on production and fix what it surfaces.
   [#655](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/655), M.
-- **Pin GitHub Actions to Node-24-compatible versions** — hard
-  deadline 16 Sep 2026.
-  [#76](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/76), S.
 - **News / Latest on the homepage** — a surface for Action news and
   cross-links to NetSec items relevant to EISS members.
   [#96](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/96), M.


### PR DESCRIPTION
Supersedes #681 (which predated closing #76).

## What

Rebalances the milestones and brings `docs/roadmap-2026.md` into line.

**v2.26.0 (Sep) was at 20 open** — too heavy and drifting off its "post-conference: activation, content & feedback" theme. Now **7**, focused on that theme:

| Kept in v2.26.0 | |
|---|---|
| #655 | Conference-week QA pass (feedback) |
| #96 / #605 / #634 | News surface + RSS feed + issue-driven publishing |
| #97 | Outputs / Publications page |
| #94 | Working Groups page |
| #329 | /initiative founding nuance |

**Moved to v2.27.0 (Dec, "Polish & ESSC 2027 prep"):** #157, #272, #474 (OG cards), #519 (brand palette), #554 (responsive images), #501 (branch protection), #607 (Mobirise redirects).

**Moved to Backlog — Under watch (externally blocked / research-gated):** #95 (NetSec coordination), #58 + #60 (Indico-data dependent), #471 (needs a reference-resolving audit), #601 (no committed need).

Each moved issue carries a one-line reason in its thread (§10). The milestone edits are already applied via the API; this PR is the doc half.

## Also dropped (no longer planned-open)

The v2.26.0 prose listed three items that aren't open planned work any more: #98 (language-switcher globe, **reverted** in #663), #56 (failure-alarm, **shipped**), and #76 (Node-24 Actions pin, **resolved early by Dependabot** — verified every `uses:` pin runs `node24`).

## Scope

Internal maintainer doc only — not built into the site, no i18n, no user-visible change. The public `/roadmap.html` doesn't list individual issue numbers, so it needs no edit; its release headlines stay accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)