### PR TITLE
release: offer to flip the public roadmap card, instead of asking for it by hand

### DIFF
--- a/.claude/skills/release-cross-check/SKILL.md
+++ b/.claude/skills/release-cross-check/SKILL.md
@@ -26,6 +26,22 @@ same release. If yes but too big to fit, open a tracking issue
   its date, add the release-notes link, and drop the `data-milestone`
   attribute so it no longer renders a progress bar. The next planned
   card is auto-promoted to *In progress* by `roadmap-progress.js`.
+
+  **`scripts/release.sh` now offers to do this**, showing the diff and
+  applying it only on an explicit `y` (#280). To do it outside a
+  release, or to check what it would change:
+
+  ```bash
+  node scripts/flip-roadmap-card.mjs v2.27.0            # dry run
+  node scripts/flip-roadmap-card.mjs v2.27.0 --write
+  ```
+
+  It edits `src/_data/roadmap.js`, which the three locale pages render
+  from, so one command covers EN, FR and DE. The dates come from the
+  same `Intl` formatter the news surface uses, so a flipped card reads
+  identically to a hand-written one. Still eyeball the rendered page:
+  the script guarantees the data is right, not that the prose around
+  it still is.
 - Anything in the *Under watch* section ready to promote to a dated
   release row (and its own milestone)?
 - The autostamp on `docs/roadmap-2026.md` (rule §11) keeps the

--- a/scripts/flip-roadmap-card.mjs
+++ b/scripts/flip-roadmap-card.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+/**
+ * Flip a /roadmap card from planned to shipped (#280).
+ *
+ *   node scripts/flip-roadmap-card.mjs v2.27.0                  # dry run, prints the diff
+ *   node scripts/flip-roadmap-card.mjs v2.27.0 --write          # apply
+ *   node scripts/flip-roadmap-card.mjs v2.27.0 --write --date 2026-09-14 --changes 31
+ *
+ * WHY
+ *
+ * The release cross-check asks the maintainer to flip the shipped card on
+ * /roadmap.html by hand at every release: set the status, add the release-notes
+ * link, drop the milestone so the progress bar stops rendering, and restate the
+ * date in three locales. Four coordinated edits across EN, FR and DE, done
+ * under release pressure, which is exactly when a hand-edit goes wrong and the
+ * public roadmap drifts from reality.
+ *
+ * HOW, AND WHY NOT AN AST REWRITE
+ *
+ * #280 suggested an AST rewrite or a move to structured data. Both are worse
+ * here. src/_data/roadmap.js is hand-written, hand-translated and heavily
+ * commented; regenerating it from an AST would reformat the whole file and
+ * throw away the comments, turning a four-line change into an unreviewable
+ * diff. Moving to JSON would strip the comments and the notes() helper.
+ *
+ * So: acorn LOCATES and VALIDATES the entry (exact character range, current
+ * field set), and the edit itself is textual within that range. The formatting
+ * and every comment survive, and the diff is the four lines a human would have
+ * written. The parser is what makes that safe rather than a regex guess.
+ *
+ * Nothing is written until the result has been re-parsed AND re-required, and
+ * the resulting object checked field by field against what was asked for.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+import * as acorn from "acorn";
+
+const require = createRequire(import.meta.url);
+const FILE = new URL("../src/_data/roadmap.js", import.meta.url);
+const PATH = "src/_data/roadmap.js";
+
+const argv = process.argv.slice(2);
+const version = argv.find((a) => /^v\d+\.\d+\.\d+$/.test(a));
+const flag = (name) => {
+  const i = argv.indexOf(`--${name}`);
+  return i === -1 ? null : argv[i + 1];
+};
+const write = argv.includes("--write");
+const date = flag("date") || new Date().toISOString().slice(0, 10);
+
+if (!version) {
+  console.error("usage: node scripts/flip-roadmap-card.mjs vX.Y.Z [--write] [--date YYYY-MM-DD] [--changes N]");
+  process.exit(2);
+}
+if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+  console.error(`error: --date must be YYYY-MM-DD, got ${date}`);
+  process.exit(2);
+}
+
+// Change count for the card. Defaults to the number of bullets under
+// [Unreleased] in the CHANGELOG, which is what the card is reporting, but stays
+// overridable because the release commit may add or fold bullets afterwards.
+function changeCount() {
+  const explicit = flag("changes");
+  if (explicit) return Number(explicit);
+  try {
+    const md = readFileSync(new URL("../CHANGELOG.md", import.meta.url), "utf8");
+    const block = md.slice(md.indexOf("## [Unreleased]"));
+    const next = block.indexOf("\n## [", 1);
+    return (block.slice(0, next === -1 ? undefined : next).match(/^- /gm) || []).length;
+  } catch {
+    return null;
+  }
+}
+
+// Same formatter the news surface uses (.eleventy.js `newsDate`), so a flipped
+// card reads identically to every hand-written one: "14 September 2026",
+// "14 septembre 2026", "14. September 2026".
+const longDate = (iso, lang) =>
+  new Intl.DateTimeFormat({ en: "en-GB", fr: "fr-FR", de: "de-DE" }[lang], {
+    day: "numeric", month: "long", year: "numeric", timeZone: "UTC",
+  }).format(new Date(iso + "T00:00:00Z"));
+
+const src = readFileSync(FILE, "utf8");
+const ast = acorn.parse(src, { ecmaVersion: "latest", sourceType: "script", ranges: true });
+
+// Find the object literal whose `version` property is the target release.
+let node = null;
+(function walk(n) {
+  if (!n || typeof n !== "object" || node) return;
+  if (n.type === "ObjectExpression") {
+    const v = n.properties.find((p) => p.key && (p.key.name || p.key.value) === "version");
+    if (v && v.value.type === "Literal" && v.value.value === version) { node = n; return; }
+  }
+  for (const k of Object.keys(n)) {
+    const c = n[k];
+    if (Array.isArray(c)) c.forEach(walk);
+    else if (c && typeof c.type === "string") walk(c);
+  }
+})(ast);
+
+if (!node) {
+  console.error(`error: no roadmap card with version "${version}" in ${PATH}.`);
+  process.exit(1);
+}
+
+const prop = (name) => node.properties.find((p) => p.key && (p.key.name || p.key.value) === name);
+const statusProp = prop("status");
+const current = statusProp && statusProp.value.value;
+if (current === "shipped") {
+  console.log(`✓ ${version} is already shipped — nothing to do.`);
+  process.exit(0);
+}
+if (current !== "planned" && current !== "in-progress") {
+  console.error(`error: ${version} has status "${current}"; expected planned or in-progress.`);
+  process.exit(1);
+}
+
+const [start, end] = node.range;
+const block = src.slice(start, end);
+const changes = changeCount();
+
+// ── the edit, line by line inside the located block ─────────────────────────
+let out = block;
+
+// 1. status
+out = out.replace(/status:\s*"(planned|in-progress)"/, 'status: "shipped"');
+
+// 2. notesUrl + changes, inserted after `version:` so the field order matches
+//    every hand-written shipped card.
+const versionLine = out.match(/^(\s*)version:\s*"[^"]+",\s*$/m);
+const indent = versionLine ? versionLine[1] : "          ";
+let insert = `\n${indent}notesUrl: notes("${version}"),`;
+if (changes != null) insert += `\n${indent}changes: ${changes},`;
+out = out.replace(/^(\s*version:\s*"[^"]+",)\s*$/m, `$1${insert}`);
+
+// 3. drop `milestone` — a shipped card must not render a progress bar
+out = out.replace(/^\s*milestone:\s*"[^"]+",\s*\n/m, "");
+
+// 4. the date, in all three locales. The existing `when` carries a planning
+//    label ("September 2026 · v2.27.0"); shipped cards carry the real date.
+const when = `when: { en: "${longDate(date, "en")} · ${version}", fr: "${longDate(date, "fr")} · ${version}", de: "${longDate(date, "de")} · ${version}" },`;
+if (!/^\s*when:\s*\{[^}]*\},\s*$/m.test(out)) {
+  console.error("error: could not find a single-line `when:` object to rewrite; roadmap.js formatting has changed.");
+  process.exit(1);
+}
+out = out.replace(/^(\s*)when:\s*\{[^}]*\},\s*$/m, `$1${when}`);
+
+const updated = src.slice(0, start) + out + src.slice(end);
+
+// ── verify before writing ───────────────────────────────────────────────────
+try {
+  acorn.parse(updated, { ecmaVersion: "latest", sourceType: "script" });
+} catch (e) {
+  console.error(`error: the edit produced invalid JavaScript (${e.message}). Nothing written.`);
+  process.exit(1);
+}
+
+// Re-require in a child process so a broken module cannot poison this one, and
+// assert the card actually says what was asked for. A diff that looks right is
+// not the same as a module that loads right.
+const tmp = new URL("../src/_data/.roadmap-flip-check.js", import.meta.url);
+writeFileSync(tmp, updated);
+let verified;
+try {
+  verified = JSON.parse(
+    execFileSync(process.execPath, ["-e",
+      `const r=require(${JSON.stringify(new URL(tmp).pathname)});const d=typeof r==='function'?r():r;` +
+      `let all=[];for(const g of (Object.values(d).find(Array.isArray)||[]))if(g.entries)all=all.concat(g.entries);` +
+      `process.stdout.write(JSON.stringify(all.find(e=>e.version===${JSON.stringify(version)})||null));`,
+    ], { encoding: "utf8" })
+  );
+} catch (e) {
+  console.error(`error: the edited module failed to load (${e.message.split("\n")[0]}). Nothing written.`);
+  process.exit(1);
+} finally {
+  try { execFileSync("rm", ["-f", new URL(tmp).pathname]); } catch {}
+}
+
+const problems = [];
+if (!verified) problems.push("the card disappeared from the parsed output");
+else {
+  if (verified.status !== "shipped") problems.push(`status is "${verified.status}", expected "shipped"`);
+  if (!verified.notesUrl || !verified.notesUrl.endsWith(version)) problems.push("notesUrl missing or wrong");
+  if (verified.milestone) problems.push(`milestone "${verified.milestone}" survived; the progress bar would still render`);
+  for (const l of ["en", "fr", "de"]) {
+    if (!verified.when || !String(verified.when[l]).includes(version)) problems.push(`when.${l} does not carry ${version}`);
+  }
+}
+if (problems.length) {
+  console.error("error: the edit did not produce the expected card. Nothing written:");
+  for (const p of problems) console.error("  - " + p);
+  process.exit(1);
+}
+
+// ── report ─────────────────────────────────────────────────────────────────
+const before = block.split("\n");
+const after = out.split("\n");
+console.log(`${write ? "flipping" : "would flip"} ${version} to shipped in ${PATH}:\n`);
+for (const l of before) if (!after.includes(l)) console.log("  - " + l.trim());
+for (const l of after) if (!before.includes(l)) console.log("  + " + l.trim());
+console.log();
+console.log(`  date:    ${date}`);
+console.log(`  changes: ${changes == null ? "(omitted — CHANGELOG unreadable)" : changes}`);
+
+if (!write) {
+  console.log("\ndry run. Re-run with --write to apply.");
+  process.exit(0);
+}
+writeFileSync(FILE, updated);
+console.log(`\n✓ written. Rebuild and eyeball /roadmap.html (+ FR + DE) before committing.`);

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -219,16 +219,37 @@ if [[ "$DRY_RUN" != "--dry-run" ]]; then
   # For minor / major releases (X.Y.Z where Z == 0), print the
   # cross-check reminder before the prompt. Skipped for patch
   # releases — they're scoped to small fixes.
+  ROADMAP_FLIPPED=0
   PATCH_PART="${VERSION##*.}"
   if [[ "$PATCH_PART" == "0" ]]; then
     printf '  Minor / major release — cross-check before publishing:\n'
     printf '    1. Roadmap       — docs/roadmap-2026.md release-history section up to date?\n'
+    printf '                       Public card: node scripts/flip-roadmap-card.mjs %s --write\n' "$VERSION"
     printf '    2. Sitemap       — sitemap.xml + /sitemap.html include any new pages?\n'
     printf '    3. Translations  — python3 scripts/check-i18n-drift.py reports zero drift?\n'
     printf '    4. README        — Versioning section reflects any convention change?\n'
     printf '\n'
     printf '  Land any edits in the same release, or open tracking issues.\n'
     printf '  ──────────────────────────────────────────────────────────────\n\n'
+
+    # The public roadmap card is the one cross-check item that is a mechanical
+    # edit rather than a judgement, so offer to make it (#280). Shown as a diff
+    # first and applied only on an explicit "y": this rewrites hand-translated
+    # data during a release, which is the wrong moment to be surprised.
+    if node scripts/flip-roadmap-card.mjs "$VERSION" 2>/dev/null | grep -q 'would flip'; then
+      printf '  The public /roadmap card for v%s is still unshipped:\n\n' "$VERSION"
+      node scripts/flip-roadmap-card.mjs "$VERSION" | sed 's/^/  /'
+      printf '\n  Apply this now? Type "y" to flip it, anything else to skip: '
+      read -r FLIP
+      case "$FLIP" in
+        [yY]|[yY][eE][sS])
+          node scripts/flip-roadmap-card.mjs "$VERSION" --write | sed 's/^/  /'
+          ROADMAP_FLIPPED=1
+          printf '\n  Roadmap card flipped. It goes into the release commit below.\n\n'
+          ;;
+        *) printf '\n  Skipped. Flip it by hand, or re-run the command above later.\n\n' ;;
+      esac
+    fi
   fi
 
   printf '  Publish v%s — %s with the title + notes above?\n' "$VERSION" "$TITLE"
@@ -304,6 +325,12 @@ fi
 step "Commit, tag, push"
 
 run git add CHANGELOG.md
+# The roadmap card, when the offer above was accepted. Staged explicitly rather
+# than with `git add -A`, so a release never sweeps in unrelated working-tree
+# changes (rule §8).
+if [[ "${ROADMAP_FLIPPED:-0}" == "1" ]]; then
+  run git add src/_data/roadmap.js
+fi
 run git commit -m \"Release v$VERSION — $TITLE\" \
        -m \"Promotes the CHANGELOG.md [Unreleased] section to [$VERSION] · $TODAY — $TITLE and resets [Unreleased].\"
 run git tag -a \"v$VERSION\" \


### PR DESCRIPTION
Closes #280.

The release cross-check asks you to flip the shipped card on `/roadmap` by hand at every release: status, release-notes link, drop the milestone so the progress bar stops, and restate the date in three locales. Four coordinated edits under release pressure — which is exactly when a hand-edit goes wrong and the public roadmap drifts from reality.

`scripts/flip-roadmap-card.mjs` does it. **Dry run by default**, `--write` to apply. `release.sh` shows the diff at the cross-check step and applies it only on an explicit `y`, because this rewrites hand-translated data mid-release and that is the wrong moment to be surprised.

```
would flip v2.27.0 to shipped in src/_data/roadmap.js:

  - status: "planned",
  - milestone: "v2.27.0",
  - when: { en: "September 2026 · v2.27.0", fr: "septembre 2026 · v2.27.0", … }
  + status: "shipped",
  + notesUrl: notes("v2.27.0"),
  + changes: 64,
  + when: { en: "14 September 2026 · v2.27.0", fr: "14 septembre 2026 · v2.27.0", … }
```

## Not an AST rewrite, deliberately

#280 suggested an AST rewrite or a move to structured data, and rated it **L-effort** for that reason. Both are worse here. `roadmap.js` is hand-written, hand-translated and heavily commented — regenerating it from an AST would reformat the file and drop every comment, turning a four-line change into an unreviewable diff. JSON would lose the comments and the `notes()` helper.

So **acorn locates and validates** the entry (exact character range, current field set), and the **edit is textual** within that range. Formatting and comments survive, and the diff is the four lines a human would have written. The parser is what makes that safe rather than a regex guess.

Nothing is written until the result has been re-parsed **and re-required in a child process**, with the resulting card checked field by field: status shipped, `notesUrl` matching, `milestone` gone, all three locale strings carrying the version. A diff that looks right is not the same as a module that loads right.

Dates come from the same `Intl` formatter `.eleventy.js` uses for the news surface, so a flipped card reads identically to a hand-written one. The change count defaults to the CHANGELOG's `[Unreleased]` bullet count and stays overridable with `--changes`.

## One thing testing corrected

My first version told you the flipped card was *"staged with the release commit below"*. **It was not** — `release.sh` stages `CHANGELOG.md` alone, so the card would have been left uncommitted in the working tree, against rule §8. It now stages `src/_data/roadmap.js` when and only when the offer was accepted, still explicitly rather than with `git add -A`.

## Verification

End to end against the real v2.27.0 card: the diff is the four intended lines, all three locales render the localised date, `data-milestone` disappears so no progress bar renders, and the release-notes link appears. **Reverted after testing — `roadmap.js` is untouched in this commit.**

Guards: an already-shipped version is a no-op, an unknown version and a malformed date both exit non-zero, and a dry run leaves the file byte-identical. `bash -n` clean on `release.sh`, and the `ROADMAP_FLIPPED` flag verified to propagate (both assignments are top-level, no subshell).

Documented in the `release-cross-check` skill, next to the manual instruction it replaces.

No CHANGELOG bullet: release tooling is internal under rule §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)