### PR TITLE
ci(links): retry once on 5xx instead of failing the build on a blip

### DIFF
--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -72,7 +72,7 @@ fi
 "$PY3" - "$SITE_ROOT" $INTERNAL_ONLY $QUIET <<'PY'
 """Inline-Python link checker. Avoids extra deps; portable across
 the maintainer's macOS laptop and Ubuntu CI."""
-import os, re, sys, urllib.parse, urllib.request, urllib.error, ssl
+import os, re, sys, time, urllib.parse, urllib.request, urllib.error, ssl
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -297,7 +297,7 @@ def _make_ssl_ctx(verify=True):
     return ssl.create_default_context()
 
 
-def check_external(url):
+def check_external(url, _retry=True):
     parsed = urllib.parse.urlparse(url)
     host = parsed.hostname or ""
     if host in SKIP_HOSTS or any(host == d or host.endswith("." + d) for d in SKIP_DOMAINS):
@@ -323,6 +323,18 @@ def check_external(url):
                 return (url, _do("GET", _make_ssl_ctx(verify=True)))
             except Exception as e2:
                 return (url, f"err: {e2}")
+        # A 5xx is the server faltering, not the link being wrong. Academic
+        # and institutional hosts routinely 503 under automated load while
+        # serving visitors perfectly well, and with no retry a single blip
+        # turns into a hard CI red on an unrelated PR. That is how the
+        # SKIP_HOSTS list above accumulated gess.ethz.ch and www.cnil.fr:
+        # neither is broken, both just flaked once. Retry once after a pause
+        # and take the second answer, so a genuine outage still fails (both
+        # attempts 5xx) while a blip does not. Preferred over adding hosts to
+        # the skip list, which trades a false red for a permanent blind spot.
+        if 500 <= e.code < 600 and _retry:
+            time.sleep(3)
+            return check_external(url, _retry=False)
         return (url, f"HTTP {e.code}")
     except urllib.error.URLError as e:
         # On macOS the default Python install often ships with an


### PR DESCRIPTION
## What's happening

The link check went red on [#1279](https://github.com/EISSeuropa/EISSeuropa.github.io/pull/1279):

```
EXTERNAL BROKEN (1):
  ✗ anthology.de.html → https://netsec-cost.eu/people/saurav-narain.html  (HTTP 503)
```

That URL is fine. Three consecutive probes return 200, and the page loads normally in a browser.

## Why it happened

Load, not a broken link. The built site carries **79 unique `netsec-cost.eu` URLs across 443 occurrences**, because every Anthology author who also appears in the NetSec directory links through to their profile there. The checker fires those at 3-way concurrency with no pause, and the sister site sheds one request under the burst.

`check_external` had no retry on 5xx, so a single blip became a hard failure. That is how `SKIP_HOSTS` accumulated `gess.ethz.ch` and `www.cnil.fr`, both documented in place as intermittently 503-ing under automated load while returning 200 on a manual probe. Neither host is broken. The skip list has been quietly absorbing a missing retry.

## The fix

Retry once after a three-second pause and take the second answer. A real outage still fails, since both attempts return 5xx. A blip does not.

Preferred over adding `netsec-cost.eu` to the skip list, which would trade one false red for a permanent blind spot over 79 machine-generated cross-repo links. Those are the ones that genuinely could rot, since `netsecDirectory.json` is auto-synced.

## Verification

Against a local server returning scripted statuses:

| Case | Result | Attempts |
| --- | --- | --- |
| 503 then 200 | recovers, returns 200 | 2 |
| persistent 503 | still fails, `HTTP 503` | 2 |
| 404 | fails immediately | 1 |

So genuine outages stay red and real broken links never burn a retry. `./scripts/check-links.sh --internal` passes on a fresh build (33,272 internal targets, zero broken).

The harness is not committed. A test that string-slices the embedded Python out of a shell script is more fragile than the four-line branch it guards, and this repository has no existing test suite for `scripts/`.

## Cost

Three seconds per 5xx encountered, bounded by one retry per URL. Zero effect on a clean run.

No CHANGELOG bullet, since CI tooling is exempt under rule §4.

Surfaced while working on [#1279](https://github.com/EISSeuropa/EISSeuropa.github.io/pull/1279), which this unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)