### PR TITLE
Release prep for v2.27.0: the site map, and the docs index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,8 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ### Changed
 
+- **The Anthology Atlas is listed on the site map.** `/sitemap.html` and its French and German siblings carried a line for the Anthology and none for the map of it, so the one page in this release a reader is most likely to want to find was reachable from the navigation and the Anthology header but not from the inventory that claims to list everything. The French and German entries flag that the Atlas itself is in English.
+
 - **The Atlas card on the Anthology says what the map is for, instead of repeating the stats above it.** Its sub-line read "511 papers · 494 authors · 17 research themes, mapped", three numbers the stats row directly above already shows. It now reads "Visualise the data and identify connections between authors and clusters", which is what the Atlas actually offers a reader deciding whether to open it. The French and German lines are hand-translated and both keep the note that the Atlas itself is in English, and both are a line shorter on a phone than the counts they replace.
 
 - **The Anthology's "Cite this corpus" panel now carries all three deposits, not just the DOI.** Beside the Zenodo DOI it lists the corpus-description note in HAL (`hal-05711925`) and the Software Heritage archive of the code that builds the corpus (`swh:1:dir:482a1c8…`), each on the same row treatment so the three read as one list. The SWHID moved into `site.corpus` in `_data/site.js`, where the DOI and the HAL identifier already live, so `/licensing` and the Anthology now quote one recorded value rather than a literal repeated in four templates.

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -102,14 +102,14 @@
     "src/sitemap.njk": {
       "fr": {
         "file": "src/sitemap.fr.njk",
-        "source_sha1": "59c77c86206d3a2cef52293a6ad78c7d9e9ef8b1",
-        "translated_on": "2026-08-18",
+        "source_sha1": "4acc349c7645d42d7e60c791dc94525557c51c0a",
+        "translated_on": "2026-08-19",
         "status": "beta"
       },
       "de": {
         "file": "src/sitemap.de.njk",
-        "source_sha1": "59c77c86206d3a2cef52293a6ad78c7d9e9ef8b1",
-        "translated_on": "2026-08-18",
+        "source_sha1": "4acc349c7645d42d7e60c791dc94525557c51c0a",
+        "translated_on": "2026-08-19",
         "status": "beta"
       }
     },

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,15 +7,18 @@ Maintainer-facing docs for [eiss-europa.com](https://eiss-europa.com)
 | Doc | What it covers |
 |---|---|
 | [architecture.md](architecture.md) | Build pipeline, data sources, sync jobs, CI gates, deploy — the data-flow map. |
+| [admin-guide.md](admin-guide.md) | Operator and handover guide: who holds what access, what runs unattended, and what a successor needs on day one. |
 | [design-system.md](design-system.md) | UI components and interaction patterns (the `.njk` partials + their CSS/JS). |
 | [a11y-audit-2026-08.md](a11y-audit-2026-08.md) | The August 2026 accessibility audit for #1225: method, the five defect classes found, what the tooling could not check, and what declaring conformance would take. |
 | [qa-checklist.md](qa-checklist.md) | Release / pre-conference Go/No-Go audit using the repo's own tooling. |
+| [qa-audit-2026-06.md](qa-audit-2026-06.md) | The June 2026 site-wide QA audit across seven dimensions: method, the 19 confirmed findings, and what each one turned into. |
 | [i18n.md](i18n.md) | Translation model (EN source + FR/DE), the drift checker, the beta ribbon. |
 | [search.md](search.md) | Pagefind search: deploy-time index, bio stubs, why local search is "unavailable". |
 | [board-bios-setup.md](board-bios-setup.md) | The Form → `board.json` → board page bios pipeline. |
 | [indico-programme-integration.md](indico-programme-integration.md) | The live ESSC programme grid from the Indico sync. |
 | [indico-api-token.md](indico-api-token.md) | Indico API token setup for the authenticated sync. |
 | [new-conference.md](new-conference.md) | Per-year-page rollover procedure for a new ESSC. |
+| [news-publishing.md](news-publishing.md) | The News surface: the homepage "Latest" section, the `/news` archive, the Atom feed, and how an item gets added. |
 | [publication-matching.md](publication-matching.md) | Linking ESSC papers to their later-published versions: the matcher, the review queue, the confirm step, the monthly sync. |
 | [anthology-corpus-note.md](anthology-corpus-note.md) | The public corpus-description note: scope, sources, the theme vocabulary, co-authorship, coverage, limitations. Drafted for deposit. |
 | [corpus-archiving.md](corpus-archiving.md) | Depositing the Anthology outside the repo: the Zenodo concept vs version DOI, where the DOI surfaces, the versioning cadence, HAL. |

--- a/src/sitemap.de.njk
+++ b/src/sitemap.de.njk
@@ -41,6 +41,7 @@ alternates:
         <li><a href="/2017.html">EISS 2017 — Paris (Eröffnung)</a></li>
         <li><a href="/past.de.html">Alle vergangenen Konferenzen</a></li>
         <li><a href="/anthology.de.html">Die Anthologie der europäischen Sicherheitsstudien</a> — Vortragende und Beiträge aller Ausgaben</li>
+        <li><a href="/anthology-atlas.html" hreflang="en">Anthologie-Atlas</a> — dasselbe Korpus als Karte der Themen und Autor:innen (auf Englisch)</li>
       </ul>
 
       <h2>Aktivitäten</h2>

--- a/src/sitemap.fr.njk
+++ b/src/sitemap.fr.njk
@@ -41,6 +41,7 @@ alternates:
         <li><a href="/2017.html">EISS 2017 — Paris (inaugurale)</a></li>
         <li><a href="/past.fr.html">Toutes les conférences passées</a></li>
         <li><a href="/anthology.fr.html">L'Anthologie des études de sécurité européennes</a> — intervenants et communications de toutes les éditions</li>
+        <li><a href="/anthology-atlas.html" hreflang="en">Atlas de l'Anthologie</a> — le même corpus sous forme de carte des thèmes et des auteurs (en anglais)</li>
       </ul>
 
       <h2>Activités</h2>

--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -40,6 +40,7 @@ alternates:
         <li><a href="/2017.html">EISS 2017 — Paris (inaugural)</a></li>
         <li><a href="/past.html">All past conferences</a></li>
         <li><a href="/anthology.html">The European Security Studies Anthology</a> — speakers &amp; papers across all editions</li>
+        <li><a href="/anthology-atlas.html">Anthology Atlas</a> — the same corpus as a map of themes and authors</li>
       </ul>
 
       <h2>Activities</h2>


### PR DESCRIPTION
Closing the gaps the §5 release cross-check turned up, so v2.27.0 can be cut.

## The site map missed the Atlas

`/sitemap.html` and its French and German siblings carried a line for the Anthology and none for the map of it. The Atlas is the page this release leads with, reachable from the nav and the Anthology header but absent from the inventory that claims to list every page. The XML sitemap was fine throughout: it generates from `collections.all`, so it has had the Atlas since the day it shipped. The visual one is hand-curated, which is exactly why it drifted.

The French and German entries carry `hreflang="en"` and say the Atlas itself is in English, matching how the Atlas card on the Anthology handles the same fact.

## Three docs were never indexed

`docs/README.md` is the index for `docs/`, and `admin-guide.md`, `news-publishing.md` and `qa-audit-2026-06.md` had never been added. Each now has a row, placed by subject rather than appended.

## Milestone hygiene

The two issues still open on the v2.27.0 milestone are reslipped to v2.28.0, each with a one-line reason in its thread: [#1225](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1225) (the RGAA conformance declaration, as distinct from the August audit fixes that did ship) and [#328](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/328) (joint-event programme pages, not started this cycle). **v2.27.0 now stands at 128 closed, 0 open.**

## Cross-check results for the record

| Surface | Result |
| --- | --- |
| Roadmap | `flip-roadmap-card.mjs v2.27.0` dry-runs clean, would stamp 19 August with 82 changes |
| Sitemap | XML generated and complete, visual one fixed here |
| Translations | Zero drift |
| Repo docs | Updated inline through the cycle, index fixed here |
| Abstract coverage | 0 stranded across 8 years, 48 panel-level or confirmed-absent correctly excluded |

Once this is in, the cut is `scripts/release.sh 2.27.0 "The Anthology Atlas and the recovered back catalogue"`.