### PR TITLE
feat(anthology): signpost + paper-page navigation polish (#889)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,14 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ## [Unreleased]
 
+### Changed
+
+- **Anthology navigation and signposting polish.** Four refinements: (1) the Anthology signpost on every conference archive page is now its own section after the programme (rather than tucked under it) and is edition-aware, linking to that edition's papers in the Anthology (`/papers.html?year=YYYY`) with a sub-line placing the edition within the full archive. (2) On a paper page, the "Panel:" line below the abstract now links to that panel's anchor in the edition programme. (3) The adaptive Back control on paper pages stands on its own line, a touch larger than the secondary actions, with a return-arrow icon. Part of [#889](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/889).
+
+### Fixed
+
+- **The separator above a paper's "matched automatically" note is no longer cramped against the buttons.** The note's top margin was being zeroed by the more specific `.prose p` rule, so the dividing line sat tight under the Cite button. Scoping it as `.pub-match .pub-match-note` restores the intended breathing room. Part of [#889](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/889).
+
 ### Added
 
 - **The Anthology now carries an "early access" notice.** Both `/speakers` and `/papers` open with a small amber-flagged callout explaining the archive is an evolving preview, still being filled in edition by edition, and inviting corrections. On the French and German pages the same notice also states that the individual paper pages are in English (the per-paper pages are EN-only by design, alongside the existing beta-translation ribbon on those locales). EN + FR + DE, rendered once from the navigator i18n catalog so it stays in step across both views and all three languages. Part of [#889](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/889).

--- a/src/_data/i18n.js
+++ b/src/_data/i18n.js
@@ -318,6 +318,7 @@ const locales = {
       sourceNote: "Indico holds the authoritative programme. This grid is a daily snapshot.",
       viewOnIndico: "View the event on Indico",
       speakersLink: "Anthology",
+      speakersSignpostEdition: "This edition's papers and speakers, within the full archive since 2017.",
       // Livestream signpost + per-session pill (replaces the old standalone
       // "Livestreamed sessions" block).
       livestreamPill: "Livestream",
@@ -798,6 +799,7 @@ const locales = {
       sourceNote: "Indico fait foi pour le programme. Cette grille en est un instantané quotidien.",
       viewOnIndico: "Voir l'événement sur Indico",
       speakersLink: "Anthologie",
+      speakersSignpostEdition: "Les communications et intervenants de cette édition, au sein de l'archive complète depuis 2017.",
       livestreamPill: "En direct",
       livestreamNote: "Les sessions plénières sont diffusées en direct, signalées ci-dessous.",
       livestreamNoteCta: "Suivre en ligne sur Indico",
@@ -1219,6 +1221,7 @@ const locales = {
       sourceNote: "Indico ist die maßgebliche Quelle für das Programm. Dieses Raster ist ein tägliches Abbild.",
       viewOnIndico: "Veranstaltung auf Indico ansehen",
       speakersLink: "Anthologie",
+      speakersSignpostEdition: "Die Beiträge und Vortragenden dieser Ausgabe, innerhalb des Gesamtarchivs seit 2017.",
       livestreamPill: "Livestream",
       livestreamNote: "Die Plenarsitzungen werden live übertragen, unten gekennzeichnet.",
       livestreamNoteCta: "Online auf Indico teilnehmen",

--- a/src/_includes/archive-programme.njk
+++ b/src/_includes/archive-programme.njk
@@ -47,7 +47,10 @@
 
           <div class="programme-row-items">
             {%- for slot in row.items %}
-            <article class="programme-slot programme-slot--{{ slot.kind }}{% if slot.subtype %} programme-slot--{{ slot.subtype }}{% endif %}">
+            {# id="panel-<slugified title>" gives each session an anchor that
+               a paper landing page can deep-link to (its "Panel:" line). #}
+            <article class="programme-slot programme-slot--{{ slot.kind }}{% if slot.subtype %} programme-slot--{{ slot.subtype }}{% endif %}"
+                     {% if slot.kind != "break" and slot.title %}id="panel-{{ slot.title | slugify }}"{% endif %}>
 
               {%- if slot.kind == "break" %}
               <p class="programme-break-title">{{ slot.title }}</p>
@@ -123,13 +126,21 @@
     </div>
     {%- endfor %}
 
-    {% include "speakers-signpost.njk" %}
-
     {%- if _prog.sourceNote %}
     <p class="muted programme-footnote" style="margin-top: var(--space-4); font-size: var(--fs-sm);">
       {{ t.archiveProgramme.reconstructedNote }}
     </p>
     {%- endif %}
+  </div>
+</section>
+
+{# Anthology signpost (#889): its own section after the programme for
+   prominence, edition-aware — links to this edition's papers in the Anthology
+   when the slug is a year, else the generic /speakers card. #}
+<section class="section">
+  <div class="container">
+    {%- set signpostYear = archiveSlug if (archiveSlug | int) >= 2017 else "" -%}
+    {% include "speakers-signpost.njk" %}
   </div>
 </section>
 {% endif %}

--- a/src/_includes/icons.njk
+++ b/src/_includes/icons.njk
@@ -84,6 +84,8 @@ class="{{ classes }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fil
 <svg {{ svgAttrs | safe }}><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
 {%- elif name == "arrow-right" -%}
 <svg {{ svgAttrs | safe }}><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+{%- elif name == "arrow-left" -%}
+<svg {{ svgAttrs | safe }}><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>
 {%- elif name == "search" -%}
 <svg {{ svgAttrs | safe }}><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
 {%- elif name == "download" -%}

--- a/src/_includes/paper-page-body.njk
+++ b/src/_includes/paper-page-body.njk
@@ -81,21 +81,25 @@
       <p>{{ paper.abstract }}</p>
       {%- endif %}
       {%- if paper.panel %}
-      <p class="muted" lang="en"><strong>Panel:</strong> {{ paper.panel }}</p>
+      {# Panel title links to that panel's anchor in the edition programme. #}
+      <p class="muted" lang="en"><strong>Panel:</strong> <a href="{{ paper.conferenceUrl }}#panel-{{ paper.panel | slugify }}">{{ paper.panel }}</a></p>
       {%- endif %}
-      <p style="margin-top: var(--space-5); display: flex; gap: var(--space-3); flex-wrap: wrap;">
-        {%- if paper.abstractUrl %}<a class="btn btn-secondary btn-sm" href="{{ paper.abstractUrl }}" target="_blank" rel="noopener">{{ icon("external-link") }} View on Indico</a>{% endif %}
-        <a class="btn btn-secondary btn-sm" href="{{ paper.conferenceUrl }}#programme">{{ icon("file-text") }} {{ paper.conferenceLabel }} {{ paper.year }} programme</a>
-        {# Adaptive Back (#889, item 1). Baseline: a real anchor to the index at
-           this paper's anchor. paper-back.js upgrades it to history.back() with
-           a referrer-aware label when the reader came from a same-origin page,
-           returning them to their exact filtered index + scroll. #}
-        <a class="btn btn-secondary btn-sm" href="/papers.html#paper-{{ paper.slug }}"
+      {# Adaptive Back (#889). Stands apart from the secondary actions and is a
+         touch larger, with a return arrow. Baseline: a real anchor to the index
+         at this paper's anchor. paper-back.js upgrades it to history.back() with
+         a referrer-aware label when the reader came from a same-origin page,
+         returning them to their exact filtered index + scroll. #}
+      <p style="margin-top: var(--space-5);">
+        <a class="btn btn-secondary" href="/papers.html#paper-{{ paper.slug }}"
            data-paper-back
            data-back-conf-path="{{ paper.conferenceUrl }}"
            data-back-event="{{ paper.conferenceLabel }} {{ paper.year }}"
            data-back-anthology="Back to the Anthology"
-           data-back-generic="Back"><span data-back-label>All papers</span></a>
+           data-back-generic="Back">{{ icon("arrow-left") }} <span data-back-label>All papers</span></a>
+      </p>
+      <p style="margin-top: var(--space-4); display: flex; gap: var(--space-3); flex-wrap: wrap;">
+        {%- if paper.abstractUrl %}<a class="btn btn-secondary btn-sm" href="{{ paper.abstractUrl }}" target="_blank" rel="noopener">{{ icon("external-link") }} View on Indico</a>{% endif %}
+        <a class="btn btn-secondary btn-sm" href="{{ paper.conferenceUrl }}#programme">{{ icon("file-text") }} {{ paper.conferenceLabel }} {{ paper.year }} programme</a>
       </p>
     </article>
   </div>

--- a/src/_includes/speakers-signpost.njk
+++ b/src/_includes/speakers-signpost.njk
@@ -1,15 +1,19 @@
-{# Locale-aware signpost to the /speakers index, as a link-card. Used at
-   the foot of the conference programme grid and on the People page.
-   Reads `lang` to pick the right-locale page, and `t.programme.speakersLink`
-   for the label. The count line reuses the speaker stats. #}
+{# Locale-aware signpost to the Anthology, as a link-card. Used on the People
+   page (generic: links to /speakers, shows the global speaker count) and at the
+   foot of a conference programme. On a conference page the caller sets
+   `signpostYear` to the edition year: the card then links to that edition's
+   papers in the Anthology (/papers?year=YYYY) and the sub-line frames it as
+   this edition within the wider archive. Reads `lang` for the right-locale URL
+   and `t.programme.*` for the copy. #}
 {% from "icons.njk" import icon %}
 {%- set t = i18n[lang or "en"] -%}
-{%- set _spk = "/speakers.html" if (lang or "en") == "en" else "/speakers." + lang + ".html" -%}
-<a class="speakers-cta" href="{{ _spk }}">
+{%- set _suffix = "" if (lang or "en") == "en" else "." + lang -%}
+{%- set _href = ("/papers" + _suffix + ".html?year=" + signpostYear) if signpostYear else ("/speakers" + _suffix + ".html") -%}
+<a class="speakers-cta" href="{{ _href }}">
   <span class="speakers-cta__icon" aria-hidden="true">{{ icon("users") }}</span>
   <span class="speakers-cta__body">
     <span class="speakers-cta__title">{{ t.programme.speakersLink }}</span>
-    <span class="speakers-cta__sub muted">{{ corpus.stats.speakerCount }} {{ t.speakers.statSpeakers }} · {{ t.speakers.statConferencesSince }}</span>
+    <span class="speakers-cta__sub muted">{% if signpostYear %}{{ t.programme.speakersSignpostEdition }}{% else %}{{ corpus.stats.speakerCount }} {{ t.speakers.statSpeakers }} · {{ t.speakers.statConferencesSince }}{% endif %}</span>
   </span>
   <span class="speakers-cta__arrow" aria-hidden="true">{{ icon("arrow-right") }}</span>
 </a>

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -3442,9 +3442,11 @@ a.programme-live-tag:focus-visible {
   cursor: pointer;
 }
 .pub-bibtex-copy:hover { border-color: var(--accent); color: var(--accent); }
-.pub-match-note {
-  margin: var(--space-4) 0 0;
-  padding-top: var(--space-3);
+/* Scoped under .pub-match to beat `.prose p` (which otherwise zeroes the
+   top margin, leaving the separator cramped against the buttons above it). */
+.pub-match .pub-match-note {
+  margin: var(--space-5) 0 0;
+  padding-top: var(--space-4);
   border-top: 1px solid var(--border);
   font-size: var(--fs-sm);
   color: var(--text-muted);


### PR DESCRIPTION
## Summary

Four refinements requested on the Anthology UX.

**1. Conference-page Anthology signpost — better location + design.** The signpost (`speakers-signpost.njk`) on every conference archive page moves out of the programme's footer into **its own section** after the programme, and is now **edition-aware**: when the page's archive slug is a year it links to that edition's papers in the Anthology (`/papers.html?year=YYYY`) with a sub-line framing the edition within the full archive. The People-page usage is untouched (no `signpostYear` → the generic `/speakers` card as before).

**2. Linkable panel title.** A paper page's "Panel:" line (below the abstract) now links to that panel's anchor in the edition programme. `archive-programme.njk` gives each non-break session `id="panel-<slugified title>"`; the paper page links to the same slug. Verified the anchor resolves (e.g. the 2024 maritime panel).

**3. Back control redesign.** The adaptive Back control now sits on **its own line**, is **slightly larger** (`btn`, not `btn-sm`), and has a **return-arrow icon** (new `arrow-left` icon). Separated from the "View on Indico" / "programme" secondary buttons.

**4. Separator padding fix.** The `.pub-match-note` divider (above the "matched automatically" note) had its top margin zeroed by the more specific `.prose p` rule, so the line sat cramped against the Cite button. Scoping it `.pub-match .pub-match-note` restores the margin — verified 24px above the line (was 0).

## Verification (Preview MCP + build)

Single paper page confirms #2/#3/#4 together: "Panel: Military Technology" is a link, Back is a standalone arrow button on its own row, and the separator has clear space. Conference page confirms #1: signpost in its own section, "Anthology — This edition's papers and speakers, within the full archive since 2017", href `/papers.html?year=2024`. `check-i18n-drift.py` clean; new `speakersSignpostEdition` string added EN/FR/DE.

Closes the remaining design items raised against #889 (items 3–4 of that issue — within-event prev/next and the mobile sticky back — are still open).

Visual change — please eyeball the deploy preview (conference page signpost + a paper page with a published-version card) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)