### PR TITLE
fix: uniform Summer School gallery tiles (ragged row in #935)

### DIFF
--- a/src/NetSecSchool.njk
+++ b/src/NetSecSchool.njk
@@ -62,31 +62,31 @@ navKey: programmes
     <p class="lead muted" style="max-width: 44rem; margin-bottom: var(--space-5);">
       Scenes from the inaugural NetSec Summer School at Stockholm University, 9 to 11 June 2026.
     </p>
-    <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(min(18rem, 100%), 1fr));">
-      <figure style="margin: 0; border-radius: var(--radius-md); overflow: hidden;">
+    <div class="photo-gallery">
+      <figure>
         <img src="/assets/images/ecs3-2026-cohort.jpg"
              srcset="/assets/images/ecs3-2026-cohort-480.jpg 480w,
                      /assets/images/ecs3-2026-cohort-960.jpg 960w,
                      /assets/images/ecs3-2026-cohort.jpg 1417w"
-             sizes="(max-width: 720px) 100vw, 22rem"
+             sizes="(max-width: 720px) 100vw, 18rem"
              alt="The 2026 NetSec Summer School cohort with faculty outside Stockholm University."
              width="1417" height="1012" loading="lazy">
       </figure>
-      <figure style="margin: 0; border-radius: var(--radius-md); overflow: hidden;">
+      <figure>
         <img src="/assets/images/ecs3-2026-session.jpg"
              srcset="/assets/images/ecs3-2026-session-480.jpg 480w,
                      /assets/images/ecs3-2026-session-960.jpg 960w,
                      /assets/images/ecs3-2026-session.jpg 1417w"
-             sizes="(max-width: 720px) 100vw, 22rem"
+             sizes="(max-width: 720px) 100vw, 18rem"
              alt="A teaching session in the classroom during the 2026 Summer School."
              width="1417" height="1063" loading="lazy">
       </figure>
-      <figure style="margin: 0; border-radius: var(--radius-md); overflow: hidden;">
+      <figure>
         <img src="/assets/images/ecs3-2026-visit.jpg"
              srcset="/assets/images/ecs3-2026-visit-480.jpg 480w,
                      /assets/images/ecs3-2026-visit-960.jpg 960w,
                      /assets/images/ecs3-2026-visit.jpg 1063w"
-             sizes="(max-width: 720px) 100vw, 22rem"
+             sizes="(max-width: 720px) 100vw, 18rem"
              alt="Participants on a study visit during the 2026 Summer School."
              width="1063" height="1417" loading="lazy">
       </figure>
@@ -101,17 +101,17 @@ navKey: programmes
       Participants of Euro-SWAMOS 2023 at the Hertie School in Berlin, the previous EISS event
       dedicated to the training and mentoring of early-career researchers.
     </p>
-    <div class="tile-grid" style="grid-template-columns: repeat(auto-fit, minmax(min(16rem, 100%), 1fr));">
-      <figure style="margin: 0; border-radius: var(--radius-md); overflow: hidden;">
+    <div class="photo-gallery">
+      <figure>
         <img src="/assets/images/fwllhajwaaed8cu-538x359.jpg" alt="Euro-SWAMOS 2023 scene." loading="lazy">
       </figure>
-      <figure style="margin: 0; border-radius: var(--radius-md); overflow: hidden;">
+      <figure>
         <img src="/assets/images/fymxtpuxkaathvo.jpeg" alt="Euro-SWAMOS 2023 scene." loading="lazy">
       </figure>
-      <figure style="margin: 0; border-radius: var(--radius-md); overflow: hidden;">
+      <figure>
         <img src="/assets/images/fxypyzcvuair46-.jpeg" alt="Euro-SWAMOS 2023 scene." loading="lazy">
       </figure>
-      <figure style="margin: 0; border-radius: var(--radius-md); overflow: hidden;">
+      <figure>
         <img src="/assets/images/fxypyarvsaclmk1.jpeg" alt="Euro-SWAMOS 2023 scene." loading="lazy">
       </figure>
     </div>


### PR DESCRIPTION
Follow-up to #935. On `/NetSecSchool` the summer-school photos mixed landscape and portrait aspect ratios inside a `.tile-grid`, so the row rendered ragged (the portrait "study visit" photo was much taller than its neighbours).

**Fix:** switch both galleries on the page to the existing `.photo-gallery` component (`aspect-ratio: 3/2` + `object-fit: cover`), matching `/2025` and `/2026`. All tiles are now uniform height (373×249 at desktop) and the portrait crops to fit. No new CSS.

Verified on the preview (light + the dark mode in the report): three equal-height tiles, `object-fit: cover`, no ragged row.

Visual change — auto-merge not armed; please eyeball the deploy preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)