### PR TITLE
Resolve a working python3 in release.sh + check-links.sh

### DIFF
--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -53,7 +53,23 @@ for arg in "$@"; do
   esac
 done
 
-python3 - "$SITE_ROOT" $INTERNAL_ONLY $QUIET <<'PY'
+# Resolve a python3 that actually runs. On some macOS setups the first
+# python3 on PATH is an x86 framework build that aborts with "Bad CPU
+# type in executable" on Apple silicon, so test each candidate before
+# committing to it rather than trusting `command -v`.
+PY3=""
+for _cand in python3 /usr/bin/python3 /opt/homebrew/bin/python3 python; do
+  if command -v "$_cand" >/dev/null 2>&1 && "$_cand" -c '' >/dev/null 2>&1; then
+    PY3="$_cand"; break
+  fi
+done
+if [ -z "$PY3" ]; then
+  echo "error: no working python3 found (tried python3, /usr/bin/python3, /opt/homebrew/bin/python3, python)." >&2
+  echo "       install python3 or fix the broken interpreter on PATH, then re-run." >&2
+  exit 2
+fi
+
+"$PY3" - "$SITE_ROOT" $INTERNAL_ONLY $QUIET <<'PY'
 """Inline-Python link checker. Avoids extra deps; portable across
 the maintainer's macOS laptop and Ubuntu CI."""
 import os, re, sys, urllib.parse, urllib.request, urllib.error, ssl

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -112,6 +112,22 @@ step() {
   echo "── $1"
 }
 
+# Resolve a python3 that actually runs. On some macOS setups the first
+# python3 on PATH is an x86 framework build that aborts with "Bad CPU
+# type in executable" on Apple silicon, so test each candidate before
+# committing to it rather than trusting `command -v`.
+PY3=""
+for _cand in python3 /usr/bin/python3 /opt/homebrew/bin/python3 python; do
+  if command -v "$_cand" >/dev/null 2>&1 && "$_cand" -c '' >/dev/null 2>&1; then
+    PY3="$_cand"; break
+  fi
+done
+if [[ -z "$PY3" ]]; then
+  echo "✗ No working python3 found (tried python3, /usr/bin/python3, /opt/homebrew/bin/python3, python)."
+  echo "  Install python3 or fix the broken interpreter on PATH, then re-run."
+  exit 1
+fi
+
 # ────────────────────────────────────────────────────────────────────
 # Pre-flight checks
 # ────────────────────────────────────────────────────────────────────
@@ -229,7 +245,7 @@ if [[ "$DRY_RUN" != "--dry-run" ]]; then
 fi
 
 if [[ "$DRY_RUN" != "--dry-run" ]]; then
-  python3 - "$CHANGELOG" "$VERSION" "$TODAY" "$TITLE" <<'PY'
+  "$PY3" - "$CHANGELOG" "$VERSION" "$TODAY" "$TITLE" <<'PY'
 import re
 import sys
 from pathlib import Path
@@ -306,7 +322,7 @@ step "Publish GitHub Release v$VERSION"
 NOTES_FILE="$(mktemp -t "release-v$VERSION-XXXXXX.md")"
 
 if [[ "$DRY_RUN" != "--dry-run" ]]; then
-  python3 - "$CHANGELOG" "$VERSION" >"$NOTES_FILE" <<'PY'
+  "$PY3" - "$CHANGELOG" "$VERSION" >"$NOTES_FILE" <<'PY'
 import re
 import sys
 


### PR DESCRIPTION
Both scripts called bare `python3`. On an Apple-silicon setup the first `python3` on PATH can be an x86 framework build that aborts with **"Bad CPU type in executable"** — which is why `check-links.sh` couldn't be run locally during recent work.

Each script now resolves a **working** interpreter up front (probing `python3`, `/usr/bin/python3`, `/opt/homebrew/bin/python3`, `python` and testing that each actually runs), then routes its invocations through `$PY3`:

- `release.sh` — the two inline-Python heredocs (CHANGELOG promotion, release-notes extraction). Cosmetic `python3` mentions in the printed reminders are left as-is.
- `check-links.sh` — the inline-Python link checker.

Ported from the NetSec sister repo ([netsec.github.io#1032](https://github.com/EISSeuropa/netsec.github.io/pull/1032)); the same idea `docs/pdf/build.sh` already uses.

**Verified:** `bash -n` clean on both; the resolver picks the arm64 interpreter; `check-links.sh --internal` now runs end-to-end (14,668 internal links, 0 broken, exit 0). Internal tooling only, so no CHANGELOG entry (§4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)