### PR TITLE
roadmap: reschedule v2.26.0 → late June, v2.27.0 → September

### DIFF
--- a/docs/roadmap-2026.md
+++ b/docs/roadmap-2026.md
@@ -50,8 +50,8 @@ other way round, so this is where a new release first appears.
 | --- | --- | --- | --- |
 | v2.24.0 | 30 May 2026 | **Shipped** | Live programme depth and a print overhaul |
 | v2.25.0 | 9 Jun 2026 | **Shipped** | Ready for Stockholm (pre-conference release) |
-| v2.26.0 | Sep 2026 | Planned | Post-conference: activation, content & feedback |
-| v2.27.0 | Dec 2026 | Planned | Polish and ESSC 2027 prep |
+| v2.26.0 | Late Jun 2026 | Planned | Post-conference: activation, content & feedback |
+| v2.27.0 | Sep 2026 | Planned | Polish and ESSC 2027 prep |
 
 (`v2.24.1` was planned as a pre-ESSC patch but the work grew into a feature-rich minor, so it shipped as the **v2.25.0** *Ready for Stockholm* release instead; the `v2.24.1` milestone is closed as superseded.)
 
@@ -88,7 +88,7 @@ drops. Sequence: legal pages first (highest accuracy bar), then
 rest. Per [`docs/i18n.md`](i18n.md). Each reviewed page can ship in
 any patch.
 
-### v2.26.0 — Post-conference: activation, content and feedback · target September 2026
+### v2.26.0 — Post-conference: activation, content and feedback · target late June 2026
 
 The first release after ESSC 2026. It turns conference-week feedback
 into fixes and builds out the public-content surfaces (a news feed, an
@@ -132,7 +132,7 @@ the headline items:
   the conference numbering and the deferred-2020 edition.
   [#329](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/329), M.
 
-### v2.27.0 — Polish and ESSC 2027 prep · target December 2026
+### v2.27.0 — Polish and ESSC 2027 prep · target September 2026
 
 - **CSS class-collision guard** — a build check so an archive
   component can never again override the live grid (the regression

--- a/src/_data/roadmap.js
+++ b/src/_data/roadmap.js
@@ -144,21 +144,11 @@ const roadmap = {
             de: "Die 9. Jährliche Konferenz für Europäische Sicherheitsstudien an der Universität Stockholm. Das wichtigste Treffen des Jahres; die Website ist der zentrale Einstiegspunkt für Neuankömmlinge.",
           },
         },
-      ],
-    },
-    {
-      label: { en: "Q3 2026", fr: "T3 2026", de: "Q3 2026" },
-      sub: {
-        en: "July · August · September",
-        fr: "juillet · août · septembre",
-        de: "Juli · August · September",
-      },
-      entries: [
         {
           status: "planned",
           version: "v2.26.0",
           milestone: "v2.26.0",
-          when: { en: "September 2026 · v2.26.0", fr: "septembre 2026 · v2.26.0", de: "September 2026 · v2.26.0" },
+          when: { en: "Late June 2026 · v2.26.0", fr: "fin juin 2026 · v2.26.0", de: "Ende Juni 2026 · v2.26.0" },
           title: {
             en: "Post-conference: activation, content and feedback",
             fr: "Après la conférence : activation, contenus et retours",
@@ -173,18 +163,18 @@ const roadmap = {
       ],
     },
     {
-      label: { en: "Q4 2026", fr: "T4 2026", de: "Q4 2026" },
+      label: { en: "Q3 2026", fr: "T3 2026", de: "Q3 2026" },
       sub: {
-        en: "October · November · December",
-        fr: "octobre · novembre · décembre",
-        de: "Oktober · November · Dezember",
+        en: "July · August · September",
+        fr: "juillet · août · septembre",
+        de: "Juli · August · September",
       },
       entries: [
         {
           status: "planned",
           version: "v2.27.0",
           milestone: "v2.27.0",
-          when: { en: "December 2026 · v2.27.0", fr: "décembre 2026 · v2.27.0", de: "Dezember 2026 · v2.27.0" },
+          when: { en: "September 2026 · v2.27.0", fr: "septembre 2026 · v2.27.0", de: "September 2026 · v2.27.0" },
           title: {
             en: "Polish and ESSC 2027 prep",
             fr: "Finitions et préparation de l’ESSC 2027",


### PR DESCRIPTION
Moves the planned schedule forward.

- **Milestone due dates** (already applied via API): v2.26.0 → **2026-06-30**, v2.27.0 → **2026-09-30**.
- **`docs/roadmap-2026.md`**: At-a-glance targets (Late Jun 2026 / Sep 2026) and the two section headings.
- **Public `/roadmap`** (`src/_data/roadmap.js`, EN + FR + DE): moved the **v2.26.0** card into **Q2 2026** (Late June, beside v2.25.0 and the ESSC event), moved **v2.27.0** into **Q3 2026** (September), and dropped the now-empty **Q4 2026** quarter.

Verified: `/roadmap.html` shows Q2 → "Late June 2026 · v2.26.0", Q3 → "September 2026 · v2.27.0", no Q4. Build, build-sanity, i18n-drift green.

Public-roadmap visual change — **eyeball `/roadmap` on the deploy preview** (the in-progress progress bar now tracks v2.26.0 against its milestone, unchanged behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)