### PR TITLE
Restore per-author ?person=<slug> anchor (regression from #974)

### DIFF
--- a/src/_includes/speakers-index.njk
+++ b/src/_includes/speakers-index.njk
@@ -60,7 +60,7 @@
     <h2 id="ltr-{{ s.letter }}" class="speaker-letter-h">{{ s.letter }}</h2>
   </li>
   {%- endif %}
-  <li class="speaker-entry" {% if s.profileUrl %}id="person-{{ s.profileUrl | replace('/board/', '') | replace('.html', '') }}"{% endif %} data-speaker-entry data-name="{{ s.display }}" data-themes="{{ s.themes | join('|') }}" data-events="{{ s.editionKeys | join('|') }}">
+  <li class="speaker-entry" id="person-{{ s.slug }}" data-speaker-entry data-name="{{ s.display }}" data-themes="{{ s.themes | join('|') }}" data-events="{{ s.editionKeys | join('|') }}">
     {%- if s.profileUrl %}
     <span class="speaker-headshot" aria-hidden="true">
       {%- if s.photo %}<img src="{{ s.photo }}" alt="" loading="lazy" width="48" height="48">


### PR DESCRIPTION
**Regression fix.** #971 made every Anthology author addressable via `id="person-<slug>"` on all by-person entries. #974 (the chip polish) was branched off a stale master predating #971, so its squash-merge reverted line 63 back to the board-only conditional anchor.

**Impact (live):** `/data/authors-index.json` (consumed by NetSec for the reverse profile→Anthology link) and the board "their conference papers" links still emit `?person=<slug>` urls for all 492 authors, but only the ~26 board members had a matching anchor — the other ~466 `?person=` deep links 404-scrolled to the top of the list.

**Fix:** restore `id="person-{{ s.slug }}"` on every entry. `corpus.slug` and `authorsIndex.js` were untouched by the revert, so this one line fully restores it.

**Verified:** 492/492 entries carry an anchor; every `authors-index.json` url resolves to one; i18n drift green.

No visible change (just `id` attributes + deep-link resolution restored), so auto-merge armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)