### PR TITLE
fix(navigator): match Published pill colour to Early-access preview badge

### DIFF
--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -3650,9 +3650,9 @@ a.programme-live-tag:focus-visible {
   letter-spacing: 0.04em;
   text-transform: uppercase;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-  color: var(--accent);
-  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  background: var(--warning);
+  color: hsl(222 30% 8%);
+  border: 1px solid transparent;
   white-space: nowrap;
   line-height: 1.6;
 }


### PR DESCRIPTION
## Summary

- `.paper-pub-chip` (the "Published" pill in the Navigator paper list) was styled with a tinted accent colour
- `.pub-match-badge` ("Early-access preview" on paper pages) uses `var(--warning)` amber
- Both now use `var(--warning)` amber background on `hsl(222 30% 8%)` dark text, so the same visual signal ("this record has a matched publication link") is consistent across both surfaces

## Verification

Computed styles confirmed via preview:
- Navigator chip: `background: rgb(249, 152, 6)`, `color: rgb(14, 18, 27)` ✓
- Paper page badge: `background: rgb(249, 152, 6)`, `color: rgb(14, 18, 27)` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)