### PR TITLE
ci(links): skip doi.org in the broken-link checker

### DIFF
--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -105,6 +105,17 @@ SKIP_HOSTS = {
                                 # initiative) returns 403 to anonymous
                                 # HEAD/GET. Article reads fine in a
                                 # browser.
+    "doi.org",                  # DOI resolver for the member-publication
+                                # links on /outputs (and the board cards),
+                                # sourced from ORCID. It 302-redirects to
+                                # the publisher, which then 403s the bot
+                                # (West European Politics, JCMS, Cairn and
+                                # the like, same anti-bot class as the
+                                # academic hosts here). The DOIs are
+                                # machine-sourced and resolve fine in a
+                                # browser. Skipping covers every current
+                                # and future synced DOI without a per-link
+                                # allowlist.
     "www.berlin-airport.de",    # Anti-bot UA filter, returns 403 to
                                 # unrecognised User-Agent strings.
                                 # The transit-info page works for


### PR DESCRIPTION
The link check went red on the member-publication DOI links on `/outputs` (from the ORCID sync): three `https://doi.org/…` links returning `403 Forbidden`. doi.org 302-redirects to the publisher (West European Politics, JCMS, Cairn), which then 403s the anonymous bot. The DOIs are valid and resolve fine in a browser.

Adds `doi.org` to `SKIP_HOSTS`, the same treatment the script already gives `shs.cairn.info`, `eur-lex.europa.eu` and the other academic/anti-bot hosts. This covers every current and future synced DOI without a per-link allowlist.

CI-tooling change, no CHANGELOG bullet (§4-exempt). Unblocks the link-check on #737 and #739, which only failed on these pre-existing /outputs DOIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)