### PR TITLE
feat(navigator): Published-only filter on the papers view

### DIFF
--- a/src/_data/i18n.js
+++ b/src/_data/i18n.js
@@ -486,6 +486,7 @@ const locales = {
       allYears: "All years",
       themeLabel: "Theme",
       allThemes: "All themes",
+      publishedOnly: "Published only",
       clear: "Clear",
       note: "Assembled from the published conference programmes. Themes are inferred from the panel each paper sat in (the nine permanent EISS sections plus recurring themes), so a paper may carry more than one or none. Titles, author names, affiliations and theme labels stay in their original language.",
       // Live-region status strings, read by paper-filter.js. {n}/{q} are
@@ -908,6 +909,7 @@ const locales = {
       allYears: "Toutes les années",
       themeLabel: "Thème",
       allThemes: "Tous les thèmes",
+      publishedOnly: "Publiées uniquement",
       clear: "Effacer",
       note: "Constitué à partir des programmes publiés des conférences. Les thèmes sont déduits du panel dans lequel chaque communication a été présentée (les neuf sections permanentes de l'EISS et des thèmes récurrents) : une communication peut en porter plusieurs ou aucun. Les titres, noms d'auteurs, affiliations et intitulés de thèmes restent dans leur langue d'origine.",
       resultsOne: "{n} communication",
@@ -1323,6 +1325,7 @@ const locales = {
       allYears: "Alle Jahre",
       themeLabel: "Thema",
       allThemes: "Alle Themen",
+      publishedOnly: "Nur veröffentlichte",
       clear: "Zurücksetzen",
       note: "Zusammengestellt aus den veröffentlichten Konferenzprogrammen. Themen werden aus dem Panel abgeleitet, in dem der jeweilige Beitrag stand (die neun ständigen EISS-Sektionen sowie wiederkehrende Themen): ein Beitrag kann mehrere oder gar keines tragen. Titel, Autorennamen, Zugehörigkeiten und Themenbezeichnungen bleiben in ihrer Originalsprache.",
       resultsOne: "{n} Beitrag",

--- a/src/_includes/papers-page.njk
+++ b/src/_includes/papers-page.njk
@@ -34,6 +34,12 @@
       {%- endfor %}
     </select>
   </div>
+  <div class="speaker-field speaker-field--check">
+    <label class="speaker-field-label--check" for="paper-published">
+      <input type="checkbox" id="paper-published" data-paper-published data-label="{{ p18n.publishedOnly }}">
+      {{ p18n.publishedOnly }}
+    </label>
+  </div>
   <button type="button" class="btn btn-sm speaker-clear" data-paper-clear hidden>{{ p18n.clear }}</button>
 </div>
 
@@ -52,7 +58,8 @@
       {% if p.slug %}id="paper-{{ p.slug }}"{% endif %}
       data-year="{{ p.year }}"
       data-themes="{{ p.theme | join('|') }}"
-      data-search="{{ p.title }} {{ p.authors | join(' ') }} {{ p.affiliations | join(' ') }}">
+      data-search="{{ p.title }} {{ p.authors | join(' ') }} {{ p.affiliations | join(' ') }}"
+      {% if p.publishedUrl %}data-published="1"{% endif %}>
     <article class="paper-card">
       <h2 class="paper-title" lang="en">{% if p.paperUrl %}<a href="{{ p.paperUrl }}">{{ p.title }}</a>{% else %}{{ p.title }}{% endif %}{%- if p.publishedUrl %}<span class="paper-pub-chip" lang="en" title="A published version of this paper exists">Published</span>{% endif %}</h2>
       {%- if p.authorsLinked.length %}

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -3460,6 +3460,26 @@ a.programme-live-tag:focus-visible {
 .speaker-field--search {
   flex: 1 1 16rem;
 }
+.speaker-field--check {
+  justify-content: flex-end;
+}
+.speaker-field-label--check {
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+  cursor: pointer;
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+}
+.speaker-field-label--check input[type="checkbox"] {
+  width: 1em;
+  height: 1em;
+  accent-color: var(--accent);
+  cursor: pointer;
+  flex-shrink: 0;
+}
 .speaker-field-label {
   font-size: var(--fs-xs);
   font-weight: 600;

--- a/src/assets/js/paper-filter.js
+++ b/src/assets/js/paper-filter.js
@@ -1,25 +1,27 @@
-/* /papers — year + theme + free-text filtering over the cross-year paper
- * index (#632).
+/* /papers — year + theme + published + free-text filtering over the
+ * cross-year paper index (#632).
  *
  * Progressive enhancement: with JS off the page shows every paper (the
  * controls simply do nothing). With JS on:
  *   - a year <select> narrows to one edition's papers;
  *   - a theme <select> narrows to papers carrying that theme;
+ *   - a "Published only" checkbox narrows to papers with a confirmed
+ *     published version (data-published="1");
  *   - a search box narrows by title / author / affiliation (diacritic-
  *     insensitive);
- *   - the three combine (AND);
+ *   - all four combine (AND);
  *   - a role=status region announces the new count to assistive tech (no
  *     focus move);
- *   - a Clear button resets all three;
- *   - year + theme are mirrored in the URL (?year=…&theme=…) so a filtered
- *     view is shareable and survives Back. The served page's
- *     <link rel=canonical> stays the clean /papers.html (the params are
- *     added client-side only), so this introduces no duplicate-content URL
- *     for crawlers.
+ *   - a Clear button resets all four;
+ *   - year + theme + published are mirrored in the URL so a filtered view
+ *     is shareable and survives Back. The served page's <link rel=canonical>
+ *     stays the clean /papers.html (the params are added client-side only),
+ *     so this introduces no duplicate-content URL for crawlers.
  *
- * Entries carry data-year, data-themes="A|B" and data-search (title +
- * authors + affiliations). Matching is on those attributes, not visible
- * text, so the JS stays locale-agnostic.
+ * Entries carry data-year, data-themes="A|B", data-published="1" (when a
+ * published version exists) and data-search (title + authors + affiliations).
+ * Matching is on those attributes, not visible text, so the JS stays
+ * locale-agnostic.
  */
 (function () {
   "use strict";
@@ -29,6 +31,7 @@
   if (!list || (!yearSel && !themeSel)) return;
 
   var findEl = document.querySelector("[data-paper-find]");
+  var pubCheck = document.querySelector("[data-paper-published]");
   var clearEl = document.querySelector("[data-paper-clear]");
   var statusEl = document.querySelector("[data-paper-status]");
   var entries = [].slice.call(list.querySelectorAll("[data-paper-entry]"));
@@ -44,18 +47,20 @@
   function apply() {
     var year = yearSel ? yearSel.value : "";
     var theme = themeSel ? themeSel.value : "";
+    var pub = pubCheck && pubCheck.checked;
     var q = norm(findEl && findEl.value);
     var visible = 0;
     entries.forEach(function (el) {
       var okYear = !year || el.getAttribute("data-year") === year;
       var okTheme = !theme || (el.getAttribute("data-themes") || "").split("|").indexOf(theme) !== -1;
+      var okPub = !pub || el.getAttribute("data-published") === "1";
       var okText = !q || norm(el.getAttribute("data-search")).indexOf(q) !== -1;
-      var show = okYear && okTheme && okText;
+      var show = okYear && okTheme && okPub && okText;
       el.hidden = !show;
       if (show) visible++;
     });
 
-    var filtering = !!(year || theme || q);
+    var filtering = !!(year || theme || pub || q);
     if (clearEl) clearEl.hidden = !filtering;
     if (statusEl) {
       if (!filtering) {
@@ -73,6 +78,7 @@
           var bits = [];
           if (year) bits.push(year);
           if (theme) bits.push(theme);
+          if (pub && pubCheck && pubCheck.dataset.label) bits.push(pubCheck.dataset.label);
           if (q) {
             var matchTmpl = d.msgMatching || 'matching "{q}"';
             bits.push(matchTmpl.replace("{q}", (findEl.value || "").trim()));
@@ -85,8 +91,8 @@
     }
   }
 
-  // Mirror year + theme in the URL (shareable / Back-restorable). Free-text
-  // search stays out of the URL — it's an ephemeral accelerator, not a view.
+  // Mirror year + theme + published in the URL (shareable / Back-restorable).
+  // Free-text search stays out of the URL — it's an ephemeral accelerator.
   function syncUrl() {
     if (!window.history || !history.replaceState) return;
     var url = new URL(window.location.href);
@@ -94,16 +100,20 @@
     else url.searchParams.delete("year");
     if (themeSel && themeSel.value) url.searchParams.set("theme", themeSel.value);
     else url.searchParams.delete("theme");
+    if (pubCheck && pubCheck.checked) url.searchParams.set("published", "1");
+    else url.searchParams.delete("published");
     history.replaceState(null, "", url.pathname + url.search + url.hash);
   }
 
   if (yearSel) yearSel.addEventListener("change", function () { syncUrl(); apply(); });
   if (themeSel) themeSel.addEventListener("change", function () { syncUrl(); apply(); });
+  if (pubCheck) pubCheck.addEventListener("change", function () { syncUrl(); apply(); });
   if (findEl) findEl.addEventListener("input", apply);
   if (clearEl) {
     clearEl.addEventListener("click", function () {
       if (yearSel) yearSel.value = "";
       if (themeSel) themeSel.value = "";
+      if (pubCheck) pubCheck.checked = false;
       if (findEl) findEl.value = "";
       syncUrl();
       apply();
@@ -111,7 +121,7 @@
     });
   }
 
-  // Restore year + theme from the URL on load (deep link / Back).
+  // Restore year + theme + published from the URL on load (deep link / Back).
   function restore(param, sel) {
     if (!sel) return;
     var v = new URL(window.location.href).searchParams.get(param);
@@ -119,5 +129,6 @@
   }
   restore("year", yearSel);
   restore("theme", themeSel);
+  if (pubCheck && new URL(window.location.href).searchParams.get("published") === "1") pubCheck.checked = true;
   apply();
 })();


### PR DESCRIPTION
## Summary

- Adds a "Published only" checkbox to the paper index filter bar
- Filters to papers with a confirmed published version (`data-published="1"` on the `<li>`)
- Combines with year, theme, and free-text filters (AND logic, consistent with existing filters)
- State mirrored in `?published=1` — filtered views are shareable and survive Back
- Clear button resets it alongside the other controls
- Status line reads e.g. "49 papers · Published only"
- EN / FR / DE labels via `i18n.js` (`publishedOnly` key in `papers.*`)

## Verification

Live preview check:
- Checkbox renders, `display: flex`, label "Published only" ✓
- 510 total entries, 49 with `data-published="1"` ✓
- Tick → 49 visible, status "49 papers · Published only", URL `?published=1` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)