### PR TITLE
Skip www.cnil.fr in the link checker (intermittent 503)

### DIFF
--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -155,6 +155,14 @@ SKIP_HOSTS = {
                                 # 503. Same intermittent-5xx class as the
                                 # academic hosts above; skipping stops the
                                 # recurring false-red.
+    "www.cnil.fr",              # France's data-protection regulator (CNIL),
+                                # cited from the privacy notice (`/policy` +
+                                # FR/DE). Returns HTTP 503 to the checker
+                                # under automated load while loading fine for
+                                # visitors — same intermittent-5xx class as
+                                # gess.ethz.ch. Flaked the link-check on
+                                # PR #814; skipping stops the recurring
+                                # false-red on every src-touching PR.
 }
 
 # Domains skipped together with ALL their subdomains. SKIP_HOSTS matches an


### PR DESCRIPTION
Fixes the link-check false-red the maintainer flagged on #814.

The failure was **two pre-existing CNIL links** on the privacy notice — `https://www.cnil.fr/` and `https://www.cnil.fr/en` — returning **HTTP 503** to the checker under automated load (the site loads fine for visitors). Nothing to do with the publication DOIs (`doi.org` is already skipped, and those passed).

Adds `www.cnil.fr` to `SKIP_HOSTS`, the same intermittent-5xx treatment `gess.ethz.ch` already gets. One host entry covers both CNIL URLs. This stops the recurring false-red on every `src/**`-touching PR (it currently flakes #818 too).

Note: link-check isn't a blocking required check yet, so #814/#815 merged through the red — this just removes the noise. Embedded Python validated. CI tooling, no CHANGELOG entry.