### PR TITLE
deps: patch js-yaml, brace-expansion and liquidjs DoS advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -370,9 +370,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -804,9 +804,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -999,9 +999,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -1072,9 +1072,9 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.27.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.0.tgz",
-      "integrity": "sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==",
+      "version": "10.27.2",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.2.tgz",
+      "integrity": "sha512-kvknfAEtOHjHkAAv7GxLEJh8ghpMQm3Fc4uWVyF7hERSTsSRsdC7saWs0p5aDG7GDcWsu5o+T4232O+8KZO55w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Clears the four open Dependabot alerts. All are algorithmic-complexity DoS in **build-time** dependencies.

| Package | From | To | Alert |
| --- | --- | --- | --- |
| js-yaml | 4.2.0 | 4.3.0 | [#15](https://github.com/EISSeuropa/EISSeuropa.github.io/security/dependabot/15) |
| js-yaml | 3.14.2 | 3.15.0 | [#14](https://github.com/EISSeuropa/EISSeuropa.github.io/security/dependabot/14), [#11](https://github.com/EISSeuropa/EISSeuropa.github.io/security/dependabot/11) |
| brace-expansion | 1.1.14 | 1.1.16 | [#13](https://github.com/EISSeuropa/EISSeuropa.github.io/security/dependabot/13) |
| liquidjs | 10.27.0 | 10.27.2 | [#16](https://github.com/EISSeuropa/EISSeuropa.github.io/security/dependabot/16) (auto-dismissed) |

Lockfile only. All four are transitive under `@11ty/eleventy`, which is already at its latest (3.1.6), and every bump is patch/minor. `package.json` has no runtime dependencies at all, so none of this ever reached a visitor.

## Output verified unchanged

Built the site with the old lockfile, then with the new one, and diffed file by file:

- 1102 files both times
- **one** file differs: `data/authors-index.json`
- that file also differs between two consecutive builds on *identical* dependencies, in exactly one field: `generated_at`

So the update changes nothing about the site.

## One advisory deliberately left open

`npm audit` still reports **GHSA-mh99-v99m-4gvg** (brace-expansion, OOM crash). It is patched *only* in 5.0.8, and `minimatch@3.1.5` — pulled in by `@11ty/recursive-copy` — constrains to `^1.1.7`. There is no 1.x backport.

npm's suggested fix is downgrading Eleventy to 3.1.2, which is not a fix. The alternative is an `overrides` entry forcing brace-expansion 1.x → 5.x underneath minimatch 3, whose API predates it. I judged that a bad trade: real risk of breaking the build, against a DoS whose only input is the glob patterns in our own `.eleventy.js`. It resolves when Eleventy moves to minimatch 9/10.

## Gates

Build, i18n drift and build-sanity all pass. No CHANGELOG entry, per §4's internal-only exemption and matching #1196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)