### PR TITLE
fix(board): equal-height cards + pinned footer (re-land orphaned #751 refinement)

### DIFF
--- a/src/_includes/person-card.njk
+++ b/src/_includes/person-card.njk
@@ -114,6 +114,11 @@
 
     {%- set links = person.links or {} -%}
     {%- set hasAnyLink = links.publicEmail or links.website or links.orcid or links.linkedin or links.twitter or links.bluesky or links.mastodon -%}
+    {# Footer (contact links + View profile) pinned to the card bottom via
+       `.person-foot { margin-top: auto }`, so footers align across a row and
+       cards in a row share one height (align-items: stretch). #}
+    {%- if hasAnyLink or hasDetail %}
+    <div class="person-foot">
     {%- if hasAnyLink %}
     <ul class="person-links" aria-label="{{ t.boardPage.linksAriaLabel }}">
       {%- if links.publicEmail %}
@@ -147,6 +152,8 @@
     <a class="person-more" href="#dialog-{{ person.slug }}" data-dialog="dialog-{{ person.slug }}">
       {{ t.boardPage.viewProfile }}{{ icon("arrow-right") }}
     </a>
+    {%- endif %}
+    </div>
     {%- endif %}
   </div>
 

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -2021,7 +2021,13 @@ h4 { font-size: var(--fs-lg); }
 
 .person-body {
   padding: var(--space-4) var(--space-4) var(--space-5);
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
 }
+/* Footer (links + View profile) pushed to the card bottom so it aligns across
+   a row of equal-height cards. */
+.person-foot { margin-top: auto; }
 
 .person-role {
   font-size: var(--fs-xs);
@@ -5998,10 +6004,13 @@ a.joint-orgs-card:hover .joint-orgs-name {
    publications open in a per-person modal so an expanded profile can never
    stretch its grid rowmates (the inline-bio blow-out this replaces). */
 
-/* Cards size to their own content; a tall card no longer drags its row. */
+/* Cards in a row share one height (uniform boxes), and the footer pins to the
+   bottom (see .person-foot) so View profile / links align across the row. Safe
+   now that deep content lives in a modal: no inline expansion can blow a card
+   out, which is why the grid briefly used align-items: start. */
 .people-grid,
 .people-grid--compact {
-  align-items: start;
+  align-items: stretch;
 }
 
 /* Clamp the research-themes line so a long list doesn't make cards uneven. */


### PR DESCRIPTION
Re-lands the card-length normalisation that was orphaned when #751 squash-merged before this commit landed on its branch (the CLAUDE.md §2 frozen-branch trap).

Master shipped the board redesign with `align-items: start` (ragged card bottoms). This restores the approved fix: cards in a row share one height (`align-items: stretch`), and the footer (links + View profile) is pinned to the card bottom via a `.person-foot` wrapper with `margin-top: auto` so footers align across the row.

Cherry-pick of the orphaned commit `9fd351f`, verified in preview earlier (4-card row = 571px each, footers pinned). Gates green: build, build-sanity, a11y, i18n drift, i18n keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)