### PR TITLE
ci(links): skip www.hugomeijer.com (flaky HTTP 429)

### DIFF
--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -194,6 +194,14 @@ SKIP_HOSTS = {
                                 # anonymous HEAD/GET, same academic-publisher
                                 # anti-bot class as doi.org / shs.cairn.info.
                                 # The journal page opens fine in a browser.
+    "www.hugomeijer.com",       # Founding-and-Honorary-Director Hugo Meijer's
+                                # personal site, linked from his board profile
+                                # (`/board/...` + FR/DE). Returns HTTP 429
+                                # (rate-limited) to the checker under automated
+                                # load while loading fine for visitors. Same
+                                # recurring-flake class as the academic hosts
+                                # above; flaked PR #1007's link-check. Skipping
+                                # stops the false-red on every src-touching PR.
 }
 
 # Domains skipped together with ALL their subdomains. SKIP_HOSTS matches an


### PR DESCRIPTION
`https://www.hugomeijer.com/` (Hugo Meijer's personal site, linked from his board profile) returns **HTTP 429** to the link checker under automated load while loading fine for visitors. It flaked [#1007](https://github.com/EISSeuropa/EISSeuropa.github.io/pull/1007)'s link-check (cleared on re-run) and will keep flaking every src-touching PR, since the checker builds the whole `_site`.

Same recurring-flake class as the academic hosts already in `SKIP_HOSTS` (tandfonline 403, cnil/etsi 5xx/timeouts). One-line addition with a comment matching the established style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)