### PR TITLE
Rule §7: don't justify the fact you just stated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,19 @@ across consecutive sentences. Writing "the script" then "the sync"
 then "the workflow" for the same thing in three sentences is an AI
 tell, even when each label is technically accurate.
 
+**Don't justify the fact you just stated.** State it and stop. The
+tell is a trailing clause arguing for the decision the sentence has
+already described: "because our reviewing capacity is the real
+limit", "it exists so that working alone does not mean working in
+silence", "not favours we extend if there is time". Cut it, headings
+included: "Unpaid, and we say so plainly" is "Unpaid". **Site pages
+only.** The CHANGELOG, PR bodies and maintainer docs are where
+reasoning belongs. Grep a page you are editing for `because`, `so
+that`, `rather than`, `which is why`: each hit is a question, not a
+verdict, since some are real cause ("Because NetSec is COST-funded,
+all its..."). #1370 and #1372 cut `/blog.html` and `/internship.html`
+by about a fifth this way, with no fact removed.
+
 The rules are forward-looking. They apply to prose authored from the
 PR that introduces them onwards. Pre-existing em dashes and semicolons
 in the repo aren't retroactively scrubbed unless the surrounding text


### PR DESCRIPTION
Codifies the copy edit from #1370 and #1372 into `CLAUDE.md` §7, alongside the existing em dash, semicolon, rule-of-three and synonym-cycling rules.

## The rule

> **Don't justify the fact you just stated.** State it and stop. The tell is a trailing clause arguing for the decision the sentence has already described: "because our reviewing capacity is the real limit", "it exists so that working alone does not mean working in silence", "not favours we extend if there is time". Cut it, headings included: "Unpaid, and we say so plainly" is "Unpaid". **Site pages only.** The CHANGELOG, PR bodies and maintainer docs are where reasoning belongs. Grep a page you are editing for `because`, `so that`, `rather than`, `which is why`: each hit is a question, not a verdict, since some are real cause ("Because NetSec is COST-funded, all its..."). #1370 and #1372 cut `/blog.html` and `/internship.html` by about a fifth this way, with no fact removed.

## Two things it is careful about

**Scope.** §7's preamble applies its rules to the CHANGELOG and PR descriptions as well as site copy. That would be wrong here: a CHANGELOG entry explaining why a decision was taken is doing its job. The rule carves those out explicitly.

**The grep is a prompt, not a linter.** Running it over `/initiative` returns five hits, three inside Nunjucks comments and two legitimate cause. Stating that inline should stop the next reader treating a match as a defect.

My first draft of the rule ran to 190 words and closed with a sentence explaining why the rule is a good idea. Cut, for the obvious reason. It is 131 now.

Docs-only and internal, so no CHANGELOG bullet per §4 and nothing user-visible changes. Auto-merge armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)