### PR TITLE
feat(publications): add LLM judge for the review band (#805 Phase 3)

### DIFF
--- a/.github/workflows/sync-publications.yml
+++ b/.github/workflows/sync-publications.yml
@@ -9,6 +9,10 @@
 #   - scripts/confirm-publication.mjs --auto-high then records the
 #     HIGH-confidence matches (title ≥ 0.80, near-verbatim) into
 #     src/_data/paperLinks.json automatically, and drops them from the queue.
+#   - scripts/judge-publications.mjs (Phase 3, #805) adds an advisory LLM
+#     verdict to each review-band candidate, when the ANTHROPIC_API_KEY
+#     secret is set. It never writes paperLinks.json — a no-op until the
+#     secret is configured. See docs/publication-matching.md.
 #   - Opens a PR on `publications-sync/auto` and auto-merges it, so the
 #     auto-confirmed matches go live and the queue is refreshed.
 #
@@ -72,11 +76,14 @@ jobs:
 
       - name: Match, then auto-confirm the high-confidence tier
         id: match
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           set -o pipefail
           node scripts/match-publications.mjs --all | tee /tmp/match.txt
           node scripts/confirm-publication.mjs --auto-high | tee /tmp/auto.txt
           node scripts/enrich-publications.mjs | tee /tmp/enrich.txt
+          node scripts/judge-publications.mjs | tee /tmp/judge.txt
           node scripts/publication-review-md.mjs > /tmp/review.md
           # Count the review-band candidates left for a human call, so the PR
           # step can tag `needs-review` when approval is necessary.
@@ -96,6 +103,10 @@ jobs:
             grep -iE 'auto-confirmed' /tmp/auto.txt || echo "_(none this run)_"
             echo ""
             echo "## 👀 To review"
+            echo ""
+            echo "Each row carries an advisory LLM verdict when the ANTHROPIC_API_KEY secret"
+            echo "is configured (skipped otherwise — see docs/publication-matching.md). The"
+            echo "verdict is a pre-assessment only; you still decide accept/reject."
             echo ""
             cat /tmp/review.md
             echo ""

--- a/docs/publication-matching.md
+++ b/docs/publication-matching.md
@@ -110,12 +110,47 @@ it is handled:
   may be inaccurate. Shown to the maintainer for information, who can reject
   any. (Auto-confirmed entries carry `"auto": true` in `paperLinks.json`.)
 - **Review (0.50–0.79)** — titles that drifted on publication. Left in the
-  queue for a human accept/reject. An LLM judge to pre-assess these is a
-  possible later addition (kept off for now).
+  queue for a human accept/reject. An optional LLM judge (Phase 3, below)
+  can annotate these with an advisory verdict.
 
 The threshold is the maintainer's chosen policy: high enough that the
 auto-published set is near-exact, low enough that genuine same-title
 publications are not held up.
+
+## LLM judge (Phase 3): `scripts/judge-publications.mjs`
+
+An optional pre-assessment of the review band, so a human reviewer sees a
+verdict and a one-line rationale alongside each row instead of judging every
+candidate cold. It annotates each review-band candidate with an
+`llmVerdict` (`same_work`, `different_work`, or `uncertain`) plus a
+rationale, weighing author identity, topical overlap, retitle plausibility,
+and the publication-lag window. It looks up the conference abstract when one
+is on file, and always asks the model to answer `uncertain` rather than
+guess.
+
+**Advisory only.** The judge never writes `src/_data/paperLinks.json` and
+never changes a candidate's `band`. `confirm-publication.mjs` stays the only
+path to a confirmed match, and the auto-high tier is untouched. Judge each
+row on the merits, the same way as before, the verdict is a second opinion,
+not a decision.
+
+Gated on a secret:
+
+```bash
+node scripts/judge-publications.mjs
+```
+
+- Requires the `ANTHROPIC_API_KEY` repository secret. **Without it, the step
+  is a silent no-op** (prints one line, exits 0) — the monthly sync keeps
+  running clean either way.
+- Optional `PUBLICATION_JUDGE_MODEL` env var overrides the model (default
+  `claude-opus-4-8`).
+- Idempotent: re-runs skip any candidate that already carries an
+  `llmVerdict`, so it is safe to run more than once against the same queue.
+
+`sync-publications.yml` runs the judge between the matcher and the
+review-PR body composer; `publication-review-md.mjs` renders the verdict
+in the review table when one is present.
 
 ## Sanity-checking a match against the published abstract
 
@@ -181,5 +216,4 @@ of Strategic Studies* (often retitled).
   Form (see [board-bios-setup.md](board-bios-setup.md)).
 - Minting our own DOIs for ESSC papers is a separate, heavier option
   ([#795](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/795)).
-- An optional LLM judge for the ambiguous (review) band is a possible
-  later refinement, noted in #805.
+- The LLM judge (Phase 3, above) shipped in [#805](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/805).

--- a/scripts/judge-publications.mjs
+++ b/scripts/judge-publications.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * #805 Phase 3 — an LLM pre-assessment of the review band, so a human still
+ * confirms every match but sees a verdict + rationale alongside each row.
+ * Advisory only: it never writes src/_data/paperLinks.json and never changes
+ * a candidate's band. confirm-publication.mjs stays the only path to
+ * paperLinks.json; the auto-high tier is untouched.
+ *
+ * Reads data/publication-candidates.json, selects review-band candidates
+ * that don't already carry an llmVerdict (so re-runs are idempotent), and
+ * asks Claude whether the candidate is the later-published version of the
+ * conference paper. Each verdict is written back onto its candidate as:
+ *   llmVerdict: { verdict, rationale, model, judgedOn }
+ *
+ * Self-gating: with no ANTHROPIC_API_KEY (or ANTHROPIC_AUTH_TOKEN) set, this
+ * is a no-op (exit 0) so the scheduled workflow runs clean before the
+ * maintainer adds the secret.
+ *
+ * Usage:  node scripts/judge-publications.mjs
+ * Env:    ANTHROPIC_API_KEY (required to run, unless ANTHROPIC_AUTH_TOKEN is set)
+ *         ANTHROPIC_AUTH_TOKEN (alternative: an OAuth bearer token, e.g. from
+ *           `ant auth print-credentials --access-token`; sent as
+ *           `Authorization: Bearer` + `anthropic-beta: oauth-2025-04-20`
+ *           instead of `x-api-key`)
+ *         PUBLICATION_JUDGE_MODEL (optional, default claude-opus-4-8)
+ */
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const CANDIDATES = join(ROOT, "data", "publication-candidates.json");
+const MODEL = process.env.PUBLICATION_JUDGE_MODEL || "claude-opus-4-8";
+const API_KEY = process.env.ANTHROPIC_API_KEY;
+const AUTH_TOKEN = process.env.ANTHROPIC_AUTH_TOKEN;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Never log the credential itself — only whether one is present, and which kind.
+function authHeaders() {
+  if (API_KEY) return { "x-api-key": API_KEY };
+  if (AUTH_TOKEN) return { authorization: `Bearer ${AUTH_TOKEN}`, "anthropic-beta": "oauth-2025-04-20" };
+  return null;
+}
+
+// Same key convention as corpus.js / paperAbstracts.json: `${year}::${normAbsTitle(title)}`.
+function normAbsTitle(t) {
+  return String(t || "")
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function loadAbstracts() {
+  let base = {};
+  let manual = {};
+  try { base = require("../src/_data/paperAbstracts.json"); } catch { /* none yet */ }
+  try { manual = require("../src/_data/paperAbstractsManual.json"); } catch { /* none yet */ }
+  return { ...base, ...manual };
+}
+
+function abstractFor(abstracts, candidate) {
+  const key = `${candidate.paperYear}::${normAbsTitle(candidate.paperTitle)}`;
+  return abstracts[key]?.abstract || null;
+}
+
+const SCHEMA = {
+  type: "object",
+  properties: {
+    verdict: { type: "string", enum: ["same_work", "different_work", "uncertain"] },
+    rationale: { type: "string" },
+  },
+  required: ["verdict", "rationale"],
+  additionalProperties: false,
+};
+
+function buildPrompt(candidate, abstract) {
+  const ourPaper = [
+    `Title: "${candidate.paperTitle}"`,
+    `Authors: ${candidate.member || "(see conference programme)"}`,
+    `Conference: ${candidate.conference}`,
+    abstract ? `Abstract: ${abstract}` : "Abstract: (not on file)",
+  ].join("\n");
+  const candidateWork = [
+    `Title: "${candidate.candidateTitle}"`,
+    `Venue: ${candidate.journal || "(unknown)"}`,
+    `Publication year: ${candidate.candidateYear || "(unknown)"}`,
+    `DOI: ${candidate.doi || "(none)"}`,
+    `Source: ${candidate.matchedVia}`,
+  ].join("\n");
+  return [
+    "You are helping a small academic conference site decide whether a candidate publication is the later-published version of a conference paper.",
+    "",
+    "Conference paper:",
+    ourPaper,
+    "",
+    "Candidate published work:",
+    candidateWork,
+    "",
+    "Is the candidate the later-published version of the conference paper? Weigh author identity, topical overlap, the plausibility of the title having changed on the way to print, and whether the publication-lag window is reasonable.",
+    "Answer uncertain rather than guess when the evidence is thin.",
+  ].join("\n");
+}
+
+async function judgeOne(candidate, abstract) {
+  const body = {
+    model: MODEL,
+    max_tokens: 2000,
+    thinking: { type: "adaptive" },
+    output_config: { format: { type: "json_schema", schema: SCHEMA } },
+    messages: [{ role: "user", content: buildPrompt(candidate, abstract) }],
+  };
+
+  let res;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    res = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        ...authHeaders(),
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    if (res.status === 429 || res.status === 529) {
+      if (attempt === 0) { await sleep(5000); continue; }
+    }
+    break;
+  }
+
+  if (!res.ok) {
+    console.error(`! ${candidate.slug}: HTTP ${res.status} — skipped`);
+    return null;
+  }
+
+  const data = await res.json();
+  if (data.stop_reason === "refusal" || data.stop_reason === "max_tokens") {
+    console.error(`! ${candidate.slug}: stop_reason "${data.stop_reason}" — no verdict recorded`);
+    return null;
+  }
+
+  const textBlock = (data.content || []).find((b) => b.type === "text");
+  if (!textBlock) {
+    console.error(`! ${candidate.slug}: no text block in response — skipped`);
+    return null;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(textBlock.text);
+  } catch (e) {
+    console.error(`! ${candidate.slug}: could not parse verdict JSON — ${e.message}`);
+    return null;
+  }
+
+  return {
+    verdict: parsed.verdict,
+    rationale: parsed.rationale,
+    model: MODEL,
+    judgedOn: new Date().toISOString().slice(0, 10),
+  };
+}
+
+async function main() {
+  if (!authHeaders()) {
+    console.log("ANTHROPIC_API_KEY (or ANTHROPIC_AUTH_TOKEN) not set — LLM judge skipped (Phase 3 is a no-op until the secret is added).");
+    process.exit(0);
+  }
+
+  if (!existsSync(CANDIDATES)) {
+    console.log("No data/publication-candidates.json — nothing to judge.");
+    process.exit(0);
+  }
+
+  const candidates = JSON.parse(readFileSync(CANDIDATES, "utf8"));
+  const toJudge = candidates.filter((c) => c.band === "review" && !c.llmVerdict);
+
+  if (!toJudge.length) {
+    console.log("Nothing to judge — no review-band candidates without an existing llmVerdict.");
+    process.exit(0);
+  }
+
+  const abstracts = loadAbstracts();
+  let judged = 0;
+  for (const candidate of toJudge) {
+    const abstract = abstractFor(abstracts, candidate);
+    const verdict = await judgeOne(candidate, abstract);
+    if (verdict) {
+      candidate.llmVerdict = verdict;
+      judged++;
+      console.log(`✓ ${candidate.slug} → ${verdict.verdict}`);
+    }
+    await sleep(1100);
+  }
+
+  writeFileSync(CANDIDATES, JSON.stringify(candidates, null, 2) + "\n");
+  console.log(`\n${judged}/${toJudge.length} review-band candidate(s) judged. Verdicts are advisory — confirm-publication.mjs is still the only path to paperLinks.json.`);
+}
+
+await main();

--- a/scripts/publication-review-md.mjs
+++ b/scripts/publication-review-md.mjs
@@ -4,7 +4,10 @@
  * as a readable Markdown table for the weekly sync PR body
  * (sync-publications.yml). The high-confidence matches are auto-confirmed
  * before this runs, so the queue here is the review band — the part a human
- * actually decides. Prints to stdout.
+ * actually decides. When judge-publications.mjs (#805 Phase 3) has run, each
+ * row also carries its advisory LLM verdict + one-line rationale — a
+ * pre-assessment only, never a substitute for the human accept/reject call.
+ * Prints to stdout.
  */
 import { readFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -32,14 +35,30 @@ out.push("accept:  node scripts/confirm-publication.mjs <slug>");
 out.push("reject:  node scripts/confirm-publication.mjs --reject <slug>");
 out.push("```");
 out.push("");
-out.push("| Score | ESSC paper | Proposed published version | Slug |");
-out.push("|:--:|---|---|---|");
+const hasVerdicts = review.some((x) => x.llmVerdict);
+if (hasVerdicts) {
+  out.push("| Score | ESSC paper | Proposed published version | LLM verdict | Slug |");
+  out.push("|:--:|---|---|---|---|");
+} else {
+  out.push("| Score | ESSC paper | Proposed published version | Slug |");
+  out.push("|:--:|---|---|---|");
+}
 for (const x of review) {
   const venue = [x.candidateYear, x.journal ? clip(x.journal, 28) : null].filter(Boolean).join(", ");
   const pub = clip(x.candidateTitle, 56) + (venue ? ` *(${venue})*` : "");
   const paper = clip(x.paperTitle, 56) + `<br><sub>${x.conference}</sub>`;
-  out.push(`| ${x.titleScore.toFixed(2)} | ${paper} | ${pub} | \`${x.slug}\` |`);
+  if (hasVerdicts) {
+    const verdict = x.llmVerdict
+      ? `**${x.llmVerdict.verdict}** — ${clip(x.llmVerdict.rationale, 90)}`
+      : "_(not judged)_";
+    out.push(`| ${x.titleScore.toFixed(2)} | ${paper} | ${pub} | ${verdict} | \`${x.slug}\` |`);
+  } else {
+    out.push(`| ${x.titleScore.toFixed(2)} | ${paper} | ${pub} | \`${x.slug}\` |`);
+  }
 }
 out.push("");
+if (hasVerdicts) {
+  out.push("_The LLM verdict is advisory (#805 Phase 3) — a pre-assessment, not a decision. Judge each row on the merits._");
+}
 out.push("_Anything you don't act on stays in the queue for next week._");
 console.log(out.join("\n"));


### PR DESCRIPTION
## What

Adds `scripts/judge-publications.mjs`: the optional Phase 3 LLM judge for the publication matcher's review band, the last open item on #805.

For each review-band candidate without an existing `llmVerdict`, it calls the Anthropic Messages API directly (structured output, `same_work` / `different_work` / `uncertain`) with the conference paper's details (title, authors, year, abstract when on file) and the candidate publication's details, and writes the verdict + rationale back onto the candidate as `llmVerdict: { verdict, rationale, model, judgedOn }`.

Wires it into `sync-publications.yml` between the matcher/enrich step and the review-PR body, and extends `publication-review-md.mjs` so the review table shows each verdict + a clipped rationale when present.

## Why

The matcher's review band (title score 0.50–0.79) is titles that drifted enough on publication to need a human call. A pre-assessment gives the reviewer a starting opinion instead of judging every row cold. It changes nothing about the trust model: **advisory only**, never writes `src/_data/paperLinks.json`, never touches a candidate's `band`. `confirm-publication.mjs` stays the only path to a confirmed match, and the auto-high tier is untouched.

Self-gating: with no `ANTHROPIC_API_KEY` set, the script prints one line and exits 0, so the monthly sync workflow keeps running clean until the secret is added.

**Maintainer action needed:** add the `ANTHROPIC_API_KEY` repository secret. Until then, the judge step is a silent no-op (the workflow log will show the skip line, no error).

**Cost:** the review band typically holds a handful of candidates (currently 0, historically single digits). At roughly one Messages API call per candidate on the default model (`claude-opus-4-8`), this is well under $0.10/month.

## Verification

- Empty-queue run, no key: `node scripts/judge-publications.mjs` → clean skip line, exit 0.
- Empty-queue run, dummy key: → "nothing to judge", exit 0, `data/publication-candidates.json` unchanged.
- No live Anthropic credential was available in this environment (no `ANTHROPIC_API_KEY`, `ant` CLI not installed) — the live call against the Berthelsen fixture (ESSC 2025 "Innovation and engineering at the front" → Defence Studies 2026 "Innovating at the pace of relevance") is **unverified**. Instead, `fetch` was stubbed inline to return a canned Anthropic Messages API response for that exact fixture, confirming: the request shape (model, `output_config.format` schema) is sent correctly, the response is parsed correctly, and `llmVerdict` is written back onto the candidate with the expected shape. A second stub run confirmed idempotency: a candidate that already carries `llmVerdict` is skipped and `fetch` is never called.
- All synthetic fixtures reverted; `git status` clean except the intended file changes.
- `node scripts/check-build-sanity.mjs` passes; `npx @11ty/eleventy` builds clean; `python3 scripts/check-i18n-drift.py` reports no drift.

## Scope guards

- Did not touch the matcher's bands or discard threshold (out of scope).
- Judge output never auto-confirms anything.
- No new npm dependencies — plain Node, global `fetch`.

Closes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)