### PR TITLE
Matcher skip for validated rejected matches (#805)

### DIFF
--- a/data/publication-candidates.json
+++ b/data/publication-candidates.json
@@ -864,22 +864,6 @@
     "verified": false
   },
   {
-    "slug": "2019-european-perceptions-of-nuclear-deterrence-in-the-era-of-trump-and-putin-and-the",
-    "paperTitle": "European Perceptions of Nuclear Deterrence in the Era of Trump and Putin and the Path to European Strategic Autonomy",
-    "paperYear": 2019,
-    "conference": "EISS 2019",
-    "matchedVia": "openalex",
-    "member": null,
-    "candidateTitle": "European Strategic Autonomy: The Path to a Geopolitical Europe",
-    "candidateYear": 2024,
-    "journal": "The Washington Quarterly",
-    "doi": "10.1080/0163660x.2024.2327820",
-    "publishedUrl": "https://doi.org/10.1080/0163660x.2024.2327820",
-    "titleScore": 0.5,
-    "band": "review",
-    "verified": false
-  },
-  {
     "slug": "2017-why-a-nuclear-weapons-ban-treaty-is-a-bad-idea",
     "paperTitle": "Why a Nuclear Weapons Ban Treaty Is a Bad Idea",
     "paperYear": 2017,

--- a/data/publication-rejects.json
+++ b/data/publication-rejects.json
@@ -1,0 +1,5 @@
+{
+  "2019-european-perceptions-of-nuclear-deterrence-in-the-era-of-trump-and-putin-and-the": [
+    "10.1080/0163660x.2024.2327820"
+  ]
+}

--- a/docs/publication-matching.md
+++ b/docs/publication-matching.md
@@ -75,19 +75,28 @@ The human-in-the-loop step. Review the queue, then record the matches
 you accept:
 
 ```bash
-node scripts/confirm-publication.mjs --list         # show pending candidates
-node scripts/confirm-publication.mjs <slug> [<slug> ...]
+node scripts/confirm-publication.mjs --list           # show pending candidates
+node scripts/confirm-publication.mjs <slug> [<slug> ...]   # accept
+node scripts/confirm-publication.mjs --reject <slug> ...   # mark a non-match
 ```
 
 Each accepted slug is copied into `src/_data/paperLinks.json`. Rebuild
-to surface it. Reject a match simply by not confirming it (it stays in
-the queue for a later call, or is dropped on the next matcher run).
+to surface it.
+
+A match you have checked and decided is **wrong** should be rejected, not
+just left alone: `--reject` records the (paper, doi) pair in
+`data/publication-rejects.json`, and the matcher skips it from then on, so
+a validated non-match does not keep coming back in the monthly queue.
+Rejection is per pair, not per paper, so a genuinely better match for the
+same paper can still surface later. (A match you simply have not looked at
+yet just stays in the queue.)
 
 Judge each one on the merits. A strong match keeps most of the title and
 the same author across a plausible gap. A weak one shares only a theme
-word and drifts in focus or by many years — leave those unconfirmed. The
-first confirmed batch held back one such case (a 2019 nuclear-deterrence
-paper proposed against a 2024 strategic-autonomy piece).
+word and drifts in focus or by many years. The first review found one such
+case: a 2019 paper on European perceptions of nuclear deterrence proposed
+against a 2024 piece on European strategic autonomy — same author (Tara
+Varma), shared theme, but a different work. It was rejected.
 
 ## The scheduled refresh
 

--- a/scripts/confirm-publication.mjs
+++ b/scripts/confirm-publication.mjs
@@ -10,8 +10,12 @@
  * links the published version. Nothing is recorded until a human runs this.
  *
  * Usage:
- *   node scripts/confirm-publication.mjs <slug> [<slug> ...]
- *   node scripts/confirm-publication.mjs --list           # show pending candidates
+ *   node scripts/confirm-publication.mjs <slug> [<slug> ...]    # accept a match
+ *   node scripts/confirm-publication.mjs --reject <slug> ...    # mark a non-match
+ *   node scripts/confirm-publication.mjs --list                 # show pending candidates
+ *
+ * --reject records the (paper, doi) pair in data/publication-rejects.json, so
+ * the matcher stops re-proposing a match a reviewer has validated as wrong.
  */
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -20,6 +24,7 @@ import { dirname, join } from "node:path";
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const CANDIDATES = join(ROOT, "data", "publication-candidates.json");
 const LINKS = join(ROOT, "src", "_data", "paperLinks.json");
+const REJECTS = join(ROOT, "data", "publication-rejects.json");
 
 if (!existsSync(CANDIDATES)) {
   console.error("No data/publication-candidates.json — run scripts/match-publications.mjs first.");
@@ -32,33 +37,57 @@ if (!args.length || args[0] === "--list") {
   for (const c of candidates) {
     console.log(`[${c.band}] ${c.slug}\n    "${c.paperTitle}" (${c.paperYear})\n    → ${c.doi}  "${c.candidateTitle}" (${c.candidateYear})`);
   }
-  console.log(`\n${candidates.length} candidate(s). Confirm with: node scripts/confirm-publication.mjs <slug> ...`);
+  console.log(`\n${candidates.length} candidate(s).\n  accept: node scripts/confirm-publication.mjs <slug> ...\n  reject: node scripts/confirm-publication.mjs --reject <slug> ...`);
   process.exit(0);
 }
 
-const links = existsSync(LINKS) ? JSON.parse(readFileSync(LINKS, "utf8")) : {};
+const reject = args[0] === "--reject";
+const slugs = reject ? args.slice(1) : args;
+if (!slugs.length) {
+  console.error("No slug given. Usage: confirm-publication.mjs [--reject] <slug> ...");
+  process.exit(1);
+}
+
+const readJson = (p) => (existsSync(p) ? JSON.parse(readFileSync(p, "utf8")) : {});
+function writeSorted(p, obj) {
+  const sorted = {};
+  for (const k of Object.keys(obj).sort()) sorted[k] = obj[k];
+  writeFileSync(p, JSON.stringify(sorted, null, 2) + "\n");
+}
 const today = new Date().toISOString().slice(0, 10);
 let n = 0;
-for (const slug of args) {
-  const c = candidates.find((x) => x.slug === slug);
-  if (!c) {
-    console.error(`! no candidate with slug "${slug}" — skipped`);
-    continue;
+
+if (reject) {
+  // Record the (paper, doi) pair as a validated non-match.
+  const rejects = readJson(REJECTS);
+  for (const slug of slugs) {
+    const c = candidates.find((x) => x.slug === slug);
+    if (!c) { console.error(`! no candidate with slug "${slug}" — skipped`); continue; }
+    const list = rejects[slug] || (rejects[slug] = []);
+    if (!list.includes(c.doi)) list.push(c.doi);
+    n++;
+    console.log(`✗ rejected ${slug} → ${c.doi}`);
   }
-  links[slug] = {
-    doi: c.doi || null,
-    publishedUrl: c.publishedUrl || (c.doi ? `https://doi.org/${c.doi}` : null),
-    publishedTitle: c.candidateTitle || null,
-    journal: c.journal || null,
-    publishedYear: c.candidateYear || null,
-    source: c.matchedVia || "manual",
-    verifiedOn: today,
-  };
-  n++;
-  console.log(`✓ recorded ${slug} → ${links[slug].doi}`);
+  writeSorted(REJECTS, rejects);
+  console.log(`\n${n} non-match(es) recorded in data/publication-rejects.json. The matcher will stop proposing these (paper, doi) pairs.`);
+} else {
+  // Record the match so its landing page links the published version.
+  const links = readJson(LINKS);
+  for (const slug of slugs) {
+    const c = candidates.find((x) => x.slug === slug);
+    if (!c) { console.error(`! no candidate with slug "${slug}" — skipped`); continue; }
+    links[slug] = {
+      doi: c.doi || null,
+      publishedUrl: c.publishedUrl || (c.doi ? `https://doi.org/${c.doi}` : null),
+      publishedTitle: c.candidateTitle || null,
+      journal: c.journal || null,
+      publishedYear: c.candidateYear || null,
+      source: c.matchedVia || "manual",
+      verifiedOn: today,
+    };
+    n++;
+    console.log(`✓ recorded ${slug} → ${links[slug].doi}`);
+  }
+  writeSorted(LINKS, links);
+  console.log(`\n${n} match(es) recorded in src/_data/paperLinks.json. Rebuild to surface them on the /papers/<slug> pages.`);
 }
-// Stable key order for readable diffs.
-const sorted = {};
-for (const k of Object.keys(links).sort()) sorted[k] = links[k];
-writeFileSync(LINKS, JSON.stringify(sorted, null, 2) + "\n");
-console.log(`\n${n} match(es) recorded in src/_data/paperLinks.json. Rebuild to surface them on the /papers/<slug> pages.`);

--- a/scripts/match-publications.mjs
+++ b/scripts/match-publications.mjs
@@ -32,6 +32,13 @@ import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const corpus = require("../src/_data/corpus.js");
 const orcidMembers = require("../src/_data/orcidWorks.json");
+// Human-validated NON-matches: { slug: [doi, …] }. A reviewer who decides a
+// proposal is wrong records it here (confirm-publication.mjs --reject) so the
+// matcher stops re-proposing that (paper, doi) pair. Keyed on the pair, not
+// the paper, so a genuinely better match can still surface later.
+let rejects = {};
+try { rejects = require("../data/publication-rejects.json"); } catch { /* none yet */ }
+const isRejected = (slug, doi) => (rejects[slug] || []).includes(doi);
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const OUT = join(ROOT, "data", "publication-candidates.json");
@@ -106,6 +113,7 @@ async function orcidPhase() {
       let best = null;
       for (const w of works) {
         if (w.year && (w.year < p.year - 1 || w.year > p.year + 6)) continue;
+        if (isRejected(p.slug, w.doi)) continue; // human-validated non-match
         const score = dice(p.title, w.title);
         if (!best || score > best.score) best = { w, score };
       }
@@ -183,6 +191,7 @@ async function openAlexPhase() {
     let best = null;
     for (const w of pool) {
       if (w.year && (w.year < p.year - 1 || w.year > p.year + 6)) continue; // publication-lag window
+      if (isRejected(p.slug, w.doi)) continue; // human-validated non-match
       const score = dice(p.title, w.title);
       if (!best || score > best.score) best = { w, score };
     }


### PR DESCRIPTION
Makes a validated rejection stick, so the monthly matcher stops re-proposing a match a reviewer has decided is wrong (the gap exposed when validating the 2019 Varma proposal).

## How
- **`data/publication-rejects.json`** — `{ slug: [doi, …] }` of validated non-matches. **Pair-level**, not paper-level, so a genuinely better match for the same paper can still surface later.
- **`match-publications.mjs`** skips any rejected (slug, doi) pair during candidate selection, in both the ORCID and OpenAlex phases.
- **`confirm-publication.mjs --reject <slug> …`** — symmetric with accept; records the candidate's (slug, doi) into the reject file. (`--list` now shows both accept and reject usage.)

## Seeded with the validated rejection
The 2019 Tara Varma paper ("European Perceptions of Nuclear Deterrence…") proposed against her 2024 "European Strategic Autonomy: The Path to a Geopolitical Europe" — same author, shared theme, but a different work. Recorded as rejected and pruned from the committed candidate queue (56 → 55).

Verified: both scripts parse; the reject-skip unit-tests true for the Varma pair and false for the confirmed Gheorghe pair; `--list` works. Internal tooling + data artifacts (not in the Eleventy input), so no `src/` change, no CHANGELOG, no site impact. `docs/publication-matching.md` updated.