### PR TITLE
docs: catch up architecture.md + design-system.md after #241 and #756

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,7 +102,7 @@ so supersession is normal). Pure `gh` CLI, no third-party actions
 | `link-check.yml` → `check-links.sh` | Every internal/external link + `#fragment` in `_site/` resolves. |
 | `i18n-drift.yml` → `check-i18n-drift.py` | Every FR/DE page matches its EN source hash (`data/i18n-state.json`). |
 | `i18n-drift.yml` → `check-i18n-keys.js` | EN/FR/DE chrome catalogs have identical key sets. |
-| `sanity-check.yml` → `check-build-sanity.mjs` | No duplicate `_data` object keys, no empty/junk `href`/`src`, no scheme-less `board.json` links, and no markup class left undefined in `site.css` (§14 unstyled-feature guard). |
+| `sanity-check.yml` → `check-build-sanity.mjs` | No duplicate `_data` object keys, no empty/junk `href`/`src`, no scheme-less `board.json` links, no markup class left undefined in `site.css` (§14 unstyled-feature guard), and no class styled bare as the selector subject in two different `site.css` sections (§15 cross-block collision guard, CLAUDE.md issue #241). |
 | `sanity-check.yml` → `a11y_lint.py` | No accessibility findings (missing landmarks / alt / labels, heading-hierarchy gaps, duplicate IDs, accessible-name absence). |
 | CodeQL | Static analysis. |
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -72,6 +72,11 @@ know what exists and where to look before building something new.
   placeholder, role + optional functional-responsibility pill + ESSC-mic,
   affiliation, Read-more bio, themes, social-icon row. `.person`, `.person-*`.
 - **`netsec-leaders.njk`** — EISS people in NetSec roles, on `/initiative`.
+- **`board-profile.njk`** + **`board-profile-body.njk`** — one page per board/community
+  member at `/board/<slug>.html`, paginated from `board.json`. Bio, role, affiliation,
+  their ESSC papers (via `corpus.speakerByProfileUrl`), ORCID works, external links.
+  Emits a `Person` JSON-LD block (name, jobTitle, affiliation, image, `sameAs` identity
+  links, `memberOf` the EISS `Organization`) for search-engine indexing.
 
 ## Media
 


### PR DESCRIPTION
## Summary
- `docs/architecture.md`'s CI gates table understated what `check-build-sanity.mjs` checks: adds the cross-block CSS collision guard shipped in #1090 (#241).
- `docs/design-system.md`'s People section never documented the per-person `/board/<slug>.html` profile pages or their new `Person` JSON-LD, shipped in #763 and #1094 (#756).

Both are internal maintainer docs, not user-visible copy, so this is CHANGELOG-exempt per CLAUDE.md §4.

## Test plan
- [x] Read-only prose edits, no template/script changes, nothing to build or preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)