### PR TITLE
a11y lint: walk the whole build, not just the top level (#1366)

### DIFF
--- a/scripts/a11y_lint.py
+++ b/scripts/a11y_lint.py
@@ -23,6 +23,7 @@ import os
 import re
 import sys
 from html.parser import HTMLParser
+import pathlib
 from collections import defaultdict, Counter
 
 
@@ -183,10 +184,19 @@ def main():
     bucketed = defaultdict(list)
     pages_with_issues = 0
 
-    for fn in sorted(os.listdir(site_dir)):
-        if not fn.endswith(".html"):
-            continue
+    # Walk the whole tree, not just the top level (#1366). os.listdir stopped
+    # at `_site/*.html`, so the 315 paper pages, the 17 Atlas theme pages and
+    # anything else rendered into a subdirectory were never scanned, while the
+    # summary still read like coverage of the site.
+    nested = 0
+    for fn in sorted(
+        str(q.relative_to(site_dir))
+        for q in pathlib.Path(site_dir).rglob("*.html")
+        if q.is_file()
+    ):
         path = os.path.join(site_dir, fn)
+        if os.sep in fn:
+            nested += 1
         html = open(path, "r", encoding="utf-8", errors="ignore").read()
         total += 1
         if not is_modernised(html):
@@ -243,9 +253,9 @@ def main():
             bucketed["clean"].append(fn)
 
     print(f"\n=== Lint summary ===")
-    print(f"  Total HTML files:       {total}")
+    print(f"  Total HTML files:       {total}  ({total - nested} top level, {nested} nested)")
     print(f"  Modernised (scanned):   {modernised}")
-    print(f"  Legacy (skipped):       {len(bucketed['legacy_skipped'])}")
+    print(f"  Skipped, no chrome:     {len(bucketed['legacy_skipped'])}")
     print(f"  Pages with issues:      {pages_with_issues}")
     print(f"  Pages clean:            {len(bucketed['clean'])}")
 
@@ -256,7 +266,7 @@ def main():
             for i in issues:
                 print(f"    - {i}")
     if bucketed["legacy_skipped"]:
-        print(f"\nLegacy passthroughs skipped:")
+        print(f"\nSkipped, no site chrome (Pagefind stubs, legacy passthroughs):")
         for f in bucketed["legacy_skipped"]:
             print(f"  - {f}")
 


### PR DESCRIPTION
Closes #1366. Groundwork for #1225, which is in `v2.27.0`: declaring conformance is not credible while the lint sees 17 per cent of the pages.

## The change

`os.listdir(site_dir)` becomes a recursive `rglob`. Six lines, plus a summary that splits top level from nested.

```
before   Total HTML files:  113
after    Total HTML files:  736  (128 top level, 608 nested)
         Modernised (scanned):   598
         Skipped, no chrome:     138
         Pages with issues:        0
         Pages clean:            598
```

## The gap was hiding nothing

I predicted the opposite on the issue: *"expect the first run to fail, and treat that as the point"*, with advice about grouping findings by template and staging the rollout behind a flag. **None of that was needed.** I ran the recursive walk as a throwaway patch before touching the real script, and all 598 scanned pages are clean, including the 315 paper pages and the 17 Atlas theme pages that had never been checked.

So this lands as a plain fix rather than the staged cleanup the issue described. The staging advice there is now wrong and the issue should be read with this comment beside it.

## The 138 skipped files

All of them are under `search/`, and all are Pagefind bio stubs: `noindex`, a meta-refresh to the board page, a `data-pagefind-body`. They carry no `site-header`, so `is_modernised()` filters them out, which is correct. Nothing real is being skipped.

Since the site has no Mobirise passthroughs left, "Legacy (skipped)" now describes the wrong thing, so the label reads "Skipped, no chrome" and the detail line names both kinds.

## Verification

- `python3 -c "import ast; ast.parse(...)"` parses.
- Run against a fresh build: 736 files seen, 598 scanned, 0 issues, 138 skipped and every one under `search/`.
- Confirmed the skipped set by grouping the skip list by directory: `138 search/`, nothing else.
- No behaviour change for a page that was already scanned: the same 128 top-level files still go through the same checks.

Not merging, per your instruction. Nothing here is user-visible, so this would normally take auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)