### PR TITLE
fix(board): point Verschuren website link to http (dead https)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,10 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 - **The 2024 abstract coverage figure no longer counts the joint Sciences Po–EISS conference, lifting it to 49 of 52.** That one-day symposium on the origins of war and diplomacy shares its calendar year with the EISS 2024 annual conference but never collected Indico-style abstracts, the same as the other pre-Indico and joint events. Its nine papers were previously counted as "eligible" and dragging the 2024 ratio down to 49 of 60; they're now correctly excluded, the same way roundtables and keynotes already are. Progresses [#886](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/886).
 - **Board and community profile pages now carry Schema.org `Person` structured data.** Each `/board/<slug>.html` page emits a JSON-LD block with the member's name, role, affiliation, photo and identifying links (ORCID, personal site, socials), so search engines can index board profiles the same way the site's papers and events already are. Closes [#756](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/756).
 
+### Fixed
+
+- **Sanne Verschuren's board-profile website link now resolves.** Her site serves no working HTTPS (the TLS handshake fails for browsers as well as the link checker), so the `https://` link on the board cards was dead; it now points to `http://www.sanneverschuren.com`, which returns 200. This was tripping the external-link check on every HTML-touching PR.
+
 ## [2.26.0] · 2026-06-25 — Introducing The Anthology
 
 This release introduces the European Security Studies Anthology as the site's flagship: the single home for every paper and every speaker across nine editions of the annual conference. The two separate archive views become one browsable surface, carried in the main navigation and linked outward to the NetSec member directory. Members' own published research gains a page of its own, and a round of polish runs through the navigation, the share cards, the Initiative page and the board.

--- a/src/_data/board.json
+++ b/src/_data/board.json
@@ -319,7 +319,7 @@
       "themes": "military technology; strategic thinking; nuclear weapons",
       "links": {
         "publicEmail": "sverschu@bu.edu",
-        "website": "https://www.sanneverschuren.com",
+        "website": "http://www.sanneverschuren.com",
         "orcid": "https://orcid.org/0000-0001-7977-361X"
       },
       "workingGroups": "WG1"


### PR DESCRIPTION
## What's happening
The external-link CI check fails on every HTML-touching PR because Sanne Verschuren's board-profile website link is dead. `https://www.sanneverschuren.com` serves **no working HTTPS** — the TLS handshake fails (cipher NONE on TLS 1.2 and 1.3), which breaks it for real browsers, not just the checker. Plain `http://www.sanneverschuren.com` returns `200`.

## Fix
Switch `links.website` for Verschuren in `src/_data/board.json` from `https://` to `http://`. Verified locally: clean build, all 20,001 internal links resolve, build-sanity ✓.

## Notes
- `board.json` is Form-synced (`scripts/sync-board.py`). If Sanne's Form entry still holds the `https://` URL, a future sync could re-introduce it — the durable fix is for her site to serve valid HTTPS (or to update the Form). Worth a nudge to her.
- This also unblocks the external-link check on [#1111](https://github.com/EISSeuropa/EISSeuropa.github.io/pull/1111) (the leadership announcement) and any other open HTML-touching PR, once this lands on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)