### PR TITLE
fix(speakers): visible Clear button + non-colliding contribution columns

### DIFF
--- a/src/_includes/speakers-index.njk
+++ b/src/_includes/speakers-index.njk
@@ -60,7 +60,7 @@
           {%- endfor %}
         </select>
       </div>
-      <button type="button" class="btn btn-ghost btn-sm speaker-clear" data-speaker-clear hidden>{{ s18n.clear }}</button>
+      <button type="button" class="btn btn-sm speaker-clear" data-speaker-clear hidden>{{ s18n.clear }}</button>
     </div>
 
     <nav class="speaker-az" aria-label="{{ s18n.jumpToLetter }}">

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -3379,14 +3379,17 @@ a.programme-live-tag:focus-visible {
   gap: 0.4rem;
 }
 .speaker-papers li {
+  display: flex;
+  gap: var(--space-3);
   font-size: var(--fs-sm);
 }
 .speaker-paper-conf {
-  display: inline-block;
-  min-width: 11rem;
+  flex: 0 0 11rem;
   font-weight: 600;
 }
 .speaker-paper-title {
+  flex: 1 1 auto;
+  min-width: 0;
   color: var(--text);
 }
 
@@ -3436,8 +3439,19 @@ a.programme-live-tag:focus-visible {
 .speaker-field select {
   max-width: 20rem;
 }
+/* The Clear button sits on the light filter panel, so it can't use the
+   dark-surface .btn-ghost colours (white-on-white). Give it surface-aware
+   tokens instead, and let it sit on the same baseline as the fields. */
 .speaker-clear {
   align-self: flex-end;
+  color: var(--text);
+  background: var(--bg-elev);
+  border: 1px solid var(--border-strong);
+}
+.speaker-clear:hover,
+.speaker-clear:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 .speaker-status {
   color: var(--text-muted);
@@ -3479,7 +3493,8 @@ a.programme-live-tag:focus-visible {
   line-height: 1.5;
 }
 @media (max-width: 600px) {
-  .speaker-paper-conf { display: block; min-width: 0; margin-bottom: 0.1rem; }
+  .speaker-papers li { flex-direction: column; gap: 0.1rem; }
+  .speaker-paper-conf { flex: none; }
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
Two fixes from your review of the speaker-index revamp (#697).

## 1. Clear button "disappeared"
It used `.btn-ghost`, which is styled for dark surfaces (white text + translucent-white border). On the light filter panel that was **white-on-white** — invisible (same bug class as the registration badge). Dropped `btn-ghost`; `.speaker-clear` now uses surface tokens (dark text + grey border on light, the inverse on dark; accent on hover). It also no longer hides among the panel — confirmed `color: rgb(22,27,39)` on the light panel.

## 2. Contributions colliding with the event-name column
The conf-label and title were inline-block, so a long title's second line wrapped back under the "ESSC 20xx" label. Each row is now a **flex pair** (fixed 11rem conf column + flexible title); wrapped title lines stay in the title column. Verified: Blarel's "Geopolitical Europe…" title wraps to two lines aligned at left 278, clear of the label at 90. On mobile the pair stacks (label above title).

## 3. Joint Policy Workshop filter — couldn't reproduce
Selecting it returns its **13 speakers**, and `/JPW2019.html` renders all **10 papers** (titles present, from the archive programme data, not Indico). If you still see it empty, it may have been a stale deploy preview — happy to look again with the specific view.

## 4. Headshots
👍 (no change)

Build, a11y (0 issues, 86 pages) and build-sanity green. Verified at desktop + mobile widths.

**Visual change — not auto-merging.** Please re-check the Clear button (after picking a filter) and a long-titled entry on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)