### PR TITLE
CSS namespacing convention (#241 option 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -623,6 +623,36 @@ on-request**:
   dumped DOM file instead; `--force-prefers-reduced-motion=reduce` and
   computed-style reads are the dependable parts.)
 
+## 15. CSS namespacing: one prefix per component
+
+`site.css` is a single global stylesheet with no scoping, so two
+unrelated components can quietly fight over the same class name. The
+last selector in the file wins the cascade, so a later component that
+reuses an earlier one's class silently rewrites it. This shipped once:
+the `/2021` archive programme list redefined `.programme-slot` /
+`.programme-day`, the names the live `/2026` grid (`programme-grid.njk`)
+already owned, and broke the live grid in production (#231 → fixed in
+#239). The build was green throughout, because the §14 sanity guard
+catches a class used in markup but **undefined** in CSS, not a class
+**defined twice** by different components.
+
+So: **each component owns a unique class prefix, and never reuses
+another component's prefix.** The live programme grid reserves
+`programme-*`; the archive list uses `archive-programme-*`; the
+by-person view uses `speaker-*`; and so on. When adding a component,
+pick a fresh prefix and confirm it isn't already claimed
+(`grep -n '\.your-prefix' src/assets/css/site.css`) before defining it.
+Reuse another component's base class only when you genuinely mean to
+extend that component, not by accident.
+
+The enforcement half (a duplicate-definition CI lint) is the harder
+piece and is deferred: `stylelint`'s `no-duplicate-selectors` flags
+every intentional repeat (dark-mode + responsive overrides), and a
+custom check needs reliable component-block attribution to tell a
+collision from a variant (a naïve "same base class defined twice" pass
+flags ~100 legitimate cases). Tracked in #241; the convention above is
+the guard until it lands.
+
 ---
 
 *This file is short on purpose. If you need to add a rule, add it

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -1,3 +1,13 @@
+/* ==========================================================================
+   CSS namespacing convention (CLAUDE.md §15)
+   This is one global, unscoped stylesheet, so the last selector wins. To stop
+   two components silently fighting over a class name (the #231 -> #239
+   `.programme-slot` collision), EACH COMPONENT OWNS A UNIQUE CLASS PREFIX and
+   never reuses another's: the live grid reserves `programme-*`, the archive
+   list `archive-programme-*`, the by-person view `speaker-*`, etc. Before
+   adding a component, grep this file for the prefix to confirm it's free.
+   ========================================================================== */
+
 /* ---------- self-hosted Inter (variable) ----------
    Served from our own origin instead of Google Fonts, so no visitor IP
    is sent to a third party on first paint. Matches the site's no-tracking


### PR DESCRIPTION
Implements option 1 of [#241](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/241): a convention to prevent the class-name collisions that bit us in #231 → #239 (the `/2021` archive list redefined `.programme-slot`, which the live `/2026` grid owns, and broke the live grid in production while CI stayed green).

- **CLAUDE.md §15** — "one prefix per component, never reuse another's", with the grep-before-you-define habit and the reasoning (the §14 sanity guard catches *undefined* classes, not *duplicate-defined* ones).
- **`site.css` header note** — the same convention at the top of the file where it's seen on every edit.

## On the lint (option 2)
Deferred, with a reason rather than a half-baked gate: I prototyped a "same base class defined twice" detector and it flagged **~105 classes on the current stylesheet** — almost all legitimate dark-mode/responsive/variant/print repeats. `stylelint`'s `no-duplicate-selectors` has the same noise problem. A precise lint needs reliable component-block attribution to tell a real collision from a variant, which is its own project. Shipping a lint that flags 105 false positives would just block CI. Kept #241 open for it; the convention is the guard until it lands.

Docs/convention only, no site output — auto-merge armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)