### PR TITLE
fix(publications): per-member headshots + correct year counts

### DIFF
--- a/src/_includes/publications-body.njk
+++ b/src/_includes/publications-body.njk
@@ -12,6 +12,21 @@
 {%- set t = i18n[lang or "en"] -%}
 {%- set o = t.outputs -%}
 
+{# Member headshot by slug, same bubble as the Anthology by-person view. An
+   explicit loop, NOT `selectattr("slug","equalto",…)` — that test silently
+   matches nothing here and `| first` then returns the wrong (first) person.
+   Renders the photo if known, else initials; the _hit guard keeps it to the
+   first match. #}
+{%- macro headshot(slug) -%}
+<span class="speaker-headshot" aria-hidden="true">
+{%- set _hit = [] -%}
+{%- for p in peopleIndex.people -%}
+{%- if p.slug == slug and not _hit.length -%}{%- set _ = _hit.push(1) -%}{%- if p.photo %}<img src="{{ p.photo }}" alt="" loading="lazy" width="48" height="48">{% else %}<span class="speaker-headshot-ph">{{ p.initials }}</span>{% endif -%}{%- endif -%}
+{%- endfor -%}
+{%- if not _hit.length %}<span class="speaker-headshot-ph"></span>{% endif -%}
+</span>
+{%- endmacro -%}
+
 {# Flatten for the counts + year facet (Nunjucks set doesn't leak out of a for
    loop, so accumulate by pushing onto arrays whose reference we mutate). #}
 {%- set _allWorks = [] -%}
@@ -45,7 +60,8 @@
         <select id="pub-year" data-pub-year>
           <option value="">{{ o.filterAllYears }} ({{ _allWorks.length }})</option>
           {%- for y in (_years | sort(true)) %}
-          <option value="{{ y }}">{{ y }} ({{ _allWorks | selectattr("year", "equalto", y) | list | length }})</option>
+          {%- set _yc = [] -%}{%- for w in _allWorks -%}{%- if w.year == y -%}{%- set _ = _yc.push(1) -%}{%- endif -%}{%- endfor -%}
+          <option value="{{ y }}">{{ y }} ({{ _yc.length }})</option>
           {%- endfor %}
         </select>
       </div>
@@ -63,13 +79,9 @@
     <div class="member-pubs" data-pub-list>
       {%- for m in orcidWorks %}
       {%- if m.works.length %}
-      {%- set _p = peopleIndex.people | selectattr("slug", "equalto", m.slug) | first %}
       <section class="member-pub-group" data-pub-group data-member="{{ m.slug }}">
         <div class="member-pub-head">
-          <span class="speaker-headshot" aria-hidden="true">
-            {%- if _p and _p.photo %}<img src="{{ _p.photo }}" alt="" loading="lazy" width="48" height="48">
-            {%- else %}<span class="speaker-headshot-ph">{{ _p.initials if _p else "" }}</span>{% endif %}
-          </span>
+          {{ headshot(m.slug) }}
           <h2 class="member-pub-name"><a href="/board/{{ m.slug }}.html" lang="en">{{ m.name }}</a></h2>
         </div>
         <ul class="member-works" role="list">


### PR DESCRIPTION
Fixes the two bugs reported on the now-merged #1025. Both came from one cause: **`selectattr(attr, "equalto", value)` silently matches nothing in this Nunjucks and returns the whole list.**

- **Headshots were all Hugo Meijer's.** The lookup `peopleIndex.people | selectattr("slug","equalto",m.slug) | first` returned the *first* person in the index (Meijer, the Founding Director) for every member. Replaced with an explicit slug-matching loop (a macro).
- **Every year dropdown option read "(67)".** The count `_allWorks | selectattr("year","equalto",y) | list | length` returned the full total for every year. Replaced with an explicit per-year count loop.

## Verification
- 16 headshots, **16 distinct** (each member's own photo).
- Year options now read **2025 (19), 2024 (11), 2023 (10) … 2015 (1)**, summing to 67; selecting 2021 narrows the list to 4, 2025 to 19, Clear resets.
- build + build-sanity + i18n drift + link checker all green.

(The live filtering itself always worked — the visible "always 67" was the dropdown *labels*.)

Branched off fresh `master` (after #1025 merged). The fix had briefly orphaned when I pushed to the already-merged #1025 branch; this re-lands it cleanly.