### PR TITLE
ci(links): retry a timeout too, not only a 5xx

### DIFF
--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -72,7 +72,7 @@ fi
 "$PY3" - "$SITE_ROOT" $INTERNAL_ONLY $QUIET <<'PY'
 """Inline-Python link checker. Avoids extra deps; portable across
 the maintainer's macOS laptop and Ubuntu CI."""
-import os, re, sys, time, urllib.parse, urllib.request, urllib.error, ssl
+import os, re, socket, sys, time, urllib.parse, urllib.request, urllib.error, ssl
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -359,7 +359,27 @@ def check_external(url, _retry=True):
                 return (url, _do(method, _make_ssl_ctx(verify=False)))
             except Exception as e2:
                 return (url, f"err: {e2.__class__.__name__}: {e2}")
+        # A connect timeout arrives wrapped in URLError; a read timeout does
+        # not (see the TimeoutError branch below). Both retry.
+        if _retry and isinstance(getattr(e, "reason", None), (TimeoutError, socket.timeout)):
+            time.sleep(3)
+            return check_external(url, _retry=False)
         return (url, f"err: {e.__class__.__name__}: {e}")
+    except (TimeoutError, socket.timeout):
+        # A timeout is the same class of flake as a 5xx: the host is reachable,
+        # it just did not answer inside 15s under a burst. #1282 added the 5xx
+        # retry and stopped there, so a timeout still failed a PR outright —
+        # which is what took #1291 red on hal.science, a link with nothing to
+        # do with that PR.
+        #
+        # This needs its own branch: urlopen raises a bare socket.timeout on a
+        # read timeout rather than wrapping it in URLError, so it lands in the
+        # generic handler below. Verified against a server that hangs past the
+        # client timeout — without this branch, no retry fires at all.
+        if _retry:
+            time.sleep(3)
+            return check_external(url, _retry=False)
+        return (url, "err: timed out twice")
     except Exception as e:
         return (url, f"err: {e.__class__.__name__}: {e}")
 


### PR DESCRIPTION
#1282 added a one-shot retry for HTTP 5xx and stopped there, reasoning that a 5xx is the server faltering rather than the link being wrong. **A timeout is the same thing** — the host is reachable, it just did not answer inside 15s under a burst.

Leaving it out cost a red PR almost immediately. [#1291](https://github.com/EISSeuropa/EISSeuropa.github.io/pull/1291) failed on `hal.science/hal-05711925` with `URLError: <urlopen error timed out>` — a link with nothing to do with that PR, which loads fine.

It is also why `SKIP_HOSTS` still carries `su.se`, `etsi.org` and the EUI host: all three are documented *in that list* as timeouts rather than 4xx, absorbed by the skip list because there was no retry to absorb them.

## The test is what showed the first attempt was wrong

`urlopen` wraps a **connect** timeout in `URLError`, but raises a bare `socket.timeout` on a **read** timeout, which falls straight through to the generic handler. My first version only checked `URLError.reason` — so against a server that hangs past the client timeout, **no retry fired at all**: one attempt, immediate failure.

Both paths retry now, via an explicit `except (TimeoutError, socket.timeout)` branch.

## Verified against a local server with scripted behaviour

| Case | Result | Attempts |
|---|---|---|
| timeout, then 200 | recovers | 2 |
| persistent timeout | still fails | 2 |
| 503, then 200 | recovers | 2 *(unchanged)* |
| persistent 503 | still fails | 2 *(unchanged)* |
| 404 | fails immediately | 1 — no wasted retry |

Genuine breakage still goes red. `./scripts/check-links.sh --internal` passes (25,017 internal links).

The harness is not committed, for the same reason as #1282: a test that string-slices the embedded Python out of a shell script is more fragile than the branch it guards.

## Deliberately not done

**Pruning `SKIP_HOSTS`.** `su.se`, `etsi.org` and the EUI host may now survive on a retry, but each was added after a real recurring failure. Removing them is a separate change that should be judged on its own CI evidence rather than folded in here.

No CHANGELOG bullet: CI tooling is exempt under rule §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)