### PR TITLE
fix(sync-indico): detect whole-year removals from annualConferences

### DIFF
--- a/scripts/sync-indico.py
+++ b/scripts/sync-indico.py
@@ -831,6 +831,19 @@ def summarise_changes(old: dict, new: dict) -> tuple[bool, str, str]:
 
     # Annual conferences (the ESSC programme grids).
     oac, nac = old.get("annualConferences", {}), new.get("annualConferences", {})
+
+    # A year can disappear entirely (its event fell out of the from=today..to
+    # export window once the conference is over). The per-year loop below only
+    # walks nac.keys(), so a wholesale removal would otherwise never surface —
+    # this bit for three weeks after ESSC26 ended, see #1085.
+    dropped = sorted(oac.keys() - nac.keys())
+    if dropped:
+        counter += len(dropped)
+        sections.append(
+            "### Annual conferences no longer in the live window\n"
+            + "\n".join(f"- **− ESSC {year}** (event over, fell out of the export window)" for year in dropped)
+        )
+
     for year in sorted(nac.keys()):
         o, n = oac.get(year, {}), nac[year]
         sec: list[str] = []


### PR DESCRIPTION
## Summary
- `summarise_changes()` in `scripts/sync-indico.py` only iterated `nac.keys()` (the new snapshot's years), so a year that fell out of the export window entirely (its conference ended, its dates now before `from=today`) was never flagged as a change. The daily sync classified this as "timestamp only" every day for three weeks after ESSC26 ended, so no PR ever opened to drop the stale entry — root cause of the Anthology attach gap fixed in #1086.
- Now also diffs `oac.keys() - nac.keys()` and reports each dropped year, matching how the existing per-year session/paper diffing already handles additions and removals within a year.

Closes #1085.

## Test plan
- [x] Verified via ad hoc `summarise_changes()` calls: a year present in old but absent in new is now reported as substantive and named in the PR body
- [x] Verified the no-op case (identical old/new) still reports non-substantive, so quiet days still skip the PR
- [x] `python3 -m py_compile scripts/sync-indico.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)