### PR TITLE
Confirm 3 more published-version matches (#805)

### DIFF
--- a/src/_data/paperLinks.json
+++ b/src/_data/paperLinks.json
@@ -7,5 +7,32 @@
     "publishedYear": 2022,
     "source": "orcid",
     "verifiedOn": "2026-06-16"
+  },
+  "2019-france-european-defense-and-deterrence-since-the-end-of-the-cold-war": {
+    "doi": "10.1515/9781800733268-013",
+    "publishedUrl": "https://doi.org/10.1515/9781800733268-013",
+    "publishedTitle": "Chapter 11 France, Germany and Nuclear Deterrence since the End of the Cold War. From Estrangement to Rapprochement?",
+    "journal": "Berghahn Books",
+    "publishedYear": 2022,
+    "source": "openalex",
+    "verifiedOn": "2026-06-16"
+  },
+  "JPW2019-a-critical-appraisal-of-visegrad-4-security-potential": {
+    "doi": "10.1080/09668136.2018.1562045",
+    "publishedUrl": "https://doi.org/10.1080/09668136.2018.1562045",
+    "publishedTitle": "Competing Norms and Strategic Visions: A Critical Appraisal of V4 Security Potential",
+    "journal": "Europe Asia Studies",
+    "publishedYear": 2019,
+    "source": "openalex",
+    "verifiedOn": "2026-06-16"
+  },
+  "JPW2019-change-in-burden-sharing-mind-set-in-nato": {
+    "doi": "10.1080/14702436.2022.2082953",
+    "publishedUrl": "https://doi.org/10.1080/14702436.2022.2082953",
+    "publishedTitle": "NATO burden-sharing: past, present, future",
+    "journal": "Defence Studies",
+    "publishedYear": 2022,
+    "source": "openalex",
+    "verifiedOn": "2026-06-16"
   }
 }


### PR DESCRIPTION
Promotes reviewed candidates from the match queue into `src/_data/paperLinks.json`, so their `/papers/<slug>` pages now link the published version + DOI. Per your "confirm the candidates".

## Confirmed (now live on the paper pages)
| ESSC paper | Published as | DOI | score |
|---|---|---|---|
| Nuclear Alliances… Pursuit of Hegemony (2018) | Balance of Power Redux: Nuclear Alliances and the Logic of Extended Deterrence | 10.1093/cjip/poac003 | 0.53 |
| A Critical Appraisal of Visegrad 4 Security Potential (2019) | Competing Norms and Strategic Visions: A Critical Appraisal of V4 Security Potential | 10.1080/09668136.2018.1562045 | 0.53 |
| Change in Burden-Sharing mind-set in NATO (2019) | NATO burden-sharing: past, present, future | 10.1080/14702436.2022.2082953 | 0.50 |
| France, European Defense and Deterrence Since the End of the Cold War (2019) | France, Germany and Nuclear Deterrence since the End of the Cold War | 10.1515/9781800733268-013 | 0.60 |

(The 2018 one already shipped in #809; this adds the other three.)

## Held back — likely false positive, your call
The 2019 **"European Perceptions of Nuclear Deterrence in the Era of Trump and Putin…"** matched to a 2024 **"European Strategic Autonomy: The Path to a Geopolitical Europe"** — a different, broader paper (nuclear-deterrence focus dropped, 5-year gap, shared phrase only). Left in the review queue (`data/publication-candidates.json`, unconfirmed). If it *is* the published version, say so and I'll add it: `node scripts/confirm-publication.mjs 2019-european-perceptions-...`.

Data-only change to a hand-curated store (the published-version capability was already announced in #809's CHANGELOG bullet). Build + build-sanity pass; the three pages render the published link + DOI + `citation_doi`. The V4 → "Critical Appraisal of V4 Security Potential" match is the strongest; the NATO and France ones are plausible same-author matches worth a glance on the preview.