### PR TITLE
fix(board): ORCID block never rendered — observe the card, not the hidden placeholder (#719)

### DIFF
--- a/src/assets/js/board-publications.js
+++ b/src/assets/js/board-publications.js
@@ -114,7 +114,13 @@
         }
       }
     }, { rootMargin: "200px" });
-    Array.prototype.forEach.call(placeholders, function (el) { io.observe(el); });
+    // Observe the visible card, NOT the placeholder itself: the placeholder
+    // ships `hidden` (display:none), which has no layout box, so an observer
+    // on it never reports an intersection and the fetch never fires. Observe
+    // the enclosing `.person` card (always visible) instead.
+    Array.prototype.forEach.call(placeholders, function (el) {
+      io.observe(el.closest(".person") || el.parentElement || el);
+    });
   } else {
     // No observer: fall back to a single deferred fetch so the feature still works.
     trigger();


### PR DESCRIPTION
Follow-up bugfix to #719 (merged in #737).

**Symptom:** the "Recent publications" block never appeared on `/board` cards in any real browser, even for the members who have ORCID works.

**Cause:** the lazy-load `IntersectionObserver` was attached to the `.member-pub-recent` placeholder, which is rendered with `hidden` (`display:none`). A `display:none` element has no layout box, so the observer can never report it as intersecting, so `trigger()` never ran and the fetch never fired. (The original PR's headless check couldn't catch this — it attributed the non-firing to a headless limitation, but it was broken in real browsers too.)

**Fix:** observe the enclosing `.person` card (always visible, real geometry) instead of the hidden placeholder. One-line change plus a comment.

**Verified in the preview** (computed reads, since the feature is scroll-driven): scrolling a card into view now fills it. Both members render — Arthur Laudrain (3 works) and Moritz Weiss (3 works), DOI links opening in a new tab where a DOI exists, plain text where not, year + journal meta correct. Members without works stay hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)