### PR TITLE
probe(indico): find the authenticated endpoint for subcontribution abstracts

### DIFF
--- a/.github/workflows/probe-indico-subcontribs.yml
+++ b/.github/workflows/probe-indico-subcontribs.yml
@@ -1,0 +1,42 @@
+# One-shot manual probe: which authenticated Indico endpoint exposes
+# SUBCONTRIBUTION abstracts?
+#
+# Several ESSC panels hold their papers as subcontributions, and those
+# paper abstracts never reach the site because the anonymous /export/ API
+# omits the subcontribution description field. This probe (read-only, GET
+# only) finds the endpoint + field that carries them, so sync-abstracts.mjs
+# can be wired to it. Same probe-first discipline as probe-indico-api.yml.
+#
+# The log shows status codes, content-types and JSON shapes; for the matched
+# abstract field it prints only a length + 60-char prefix, never full bodies.
+#
+# To run: Actions → "Probe Indico subcontributions (manual)" → Run workflow.
+
+name: Probe Indico subcontributions (manual)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: Probe subcontribution endpoints
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: scripts/requirements.txt
+
+      - name: Install Python dependencies
+        run: pip install -r scripts/requirements.txt
+
+      - name: Run probe
+        env:
+          INDICO_API_TOKEN: ${{ secrets.INDICO_API_TOKEN }}
+        run: python3 scripts/probe-indico-subcontribs.py

--- a/scripts/probe-indico-subcontribs.py
+++ b/scripts/probe-indico-subcontribs.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+One-shot probe: which authenticated Indico endpoint exposes SUBCONTRIBUTION
+abstracts (descriptions)?
+
+WHY
+===
+scripts/sync-abstracts.mjs reads contribution-level descriptions from the
+anonymous /export/ API. Several ESSC panels are modelled as a contribution
+(the panel) with subcontributions (the actual papers), and the paper
+abstracts live on the subcontributions. The anonymous export returns
+subcontribution *titles* but no description field at all, so those abstracts
+never sync. This probe finds the endpoint + field that does carry them, so
+sync-abstracts.mjs can be wired to it (the same probe-first discipline used
+for the registration-state work in v2.12/v2.13; see scripts/probe-indico-api.py).
+
+TEST CASE
+=========
+Event 1 (EISS 2023), contribution 72 ("Addressing Wicked Problems in Cyber
+Conflict"), whose four subcontribution abstracts were just entered in Indico.
+If an endpoint returns a non-empty description for those subcontributions,
+it wins.
+
+WHAT IT NEVER PRINTS
+====================
+  - The token (env var, never echoed; sent as ?apikey= or a bearer header).
+  - Full bodies of large responses. For the matched description field it
+    prints only the length and a 60-char prefix, enough to confirm it is the
+    abstract and not some other text.
+
+HOW TO RUN
+==========
+Locally:  INDICO_API_TOKEN=… python3 scripts/probe-indico-subcontribs.py
+Or:       Actions → "Probe Indico subcontributions (manual)" → Run workflow.
+Paste the output back; the follow-up PR wires the winning endpoint into
+sync-abstracts.mjs.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+try:
+    import requests
+except ImportError:
+    sys.exit("Install deps: pip install -r scripts/requirements.txt")
+
+INDICO_BASE = "https://indico.eiss-europa.com"
+TOKEN = os.environ.get("INDICO_API_TOKEN", "")
+EVENT_ID = "1"
+CONTRIB_ID = "72"  # "Addressing Wicked Problems in Cyber Conflict" — has the 4 new abstracts
+
+# (label, path, params, use_bearer_header). When use_bearer is False the token
+# is sent as ?apikey=… (the scheme that works on this install per round 1).
+CANDIDATES: list[tuple[str, str, dict, bool]] = [
+    # Event export at the subcontributions detail level — does authenticating
+    # (or a richer fossil) add a description field the anonymous call lacks?
+    ("qry/evt-subcontribs", f"/export/event/{EVENT_ID}.json", {"detail": "subcontributions"}, False),
+    # Same, but contributions detail — maybe the nested subContributions here
+    # carry descriptions even when the dedicated detail level doesn't.
+    ("qry/evt-contribs",    f"/export/event/{EVENT_ID}.json", {"detail": "contributions"}, False),
+    # Single-contribution legacy export, a few detail levels.
+    ("qry/contrib",         f"/export/event/{EVENT_ID}/contribution/{CONTRIB_ID}.json", {}, False),
+    ("qry/contrib-sub",     f"/export/event/{EVENT_ID}/contribution/{CONTRIB_ID}.json", {"detail": "subcontributions"}, False),
+    # Newer flask REST surface (round 1 saw /api/v1/* return HTML, but
+    # /api/events/{id}/contributions answered 405 anonymously — try with auth).
+    ("hdr/api-contribs",    f"/api/events/{EVENT_ID}/contributions", {}, True),
+    ("hdr/api-contrib",     f"/api/events/{EVENT_ID}/contributions/{CONTRIB_ID}", {}, True),
+]
+
+
+def _find_subcontribs(data) -> list[dict]:
+    """Pull every subcontribution-looking dict out of an Indico payload,
+    wherever it sits (results[0].contributions[].subContributions[], or a
+    contribution payload's own subContributions, or a bare list)."""
+    found: list[dict] = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            for key in ("subContributions", "subcontributions"):
+                subs = node.get(key)
+                if isinstance(subs, list):
+                    found.extend(s for s in subs if isinstance(s, dict))
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for v in node:
+                walk(v)
+
+    walk(data)
+    return found
+
+
+def _describe_field(value) -> str:
+    """Strip tags, report length + a short prefix. Abstracts aren't PII, but
+    keep the dump small."""
+    import re
+
+    text = re.sub(r"<[^>]+>", " ", str(value or ""))
+    text = re.sub(r"\s+", " ", text).strip()
+    if not text:
+        return "(empty)"
+    return f"{len(text)} chars | {text[:60]!r}…"
+
+
+def probe(label: str, path: str, params: dict, use_bearer: bool) -> None:
+    url = f"{INDICO_BASE}{path}"
+    headers = {"Accept": "application/json"}
+    req_params = dict(params)
+    if use_bearer:
+        headers["Authorization"] = f"Bearer {TOKEN}"
+    else:
+        req_params["apikey"] = TOKEN
+
+    try:
+        r = requests.get(url, params=req_params, headers=headers, timeout=25)
+    except Exception as exc:  # noqa: BLE001
+        print(f"{label:<18} EXC     {str(exc)[:80]}")
+        return
+
+    ct = (r.headers.get("content-type") or "").split(";")[0].strip()
+    param_str = "  ?" + "&".join(f"{k}={v}" for k, v in params.items()) if params else ""
+    print(f"{label:<18} {r.status_code:<5} {ct:<20} {len(r.content):>8}b  {path}{param_str}")
+
+    if r.status_code != 200 or "json" not in ct.lower():
+        if len(r.content) <= 300:
+            print(f"    body: {r.text.strip().replace(chr(10), ' ')[:300]}")
+        return
+
+    try:
+        data = r.json()
+    except Exception as exc:  # noqa: BLE001
+        print(f"    ! json-parse: {exc}")
+        return
+
+    subs = _find_subcontribs(data)
+    if not subs:
+        print("    (no subcontributions found in payload)")
+        return
+
+    # Which keys do subcontribution objects expose, and does any of them carry
+    # the abstract text?
+    sample_keys = sorted(subs[0].keys())
+    print(f"    subcontributions: {len(subs)} | keys: {sample_keys}")
+    abstract_keys = ("description", "abstract", "content", "text")
+    for key in abstract_keys:
+        nonempty = [s for s in subs if str(s.get(key) or "").strip()]
+        if nonempty:
+            print(f"    ✓ field '{key}' is populated on {len(nonempty)}/{len(subs)} subcontributions:")
+            for s in nonempty[:2]:
+                print(f"        - {s.get('title', '?')[:50]!r}: {_describe_field(s.get(key))}")
+
+
+def main() -> None:
+    if not TOKEN:
+        sys.exit("No INDICO_API_TOKEN in env. Set it (export INDICO_API_TOKEN=…) and re-run.")
+    print(f"Probing {INDICO_BASE} for subcontribution abstracts "
+          f"(event {EVENT_ID}, contribution {CONTRIB_ID}).")
+    print("Status + content-type + bytes; for JSON, subcontribution keys and "
+          "any populated abstract field (length + 60-char prefix only).\n")
+    print(f"{'LABEL':<18} {'CODE':<5} {'CONTENT-TYPE':<20} {'BYTES':>9}  PATH")
+    print("-" * 100)
+    for label, path, params, use_bearer in CANDIDATES:
+        probe(label, path, params, use_bearer)
+    print("\nThe winning row is the one that prints a populated abstract field. "
+          "Paste this output back to wire it into sync-abstracts.mjs.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

Step 1 of the authenticated subcontribution sync. Six ESSC 2023 panels are modelled as a contribution (the panel) with subcontributions (the actual papers, 22 in total), and the paper abstracts live on the subcontributions. The anonymous `/export/` API returns subcontribution **titles but no `description` field at all**, so `sync-abstracts.mjs` (anonymous, contribution-level only) can't reach them — including the four abstracts just entered under EISS 2023 contribution 72 ("Addressing Wicked Problems in Cyber Conflict"). All four papers are already in the corpus, so the abstracts will attach the moment we can fetch them.

We don't yet know which authenticated endpoint exposes subcontribution descriptions on this Indico install (round 1 found `/api/v1/*` returns HTML while `/export/…?apikey=` works). So, per the same probe-first discipline as #22/#23, this PR adds a probe rather than guessing.

## What

- `scripts/probe-indico-subcontribs.py` — tries candidate authenticated endpoints (apikey query + bearer `/api`) against the known test case (event 1, contribution 72) and reports, for each, the subcontribution object keys and any populated abstract field (length + 60-char prefix only).
- `.github/workflows/probe-indico-subcontribs.yml` — manual `workflow_dispatch`, token from the `INDICO_API_TOKEN` secret, read-only. Mirrors `probe-indico-api.yml`.

Never prints the token or full response bodies.

## How to run

Either **Actions → "Probe Indico subcontributions (manual)" → Run workflow** (once this merges), or locally: `INDICO_API_TOKEN=… python3 scripts/probe-indico-subcontribs.py`. Paste the output back and the follow-up PR wires the winning endpoint into `sync-abstracts.mjs`.

Read-only tooling, no site change. Part of #794.

🤖 Generated with [Claude Code](https://claude.com/claude-code)