### PR TITLE
Extend parallel-panel sync to the live Indico grid

### DIFF
--- a/src/_includes/programme-grid.njk
+++ b/src/_includes/programme-grid.njk
@@ -227,4 +227,9 @@
     </p>
   </div>
 </section>
+{# Keeps parallel panels' expand/collapse in step (a session shares a row with
+   another), the same behaviour the archive programmes get. The abstract
+   clamp/expand half of this script is inert here: the live grid renders no
+   data-abstract markup, so it finds nothing to set up. #}
+<script src="{{ '/assets/js/programme-abstracts.js' | bust }}" defer></script>
 {% endif %}


### PR DESCRIPTION
Follow-up to #908. That PR wired the parallel-panel expand/collapse sync into the **archive** programmes (`archive-programme.njk`). This includes the same `programme-abstracts.js` on the **live Indico grid** (`programme-grid.njk`), so a future live edition gets the behaviour too.

### Notes
- **Stacked on #908** (base is `claude/parallel-panel-sync`, not `master`) because it needs the `syncParallel` code that PR adds. GitHub will retarget this to `master` once #908 squash-merges.
- The live grid renders no `data-abstract` markup, so the **abstract clamp/expand half of the script is inert** there; only the parallel-panel sync runs. The grid uses the same `details.programme-contribs` / `programme-row--parallel` structure as the archive, so the sync applies unchanged.
- The `<script>` sits inside the grid's `{% if %}` block, so it only loads when a conference is present.
- **No separate CHANGELOG entry:** #908's bullet is generic ("On a programme where two sessions share a timeslot…") and this just makes that true for the live grid too.

### Verification note
No page currently renders the live grid — 2026 is archived (uses `archive-programme.njk`) and the /2027 template is in `.eleventyignore` and needs a `conferences.js` entry before its grid renders. So there's no built page to drive in the preview here. The sync code is byte-identical to the archive path already verified in-browser on #908 (open one parallel panel → both open; collapse → both close; no loop), and the live grid's panel/row markup is identical, so the behaviour carries over when /2027 activates. Build compiles clean; archive pages still include the script exactly once (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)