### PR TITLE
docs: the August 2026 accessibility audit (#1225)

### DIFF
--- a/axe-audit.mjs
+++ b/axe-audit.mjs
@@ -1,0 +1,41 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { JSDOM } from 'jsdom';
+import axe from 'axe-core';
+
+const SITE = '_site';
+const pages = process.argv.slice(2);
+const results = [];
+
+for (const rel of pages) {
+  const file = path.join(SITE, rel);
+  if (!fs.existsSync(file)) { console.log(`SKIP (missing) ${rel}`); continue; }
+  const html = fs.readFileSync(file, 'utf8');
+  for (const theme of ['light', 'dark']) {
+    const dom = new JSDOM(html, { url: 'https://eiss-europa.com/' + rel, pretendToBeVisual: true, runScripts: 'outside-only' });
+    const { window } = dom;
+    window.document.documentElement.setAttribute('data-theme', theme);
+    // axe needs these; jsdom lacks them
+    window.matchMedia = window.matchMedia || (() => ({ matches: theme === 'dark', addListener(){}, removeListener(){}, addEventListener(){}, removeEventListener(){} }));
+    const axeSource = fs.readFileSync('node_modules/axe-core/axe.min.js', 'utf8');
+    window.eval(axeSource);
+    if (!window.axe) { console.log(`ERROR ${theme} ${rel}: axe did not attach`); window.close(); continue; }
+    try {
+      const r = await window.axe.run(window.document, {
+        runOnly: { type: 'tag', values: ['wcag2a','wcag2aa','wcag21a','wcag21aa','best-practice'] },
+        resultTypes: ['violations'],
+      });
+      for (const v of r.violations) {
+        results.push({ page: rel, theme, id: v.id, impact: v.impact, n: v.nodes.length, help: v.help, nodes: v.nodes.map(n => ({ target: n.target, summary: (n.failureSummary||'').split('\n').slice(0,3).join(' | '), html: (n.html||'').slice(0,180) })) });
+      }
+      console.log(`${r.violations.length === 0 ? 'PASS' : 'FAIL'}  ${theme.padEnd(5)}  ${rel}  (${r.violations.length} violation types)`);
+    } catch (e) {
+      console.log(`ERROR ${theme} ${rel}: ${e.message}`);
+    }
+    window.close();
+  }
+}
+fs.writeFileSync('/tmp/axe-results.json', JSON.stringify(results, null, 1));
+console.log('\n=== violations ===');
+if (!results.length) console.log('none');
+for (const r of results) console.log(`${r.impact}\t${r.id}\t${r.n} node(s)\t${r.page} [${r.theme}]\t${r.help}`);

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Maintainer-facing docs for [eiss-europa.com](https://eiss-europa.com)
 |---|---|
 | [architecture.md](architecture.md) | Build pipeline, data sources, sync jobs, CI gates, deploy — the data-flow map. |
 | [design-system.md](design-system.md) | UI components and interaction patterns (the `.njk` partials + their CSS/JS). |
+| [a11y-audit-2026-08.md](a11y-audit-2026-08.md) | The August 2026 accessibility audit for #1225: method, the five defect classes found, what the tooling could not check, and what declaring conformance would take. |
 | [qa-checklist.md](qa-checklist.md) | Release / pre-conference Go/No-Go audit using the repo's own tooling. |
 | [i18n.md](i18n.md) | Translation model (EN source + FR/DE), the drift checker, the beta ribbon. |
 | [search.md](search.md) | Pagefind search: deploy-time index, bio stubs, why local search is "unavailable". |

--- a/docs/a11y-audit-2026-08.md
+++ b/docs/a11y-audit-2026-08.md
@@ -1,0 +1,142 @@
+# Accessibility audit — August 2026
+
+Working record for [#1225](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1225)
+(*Reach full accessibility conformance and declare against RGAA*).
+
+**Outcome: the site is not conformant, and the declaration in
+`src/accessibility.njk` §7 should stay at partial conformance.** The audit
+found five defect classes beyond the Atlas barrier the issue already knew
+about. None is expensive to fix. The Atlas barrier is.
+
+---
+
+## Method
+
+| | |
+|---|---|
+| **Date** | 18 August 2026 |
+| **Referential** | WCAG 2.1 AA, EN 301 549, RGAA 4.1 |
+| **Tooling** | axe-core 4.13.0 driven over jsdom by `axe-audit.mjs`, rules `wcag2a, wcag2aa, wcag21a, wcag21aa, best-practice`; `scripts/a11y_lint.py`; targeted `grep` over `_site/` to size each finding |
+| **Themes** | Every page tested twice, `data-theme="light"` and `data-theme="dark"` |
+| **Build** | `_site/` from `npx @11ty/eleventy`, 1378 files |
+
+**Pages sampled (16):** `/`, `/index.fr`, `/index.de`, `/anthology-atlas`,
+`/anthology`, `/papers`, `/board`, `/internship`, `/accessibility`, `/past`,
+`/2026`, `/blog`, `/news`, `/membership`, `/sitemap`, `/design-system`.
+
+Each axe finding was then counted across the whole build, so the numbers
+below are the real blast radius rather than the sample.
+
+### What this method cannot check
+
+Stated plainly, because an audit that hides its limits is worth little.
+
+- **Colour contrast.** jsdom has no layout or paint, so axe's `color-contrast`
+  rule cannot run. Contrast is therefore *unverified here*, not passed.
+- **Keyboard operation, focus order and focus visibility.** Not exercisable
+  in jsdom. The Atlas finding below comes from reading the markup, not from
+  driving it.
+- **Screen-reader behaviour.** No AT was run. RGAA expects at least one
+  assistive-technology pass before a conformance claim.
+
+A declaration of full conformance needs those three closed by a human, on a
+real browser, with a real screen reader.
+
+---
+
+## Findings
+
+### 1. Atlas: no accessible equivalent, not keyboard-operable — blocker
+
+`/anthology-atlas.html` draws the whole corpus into a `<canvas>`. The canvas
+carries a long `aria-label` describing the map and pointing at the Anthology
+list view. **There is no `tabindex` anywhere on the page**, so neither the
+map nor its controls can be reached or operated from the keyboard.
+
+This is the barrier #1225 was opened for, and #1155 closed as a mitigation
+rather than an equivalent. Nothing has changed. WCAG 2.1.1 (Keyboard) and
+1.1.1 (Non-text Content); RGAA 4.1 topics 1 and 7.
+
+**Affected:** `/anthology-atlas` and the 17 per-theme Atlas pages.
+
+### 2. Beta ribbon sits outside every landmark — 132 pages
+
+```html
+<div class="beta-ribbon" role="note" aria-label="Traduction bêta — la version anglaise fait foi.">
+```
+
+It renders before `<header>`, so its content belongs to no landmark. axe
+`region`, moderate. Every French and German page carries it, which is why
+this is the widest finding on the site. English pages pass.
+
+### 3. `aria-label` on elements with no role — 21 pages
+
+`aria-label` is ignored on a generic element. Two instances:
+
+- `<div class="atlas-stats" id="atlas-stats" aria-label="Anthology statistics">` — 18 pages
+- `<span class="coverage-tip" tabindex="0" aria-label="292 of 492 eligible …">` — 3 pages
+
+axe `aria-prohibited-attr`, serious. The stats strip is the readable fallback
+the Atlas mitigation depends on, so this one bites twice.
+
+### 4. `<ol role="list">` containing an `<h2>` — 3 pages
+
+```html
+<ol class="speaker-index" role="list" data-speaker-list>
+```
+
+An explicit `role="list"` forbids non-`listitem` children, and this one wraps
+an `<h2>`. axe `aria-required-children`, **critical**. The `role` is redundant
+on an `<ol>`, so deleting it is the whole fix.
+
+### 5. Timed `<meta http-equiv="refresh">` — 26 real pages
+
+```html
+<meta http-equiv="refresh" content="3;url=/anthology.html">
+```
+
+A three-second timed redirect fails WCAG 2.2.1 (Timing Adjustable) and 2.2.4
+(Interruptions) outright. It comes from the `redirectTo` branch in
+`base.njk`, used by the legacy Mobirise URLs and by renamed pages such as
+`/papers` → `/anthology`.
+
+A further 138 hits are the Pagefind bio stubs under `search/`, which are
+`noindex` index shims rather than pages anyone navigates to. They are
+excluded from the count above, and should still be looked at.
+
+---
+
+## What it would take to declare conformance
+
+1. Build the Atlas equivalent and make the map keyboard-operable, including
+   `atlas-tour.js`. This is the effort-L item in #1225 and everything else
+   is small beside it.
+2. Fix findings 2 to 5. Each is a few lines: move the ribbon inside a
+   landmark, give the two labelled elements a role or drop the label, delete
+   one redundant `role="list"`, replace the timed refresh with a link plus a
+   server-side redirect.
+3. Re-run this audit, then close the three gaps the method cannot reach:
+   contrast in a real browser, keyboard and focus by hand, one screen-reader
+   pass.
+4. Only then rewrite §7 and add the RGAA 4.1 declaration, which must carry
+   the audit date, the technologies, the test environment, the sample, the
+   contact route and the escalation route to the Défenseur des droits.
+
+Steps 1 to 3 are the work. Step 4 is paperwork, and doing it before the
+others would put a false statement on a public page, in a jurisdiction where
+that statement is a legal one.
+
+## Reproducing
+
+`axe-audit.mjs` at the repo root, run with the page list as arguments. It
+needs `axe-core` and `jsdom`, installed with `--no-save` so neither joins
+`package.json`:
+
+```
+npm install --no-save axe-core jsdom
+npx @11ty/eleventy
+node ./axe-audit.mjs index.html anthology-atlas.html anthology.html papers.html
+```
+
+Results land in `/tmp/axe-results.json` with the failing selector and reason
+per finding.


### PR DESCRIPTION
The audit for #1225, run with axe-core 4.13.0 as the issue specifies.

**The audit does not satisfy #1225, and says so.** It is the evidence that the milestone item cannot close yet, plus an exact list of what stands between here and a conformance claim.

## Headline

**The declaration in `src/accessibility.njk` §7 should stay at partial conformance.** Flipping it now would put a false accessibility statement on a public page, in the jurisdiction where that statement is a legal one.

Five defect classes turned up beyond the Atlas barrier the issue already described. Every page was tested twice, light and dark, and each finding was then counted across the whole build rather than the 16-page sample.

| # | Finding | axe rule | Impact | Pages |
|---|---|---|---|---|
| 1 | Atlas: no accessible equivalent, **no `tabindex` anywhere** | — | blocker | 18 |
| 2 | Beta ribbon outside every landmark | `region` | moderate | **132** |
| 3 | `aria-label` on a roleless `div` / `span` | `aria-prohibited-attr` | serious | 21 |
| 4 | `<ol role="list">` wrapping an `<h2>` | `aria-required-children` | **critical** | 3 |
| 5 | Timed `<meta http-equiv="refresh">` | `meta-refresh` | **critical** | 26 |

Finding 1 is the one #1225 exists for, and it is unchanged since #1155 closed as a mitigation. The canvas carries a descriptive `aria-label` pointing at a different page, and the page has no focusable element at all, so the map is not keyboard-operable.

Finding 3 bites twice: one of the two instances is `#atlas-stats`, the readable strip the Atlas mitigation leans on.

Findings 2 to 5 are all a few lines each.

## What the tooling could not check

Stated in the document rather than glossed, because this is what separates an audit from a green tick:

- **Colour contrast** — jsdom has no layout or paint, so axe's `color-contrast` rule cannot run. Contrast is unverified, not passed.
- **Keyboard operation, focus order, focus visibility** — not exercisable in jsdom. The Atlas finding comes from reading the markup.
- **Screen-reader behaviour** — no AT was run. RGAA expects at least one pass before a conformance claim.

Those three need a human in a real browser. `scripts/a11y_lint.py` still reports 0 issues across 586 pages, which is worth knowing for what it is: it checks landmarks, `lang`, headings and labels, and it does not check any of the five findings above.

## What is in the PR

- `docs/a11y-audit-2026-08.md` — method, RGAA-shaped metadata (date, referential, tooling, environment, sample), the findings with failing selectors, the limits, and the four steps to a defensible declaration.
- `axe-audit.mjs` — the harness, committed so the run is repeatable rather than a thing I did once. `axe-core` and `jsdom` install with `--no-save` and stay out of `package.json`, per §16's no-new-dependency rule.
- A row in `docs/README.md`.

Docs plus a dev script, nothing user-visible, no CHANGELOG bullet per §4.

## Suggested next step

Findings 2 to 5 are one small PR, mostly in shared includes. Finding 1 is the effort-L piece and the real content of #1225. Say the word and I will take the four small ones first, since they are cheap and independent of the Atlas work.

**Found in passing:** three Finder duplicates (`src/funding 2.njk`, `.fr 2`, `.de 2`) had appeared in the working tree and broke the local build with a `DuplicatePermalinkOutputError`. `.gitignore` stops them being committed but Eleventy still reads them. Deleted locally. Adding `* [0-9].*` to `.eleventyignore` would stop this class breaking builds, which I have not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)