### PR TITLE
docs(roadmap): mark v2.26.0 shipped (card + history)

### DIFF
--- a/docs/roadmap-2026.md
+++ b/docs/roadmap-2026.md
@@ -50,7 +50,7 @@ other way round, so this is where a new release first appears.
 | --- | --- | --- | --- |
 | v2.24.0 | 30 May 2026 | **Shipped** | Live programme depth and a print overhaul |
 | v2.25.0 | 9 Jun 2026 | **Shipped** | Ready for Stockholm (pre-conference release) |
-| v2.26.0 | Late Jun 2026 | Planned | Post-conference: activation, content & feedback |
+| v2.26.0 | 25 Jun 2026 | **Shipped** | Introducing the Anthology |
 | v2.27.0 | Sep 2026 | Planned | Polish and ESSC 2027 prep |
 
 (`v2.24.1` was planned as a pre-ESSC patch but the work grew into a feature-rich minor, so it shipped as the **v2.25.0** *Ready for Stockholm* release instead; the `v2.24.1` milestone is closed as superseded.)
@@ -88,49 +88,21 @@ drops. Sequence: legal pages first (highest accuracy bar), then
 rest. Per [`docs/i18n.md`](i18n.md). Each reviewed page can ship in
 any patch.
 
-### v2.26.0 — Post-conference: activation, content and feedback · target late June 2026
+### v2.26.0 — Introducing the Anthology · shipped 25 June 2026
 
-The first release after ESSC 2026. It turns conference-week feedback
-into fixes and builds out the public-content surfaces (a news feed, an
-outputs list, the working groups). The polish and brand-card work that
-the old v2.25.0 plan held moved to v2.27.0, and the Indico-data and
-NetSec-coordination items moved to *Under watch*, so this release stays
-focused. (The Node-24 Actions pin the plan once tracked was resolved
-early by Dependabot, closing #76.) The full, current list
-lives on the
-[v2.26.0 milestone](https://github.com/EISSeuropa/EISSeuropa.github.io/milestone/9);
-the headline items:
-
-- **Speaker index across every edition** — a surname-ordered,
-  theme-filterable directory of everyone who has presented at an ESSC,
-  on the new `corpus.js` spine, with summary cards and a locale-aware
-  link-card signpost from the sitemap, the conference programmes and the
-  People page. In EN + FR + DE (interface hand-translated, names and
-  themes stay original). Built early (originally a v2.27.0 item) and
-  already in `[Unreleased]`, so it ships with this release.
-  [#635](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/635), done.
-- **Conference-week QA pass** — work the ESSC 2026 feedback checklist
-  on production and fix what it surfaces.
-  [#655](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/655), M.
-- **News / Latest on the homepage** — a surface for Action news and
-  cross-links to NetSec items relevant to EISS members.
-  [#96](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/96), M.
-- **Atom / RSS feed** — a machine-readable feed alongside the News
-  surface.
-  [#605](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/605), S.
-- **Issue-driven news publishing** — label an issue and have it
-  auto-PR a news post, so an update doesn't need a hand-built page.
-  [#634](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/634), M.
-- **Outputs / Publications page** — list the network's outputs (book
-  series, policy briefs, white papers, survey results, the European
-  Security Studies Prize) on a dedicated page.
-  [#97](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/97), M.
-- **Working Groups page** — render each group's objective and people.
-  The NetSec sister site ships its own, this mirrors it for EISS.
-  [#94](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/94), M.
-- **`/initiative` founding nuance** — reconcile the founding story,
-  the conference numbering and the deferred-2020 edition.
-  [#329](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/329), M.
+Shipped as [v2.26.0 — Introducing the Anthology](https://github.com/EISSeuropa/EISSeuropa.github.io/releases/tag/v2.26.0)
+on 25 June 2026. The European Security Studies Anthology became the
+site's flagship at `/anthology`, the unified home for every paper and
+every scholar across nine editions, carried in the main navigation and
+linked out to the NetSec member directory. Members' own published
+research gained a dedicated `/publications` page, a `/prizes` page
+landed for the European Security Studies Prize, and a round of polish
+ran through the navigation, the share cards, the Initiative page and the
+board. The post-conference content surfaces that did not make this cut
+(the Working Groups page [#94](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/94),
+the RSS feed [#605](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/605),
+issue-driven news publishing [#634](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/634))
+moved on to later milestones. See [`CHANGELOG.md`](../CHANGELOG.md) for the full index of changes.
 
 ### v2.27.0 — Polish and ESSC 2027 prep · target September 2026
 

--- a/src/_data/roadmap.js
+++ b/src/_data/roadmap.js
@@ -33,7 +33,7 @@ const roadmap = {
   issuesUrl: `${REPO}/issues/new/choose`,
   milestonesUrl: `${REPO}/milestones`,
   releasesUrl: `${REPO}/releases`,
-  updated: { en: "9 June 2026", fr: "9 juin 2026", de: "9. Juni 2026" },
+  updated: { en: "25 June 2026", fr: "25 juin 2026", de: "25. Juni 2026" },
 
   quarters: [
     {
@@ -145,19 +145,19 @@ const roadmap = {
           },
         },
         {
-          status: "planned",
+          status: "shipped",
           version: "v2.26.0",
-          milestone: "v2.26.0",
-          when: { en: "Late June 2026 · v2.26.0", fr: "fin juin 2026 · v2.26.0", de: "Ende Juni 2026 · v2.26.0" },
+          notesUrl: notes("v2.26.0"),
+          when: { en: "25 June 2026 · v2.26.0", fr: "25 juin 2026 · v2.26.0", de: "25. Juni 2026 · v2.26.0" },
           title: {
-            en: "Post-conference: activation, content and feedback",
-            fr: "Après la conférence : activation, contenus et retours",
-            de: "Nach der Konferenz: Aktivierung, Inhalte und Feedback",
+            en: "Introducing the Anthology",
+            fr: "L’Anthologie, désormais publique",
+            de: "Die Anthologie wird vorgestellt",
           },
           desc: {
-            en: "The first release after ESSC 2026, folding in feedback from the conference: new public surfaces (a News surface, an Outputs / Publications page, a Working Groups page, a NetSec co-branding strip), the live programme grid on past conferences with calendar links, and the reliability and accessibility follow-ups carried over from the pre-conference push.",
-            fr: "La première version après l’ESSC 2026, intégrant les retours de la conférence : de nouvelles pages publiques (un espace Actualités, une page Publications, une page Groupes de travail, un bandeau de co-marquage NetSec), la grille du programme en direct sur les conférences passées avec liens calendrier, et les suites de fiabilité et d’accessibilité reportées depuis la préparation d’avant-conférence.",
-            de: "Die erste Version nach der ESSC 2026, die das Feedback der Konferenz aufnimmt: neue öffentliche Seiten (ein Aktuelles-Bereich, eine Publikationen-Seite, eine Arbeitsgruppen-Seite, ein NetSec-Co-Branding-Streifen), das Live-Programmraster auf vergangenen Konferenzen mit Kalenderlinks sowie die Zuverlässigkeits- und Barrierefreiheits-Folgearbeiten aus der Vorbereitung vor der Konferenz.",
+            en: "The European Security Studies Anthology becomes the site's flagship at /anthology, the single home for every paper and every scholar across nine editions, carried in the main navigation and linked out to the NetSec member directory. Members' own published research gains its own page at /publications, and a round of polish runs through the navigation, the share cards, the Initiative page and the board.",
+            fr: "L’Anthologie des études de sécurité européennes devient la vitrine du site à l’adresse /anthology, le point d’accès unique à chaque communication et à chaque chercheur des neuf éditions, intégrée à la navigation principale et reliée à l’annuaire des membres de NetSec. Les publications propres de nos membres disposent désormais de leur page à l’adresse /publications, et une série de finitions touche la navigation, les cartes de partage, la page de l’Initiative et le conseil.",
+            de: "Die Anthologie der Europäischen Sicherheitsstudien wird zum Aushängeschild der Website unter /anthology, dem zentralen Zugang zu jedem Beitrag und jeder Forschenden aus neun Ausgaben, in die Hauptnavigation aufgenommen und mit dem NetSec-Mitgliederverzeichnis verknüpft. Die eigenen Veröffentlichungen unserer Mitglieder erhalten nun eine eigene Seite unter /publications, und eine Reihe von Feinarbeiten betrifft die Navigation, die Sharing-Karten, die Initiative-Seite und den Vorstand.",
           },
         },
       ],


### PR DESCRIPTION
Post-release §5.1 housekeeping for **[v2.26.0 — Introducing The Anthology](https://github.com/EISSeuropa/EISSeuropa.github.io/releases/tag/v2.26.0)**, cut earlier today.

## What changed

- **Public roadmap card (`src/_data/roadmap.js`, EN + FR + DE).** The v2.26.0 card flips from *Planned* to *Shipped*: `status: "shipped"`, ship date `25 June 2026`, `notesUrl` to the release, and the `milestone` key dropped (so it stops rendering a progress bar, and `roadmap-progress.js` auto-promotes v2.27.0 to *In progress*). The placeholder headline and blurb ("Post-conference: activation, content and feedback") are replaced with the actual release, *Introducing the Anthology*, hand-translated into FR + DE (no machine translation, §1). The "last updated" stamp moves to 25 June 2026.
- **`docs/roadmap-2026.md`.** *At a glance* row flipped to **Shipped** with the real title, and the planning section replaced by a short shipped summary linking the release notes. The post-conference surfaces that did not make this cut (Working Groups #94, RSS #605, issue-driven news #634) are noted as moved on.

## Verified

- `node --check` + a load assertion: the v2.26.0 entry is `shipped`, carries the `notesUrl`, and no longer has a `milestone` key.
- Local Eleventy build (639 files, clean): `/roadmap`, `/roadmap.fr`, `/roadmap.de` each render the new card title, the EN page carries the release-notes link, and the stale "Post-conference" headline is gone.
- §5.3 i18n drift check ran clean at release time.

## Review note (no auto-merge)

Visual change to the public `/roadmap` page, so per the §2 carve-out this is **not** armed for auto-merge. Please eyeball the deploy preview's roadmap card (the v2.26.0 card should read *Introducing the Anthology*, dated, marked Shipped, with a "release notes" link and no progress bar) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)