### PR TITLE
anthology: drop the sub-brand mark from the page header

### DIFF
--- a/src/_includes/archive-page.njk
+++ b/src/_includes/archive-page.njk
@@ -16,12 +16,10 @@
 
 <header class="page-header">
   <div class="container">
-    {# The Anthology/Atlas sub-brand constellation, the same asset the Atlas
-       masthead and the signpost below use. Standalone above the eyebrow rather
-       than inline beside the H1, because this title wraps to two lines at most
-       widths and a mark hung off the first line reads as a stray glyph.
-       Decorative: the H1 underneath names the page, so it is aria-hidden. #}
-    <span class="anthology-mark" aria-hidden="true">{% inlineSvg "assets/images/brand/anthology-mark.svg" %}</span>
+    {# No sub-brand mark above the eyebrow: the page header reads better without
+       it, and the constellation still appears on this page in the Atlas signpost
+       below (and on the Atlas page itself), which is where it does wayfinding
+       work rather than decoration. #}
     <span class="eyebrow">{{ n18n.eyebrow }}</span>
     <h1>{{ n18n.title }}</h1>
     <p class="page-lead">{{ n18n.lead }}</p>

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -7172,20 +7172,6 @@ a.profile-pub-title:hover { text-decoration: underline; }
 .atlas-mark { flex: 0 0 auto; align-self: center; display: block; color: var(--accent); }
 .atlas-mark svg { width: 2.75rem; height: 2.75rem; display: block; }
 @media (max-width: 640px) { .atlas-mark svg { width: 2.25rem; height: 2.25rem; } }
-
-/* Same mark on the Anthology page header, standalone above the eyebrow. Sized
-   a touch larger than the Atlas masthead's because it stands alone here rather
-   than sitting next to a display-size title. */
-.anthology-mark {
-  display: block;
-  /* Hug the mark rather than stretching the full container width, so the
-     wrapper never becomes a page-wide invisible box. */
-  width: max-content;
-  margin-bottom: var(--space-4);
-  color: var(--accent);
-}
-.anthology-mark svg { width: 3.25rem; height: 3.25rem; display: block; }
-@media (max-width: 640px) { .anthology-mark svg { width: 2.5rem; height: 2.5rem; } }
 .atlas-masthead h1 { font-size: var(--fs-2xl); margin: 0; color: var(--text); letter-spacing: -.02em; line-height: var(--lh-tight); }
 .atlas-proto-pill { font-size: .72rem; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; padding: 4px 11px; border-radius: var(--radius-full); background: var(--accent-soft); border: 1px solid var(--accent); color: var(--accent); }
 .atlas-lede { color: var(--text-muted); max-width: 74ch; margin: 0 0 20px; font-size: var(--fs-base); line-height: var(--lh-normal); }


### PR DESCRIPTION
The constellation above the eyebrow on `/anthology.html` did not sit right. Removed on your call.

## What stays

The mark remains on the two placements the design-system handoff actually named, where it does wayfinding rather than decoration:

- the **Atlas signpost card** further down the same page (all three locales)
- the **Atlas masthead** on `/anthology-atlas.html`

The page header was my own addition on top of those, and it was the weakest of the three: the H1 already reads "The European Security Studies Anthology", so a mark above it restates the page rather than helping anyone navigate.

## Also in this change

The `.anthology-mark` rules go with the markup rather than lingering as dead CSS. The removal had also eaten a space in the `.atlas-masthead h1` selector, which is restored.

## Verification

| Page | Marks | Header mark |
|---|---|---|
| `/anthology.html` | 1 (Atlas card) | 0 |
| `/anthology.fr.html` | 1 | 0 |
| `/anthology.de.html` | 1 | 0 |
| `/anthology-atlas.html` | 1 (masthead) | 0 |

The Atlas masthead mark still renders at 36×36 and its `h1` still computes to 36px, confirming the selector repair holds. `check-build-sanity.mjs` and `check-i18n-drift.py` pass on a clean rebuild.

## No CHANGELOG change

The bullet for this cycle names the signpost and the masthead as the two surfaces that gained the mark, and both still have it, so it stays accurate. The header placement shipped and was withdrawn inside the same unreleased cycle, so recording the round trip would be noise.

Auto-merge is not armed, per rule §2's visual-change carve-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)