### PR TITLE
fix(navigator): paper landing pages highlight Navigator, not Conferences

### DIFF
--- a/src/paper.njk
+++ b/src/paper.njk
@@ -5,7 +5,7 @@ pagination:
   alias: paper
 layout: base.njk
 permalink: "/papers/{{ paper.slug }}.html"
-navKey: conferences
+navKey: "navigator"
 eleventyComputed:
   title: "{{ paper.title }}"
   description: "{{ (paper.abstract or paper.title) | striptags | truncate(155) }}"


### PR DESCRIPTION
## What was wrong

On a per-paper landing page (`/papers/<slug>`), the top nav highlighted **Conferences** instead of **Navigator**.

`paper.njk` set `navKey: conferences`, but the paper pages are part of the Navigator surface (reached from `/papers`), and the Navigator index templates `papers.njk` / `speakers.njk` already use `navKey: "navigator"`.

## Fix

One line in `paper.njk`: `navKey: conferences` → `navKey: "navigator"`.

## Verification

Built locally; on `/papers/2025-assisting-to-win-…` the nav link carrying `aria-current="page"` is now **Navigator**.

Trivial, non-layout change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)