### PR TITLE
ORCID-anchored publication matcher (#805 phase 1)

### DIFF
--- a/data/publication-candidates.json
+++ b/data/publication-candidates.json
@@ -1,0 +1,18 @@
+[
+  {
+    "slug": "2018-nuclear-alliances-strategies-of-extended-nuclear-deterrence-and-the-pursuit-of-h",
+    "paperTitle": "Nuclear Alliances: Strategies of Extended Nuclear Deterrence and the Pursuit of Hegemony",
+    "paperYear": 2018,
+    "conference": "EISS 2018",
+    "matchedVia": "orcid",
+    "member": "Dr Eliza Gheorghe",
+    "candidateTitle": "Balance of Power Redux: Nuclear Alliances and the Logic of Extended Deterrence",
+    "candidateYear": 2022,
+    "journal": "The Chinese Journal of International Politics",
+    "doi": "10.1093/cjip/poac003",
+    "publishedUrl": "https://doi.org/10.1093/cjip/poac003",
+    "titleScore": 0.533,
+    "band": "review",
+    "verified": false
+  }
+]

--- a/scripts/match-publications.mjs
+++ b/scripts/match-publications.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * Phase 1 of #805: ORCID-anchored publication matcher.
+ *
+ * For each ESSC paper authored by an EISS member who has an ORCID iD on file,
+ * propose the member's later-published version (with a DOI) by fuzzy-matching
+ * the conference title against that member's own ORCID works. Anchoring to the
+ * member's own record makes the author match exact, so title similarity is the
+ * only discriminator and false positives are rare.
+ *
+ * It does NOT write publishedUrl/doi anywhere. It emits a REVIEW QUEUE
+ * (data/publication-candidates.json) plus a console report; a human confirms a
+ * match before it is ever recorded (the design in #805). Phases 2/3
+ * (OpenAlex/Crossref for non-members, optional LLM judge) are future work.
+ *
+ * Sources: corpus.js (the paper list, with slugs), src/_data/orcidWorks.json
+ * (the members who have an ORCID iD), and the public ORCID API (fetched live
+ * for a fuller works list than the light 3-work sidecar).
+ *
+ * Usage:  node scripts/match-publications.mjs
+ */
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const corpus = require("../src/_data/corpus.js");
+const orcidMembers = require("../src/_data/orcidWorks.json");
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const OUT = join(ROOT, "data", "publication-candidates.json");
+
+// Title similarity: Dice coefficient over normalised token sets. Handles
+// reordering, subtitle drift and added/dropped words better than a raw edit
+// distance, which is what conference→publication retitling does.
+const STOP = new Set(["the", "a", "an", "of", "and", "or", "in", "on", "to", "for", "with", "as", "at", "by", "from", "is", "are"]);
+function tokens(s) {
+  return new Set(
+    String(s || "")
+      .normalize("NFKD")
+      .replace(/[̀-ͯ]/g, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, " ")
+      .split(/\s+/)
+      .filter((t) => t && !STOP.has(t))
+  );
+}
+function dice(a, b) {
+  const A = tokens(a), B = tokens(b);
+  if (!A.size || !B.size) return 0;
+  let inter = 0;
+  for (const t of A) if (B.has(t)) inter++;
+  return (2 * inter) / (A.size + B.size);
+}
+
+const orcidIdOf = (url) => (String(url || "").match(/(\d{4}-\d{4}-\d{4}-\d{3}[\dX])/) || [])[1] || null;
+
+async function fetchWorks(id) {
+  const res = await fetch(`https://pub.orcid.org/v3.0/${id}/works`, {
+    headers: { Accept: "application/json", "User-Agent": "eiss-europa.com publication-matcher" },
+  });
+  if (!res.ok) throw new Error(`ORCID ${id}: HTTP ${res.status}`);
+  const data = await res.json();
+  const out = [];
+  for (const g of data.group || []) {
+    const s = (g["work-summary"] || [])[0];
+    if (!s) continue;
+    const title = s.title?.title?.value;
+    if (!title) continue;
+    const yearRaw = s["publication-date"]?.year?.value;
+    let doi = null, doiUrl = null;
+    for (const eid of s["external-ids"]?.["external-id"] || []) {
+      if ((eid["external-id-type"] || "").toLowerCase() === "doi") {
+        doi = eid["external-id-value"] || null;
+        doiUrl = eid["external-id-url"]?.value || (doi ? `https://doi.org/${doi}` : null);
+        break;
+      }
+    }
+    out.push({ title: title.trim(), year: /^\d{4}$/.test(yearRaw || "") ? Number(yearRaw) : null, doi, doiUrl, journal: s["journal-title"]?.value || null });
+  }
+  return out;
+}
+
+const HIGH = 0.8, REVIEW = 0.5;
+const band = (s) => (s >= HIGH ? "high" : s >= REVIEW ? "review" : "discard");
+
+const candidates = [];
+for (const member of orcidMembers) {
+  const id = orcidIdOf(member.orcid);
+  if (!id) continue;
+  const key = corpus.canonicalKey(member.name);
+  const papers = (corpus.papers || []).filter(
+    (p) => !p.publishedUrl && (p.authors || []).some((a) => corpus.canonicalKey(a.name) === key)
+  );
+  if (!papers.length) continue;
+
+  let works;
+  try {
+    works = await fetchWorks(id);
+  } catch (e) {
+    console.error(`! ${member.name}: ${e.message} — skipped`);
+    continue;
+  }
+  const dois = works.filter((w) => w.doi);
+  console.log(`\n${member.name} (${id}) — ${papers.length} ESSC paper(s), ${dois.length} ORCID work(s) with a DOI`);
+
+  for (const p of papers) {
+    let best = null;
+    for (const w of dois) {
+      if (w.year && (w.year < p.year - 1 || w.year > p.year + 6)) continue; // publication lag window
+      const score = dice(p.title, w.title);
+      if (!best || score > best.score) best = { work: w, score };
+    }
+    const b = best ? band(best.score) : "discard";
+    const mark = b === "high" ? "✓" : b === "review" ? "?" : "·";
+    console.log(`  ${mark} [${b}] "${p.title.slice(0, 56)}" (${p.year})`);
+    if (best && b !== "discard") {
+      console.log(`      → ${best.score.toFixed(2)}  "${best.work.title.slice(0, 56)}" (${best.work.year || "?"})  ${best.work.doi}`);
+      candidates.push({
+        slug: p.slug,
+        paperTitle: p.title,
+        paperYear: p.year,
+        conference: `${p.conferenceLabel} ${p.year}`,
+        matchedVia: "orcid",
+        member: member.name,
+        candidateTitle: best.work.title,
+        candidateYear: best.work.year,
+        journal: best.work.journal,
+        doi: best.work.doi,
+        publishedUrl: best.work.doiUrl,
+        titleScore: Number(best.score.toFixed(3)),
+        band: b,
+        verified: false, // a human confirms before this is recorded as publishedUrl/doi
+      });
+    }
+  }
+}
+
+candidates.sort((a, b) => b.titleScore - a.titleScore);
+writeFileSync(OUT, JSON.stringify(candidates, null, 2) + "\n");
+const high = candidates.filter((c) => c.band === "high").length;
+console.log(`\n✓ ${candidates.length} candidate(s) written to data/publication-candidates.json (${high} high-confidence, ${candidates.length - high} for review). None recorded as publishedUrl until confirmed.`);


### PR DESCRIPTION
Phase 1 of #805 — the cheapest, highest-precision slice of the publication-matching design, using data we already hold.

## What it does
`scripts/match-publications.mjs` proposes, for each ESSC paper authored by an EISS member with an ORCID iD on file, that member's later-published version (with a DOI). It fuzzy-matches the conference title against the member's *own* ORCID works (fetched live for fuller recall than the light 3-work sidecar). Anchoring to the member's record makes the author match exact, so title similarity is the only discriminator.

- Title similarity = token-set **Dice coefficient** (handles subtitle drift / reordering); candidates banded **high / review / discard** within a publication-lag year window (`confYear-1 … confYear+6`).
- It **never writes** `publishedUrl`/`doi`. It emits a **review queue** (`data/publication-candidates.json`) + a console report; a human confirms before anything is recorded — the #805 posture, same as the `indico-sync`/`bios-sync` review PRs and the `corpus.js` under-merge bias.
- Each candidate carries the paper `slug` (so a confirmed match maps straight onto the #794 landing page), the matched title/journal/DOI, the score, and `verified: false`.

## First run
3 members have an ORCID on file. Result: **1 review-band candidate** (Eliza Gheorghe's 2018 ESSC paper ↔ a 2022 *Chinese Journal of International Politics* article, score 0.53 — a plausible "presented then retitled on publication" match), **no auto-accepts**, everything else discarded. Conservative by design; coverage grows with ORCID adoption and with phases 2/3.

## Scope / not in this PR
- Does not consume the candidates (no `publishedUrl` written, no template change) — that's the confirm-and-record step, gated on review.
- Phases 2/3 (OpenAlex/Crossref author-anchored matching for non-member authors; optional LLM judge for the ambiguous band; a scheduled review-PR workflow) remain in #805.

Internal tooling + a data artifact (not in the Eleventy input), so no CHANGELOG entry and no site change. The committed `data/publication-candidates.json` is the current review queue for your eyeball.