### PR TITLE
Sync netsecDirectory.json from the live directory-index.json

### DIFF
--- a/src/_data/netsecDirectory.json
+++ b/src/_data/netsecDirectory.json
@@ -1,7 +1,7 @@
 {
   "generated_at": "2026-06-17T15:59:39+00:00",
   "count": 37,
-  "source": "bootstrap from netsec.github.io bios.json — replaced by the published directory-index.json on first sync",
+  "source": "https://netsec-cost.eu/directory-index.json",
   "members": [
     {
       "name": "Dr Alexander Lanoszka",
@@ -261,7 +261,7 @@
     },
     {
       "name": "Prof. Seyithan Ahmet Ates",
-      "name_key": "seyithan ahmet ates",
+      "name_key": "seyithan ates",
       "aliases": [],
       "slug": "seyithan-ahmet-ates",
       "url": "https://netsec-cost.eu/people/seyithan-ahmet-ates.html",
@@ -269,7 +269,7 @@
     },
     {
       "name": "Dr Silvia D'Amato",
-      "name_key": "silvia d'amato",
+      "name_key": "silvia damato",
       "aliases": [],
       "slug": "silvia-damato",
       "url": "https://netsec-cost.eu/people/silvia-damato.html",
@@ -277,7 +277,7 @@
     },
     {
       "name": "Dr Sophie Enos-Attali",
-      "name_key": "sophie enos-attali",
+      "name_key": "sophie attali",
       "aliases": [],
       "slug": "sophie-enos-attali",
       "url": "https://netsec-cost.eu/people/sophie-enos-attali.html",
@@ -293,7 +293,7 @@
     },
     {
       "name": "Ms Yanina Shved-Dogrul",
-      "name_key": "yanina shved-dogrul",
+      "name_key": "yanina dogrul",
       "aliases": [],
       "slug": "yanina-shved-dogrul",
       "url": "https://netsec-cost.eu/people/yanina-shved-dogrul.html",


### PR DESCRIPTION
NetSec published `directory-index.json` ([netsec#1134](https://github.com/EISSeuropa/netsec.github.io/pull/1134), merged), so the bootstrap snapshot from #967 is now replaced by the real index via `scripts/sync-netsec-directory.mjs`.

**Deltas:** only the `source` line and four `name_key` values where NetSec's `name_key()` is more aggressive than the bootstrap (drops middle names / hyphenated-surname prefixes): `silvia damato`, `sophie attali`, `seyithan ates`, `yanina dogrul`. No `url` changed, so the rendered links are byte-identical.

**Matches unaffected (26/37):** `corpus.js` keys each member under both `keyOf(name_key)` and `canonicalKey(name)`, so the divergent keys don't break the join — verified D'Amato, Shved-Dogrul, Sguazzini, Gheorghe still resolve, and confirmed the unmatched directory members (Enos-Attali, Ates) simply aren't ESSC authors.

This is the refresh the scheduled `sync-netsec-directory.yml` would otherwise auto-PR, landed now to pick up the live index immediately. Closes the data half of [#966](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/966).

🤖 Generated with [Claude Code](https://claude.com/claude-code)