### PR TITLE
ci(publications): run matcher weekly and tag PRs that need a review call

### DIFF
--- a/.github/workflows/sync-publications.yml
+++ b/.github/workflows/sync-publications.yml
@@ -1,4 +1,4 @@
-# Monthly publication-match refresh.
+# Weekly publication-match refresh.
 #
 # What this does
 #   - scripts/match-publications.mjs --all proposes, for each ESSC paper
@@ -20,18 +20,21 @@
 #   - REVIEW band (0.50–0.79) → left in data/publication-candidates.json for
 #     a human to accept (`confirm-publication.mjs <slug>`) or reject
 #     (`--reject <slug>`). Auto-merging the PR does NOT publish these — they
-#     are just queue data until confirmed.
+#     are just queue data until confirmed. When the run leaves any in the
+#     queue, the PR is tagged `needs-review` so the approval call is visible.
 #
-# Monthly (not weekly): published versions appear slowly, and the full
-# OpenAlex sweep is a few hundred polite API calls. The matcher skips
-# papers that already have a confirmed link or a recorded reject, so both
-# the published set grows and the queue shrinks as matches are reviewed.
+# Weekly (Mondays): a paper's published version can appear any week and a
+# title can drift enough on the way to print to land in the review band
+# (the Berthelsen 2025 case), so a monthly sweep left new matches stranded
+# for weeks. The matcher skips papers that already have a confirmed link or
+# a recorded reject, so the OpenAlex sweep stays a few hundred polite API
+# calls and the queue shrinks as matches are reviewed.
 
 name: Sync publication matches
 
 on:
   schedule:
-    - cron: '0 7 1 * *' # 07:00 UTC on the 1st of each month
+    - cron: '0 7 * * 1' # 07:00 UTC every Monday
   workflow_dispatch:
   push:
     branches: [master]
@@ -68,14 +71,19 @@ jobs:
         run: npm ci --no-audit --no-fund
 
       - name: Match, then auto-confirm the high-confidence tier
+        id: match
         run: |
           set -o pipefail
           node scripts/match-publications.mjs --all | tee /tmp/match.txt
           node scripts/confirm-publication.mjs --auto-high | tee /tmp/auto.txt
           node scripts/enrich-publications.mjs | tee /tmp/enrich.txt
           node scripts/publication-review-md.mjs > /tmp/review.md
+          # Count the review-band candidates left for a human call, so the PR
+          # step can tag `needs-review` when approval is necessary.
+          review_count=$(node -e 'const fs=require("node:fs");const p="data/publication-candidates.json";const a=fs.existsSync(p)?JSON.parse(fs.readFileSync(p,"utf8")):[];console.log(a.filter(x=>x.band==="review").length)')
+          echo "review_count=$review_count" >> "$GITHUB_OUTPUT"
           {
-            echo "Monthly publication-match sync. **Two parts:**"
+            echo "Weekly publication-match sync. **Two parts:**"
             echo ""
             echo "## ✅ Auto-confirmed — now live"
             echo ""
@@ -125,6 +133,18 @@ jobs:
           labels: |
             automated
             data-sync
+
+      # Tag the PR for a human call when the run left review-band candidates
+      # in the queue. The auto-confirmed matches still merge below; the label
+      # is the signal that an accept/reject decision is waiting (the band is
+      # listed under "👀 To review" in the PR body).
+      - name: Tag needs-review when approval is pending
+        if: steps.create-pr.outputs.pull-request-number && steps.match.outputs.review_count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit "${{ steps.create-pr.outputs.pull-request-number }}" \
+            --repo "${{ github.repository }}" --add-label needs-review
 
       # Auto-merge: publishes the auto-confirmed (high-confidence) matches and
       # refreshes the queue. CodeQL + build + build-sanity + link-check still

--- a/docs/publication-matching.md
+++ b/docs/publication-matching.md
@@ -86,7 +86,7 @@ to surface it.
 A match you have checked and decided is **wrong** should be rejected, not
 just left alone: `--reject` records the (paper, doi) pair in
 `data/publication-rejects.json`, and the matcher skips it from then on, so
-a validated non-match does not keep coming back in the monthly queue.
+a validated non-match does not keep coming back in the weekly queue.
 Rejection is per pair, not per paper, so a genuinely better match for the
 same paper can still surface later. (A match you simply have not looked at
 yet just stays in the queue.)
@@ -140,13 +140,15 @@ is a prompt to look, not a verdict.
 ## The scheduled refresh
 
 [`.github/workflows/sync-publications.yml`](../.github/workflows/sync-publications.yml)
-runs monthly (and on manual dispatch): it runs the matcher, auto-confirms
-the high band (`--auto-high`), and opens a PR on `publications-sync/auto`
-that it **auto-merges**, so the high-confidence matches go live and the
-queue is refreshed. The PR body lists the auto-confirmed matches for
-information and the review band for a human decision. Auto-merging does
-**not** publish the review band — those stay queue data until confirmed by
-hand.
+runs weekly on Mondays (and on manual dispatch): it runs the matcher,
+auto-confirms the high band (`--auto-high`), and opens a PR on
+`publications-sync/auto` that it **auto-merges**, so the high-confidence
+matches go live and the queue is refreshed. The PR body lists the
+auto-confirmed matches for information and the review band for a human
+decision. When the run leaves any review-band candidates in the queue, the
+PR is tagged `needs-review` so the pending accept/reject call is visible at
+a glance. Auto-merging does **not** publish the review band — those stay
+queue data until confirmed by hand.
 
 ## Known limitation: renamed-title publications need a manual add
 

--- a/scripts/publication-review-md.mjs
+++ b/scripts/publication-review-md.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Render the publication-match review band (data/publication-candidates.json)
- * as a readable Markdown table for the monthly sync PR body
+ * as a readable Markdown table for the weekly sync PR body
  * (sync-publications.yml). The high-confidence matches are auto-confirmed
  * before this runs, so the queue here is the review band — the part a human
  * actually decides. Prints to stdout.
@@ -18,7 +18,7 @@ const all = existsSync(QUEUE) ? JSON.parse(readFileSync(QUEUE, "utf8")) : [];
 const review = all.filter((x) => x.band === "review").sort((a, b) => b.titleScore - a.titleScore);
 
 if (!review.length) {
-  console.log("**Nothing to review this month** — no mid-confidence candidates in the queue.");
+  console.log("**Nothing to review this week** — no mid-confidence candidates in the queue.");
   process.exit(0);
 }
 
@@ -41,5 +41,5 @@ for (const x of review) {
   out.push(`| ${x.titleScore.toFixed(2)} | ${paper} | ${pub} | \`${x.slug}\` |`);
 }
 out.push("");
-out.push("_Anything you don't act on stays in the queue for next month._");
+out.push("_Anything you don't act on stays in the queue for next week._");
 console.log(out.join("\n"));


### PR DESCRIPTION
## What

Two changes to the publication matcher's automation:

1. **Weekly, not monthly.** `sync-publications.yml` now runs Mondays 07:00 UTC (was the 1st of each month). A paper's published version can land any week, and a title can drift enough on the way to print to fall into the review band — the [Berthelsen 2025 case](https://github.com/EISSeuropa/EISSeuropa.github.io/pull/1064) — so the monthly sweep was leaving new matches stranded for weeks.
2. **Tag when a decision is pending.** When a run leaves any review-band (0.50–0.79) candidates in the queue, the auto PR is tagged `needs-review`, so the pending accept/reject call is visible at a glance rather than buried in the PR body. The high-confidence band still auto-confirms and auto-merges as before; the label only flags the human follow-up.

## How

- Cron `0 7 1 * *` → `0 7 * * 1`; header comment + rationale updated.
- The match step emits a `review_count` output (counts `band: "review"` entries in `data/publication-candidates.json`).
- A new step runs `gh pr edit --add-label needs-review`, gated on `review_count != '0'` and a PR having been created.
- New `needs-review` label created in the repo (colour `#fbca04`, "A maintainer accept/reject decision is pending").
- monthly→weekly copy refreshed in `scripts/publication-review-md.mjs` and `docs/publication-matching.md` (§11 inline doc update).

## Verified

- `scripts/publication-review-md.mjs` runs; the `review_count` one-liner returns `0` against the current empty queue.
- Workflow YAML parses.

Internal CI tooling, so no `[Unreleased]` bullet (§4 exemption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)