### PR TITLE
Release v2.27.0 — The Anthology Atlas and the recovered back catalogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,10 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [2.27.0] · 2026-08-19 — The Anthology Atlas and the recovered back catalogue
+
 This release turns the Anthology from a list you read into a corpus you can explore, cite and download. The Atlas maps the whole thing as a network you can filter, search and link into, each of the 17 research themes gains a page and a feed of its own, and the corpus is now deposited with a DOI, described in HAL and archived in Software Heritage. Alongside that, EISS 2026 abstract coverage reaches every paper, recovery of the pre-Indico back catalogue begins, and volunteers get somewhere to publish under their own names.
 
 ### The Anthology Atlas
@@ -1300,7 +1304,8 @@ Preview MCP screenshots of `/index.fr.html`, `/index.de.html`, `/initiative.de.h
 
 *Originally tagged as **v2.0.0**; renumbered to **v2.0.0r** in the v2.13.0r retroactive cleanup so the SemVer signal matches the actual scope of the change.*
 
-[Unreleased]: https://github.com/EISSeuropa/EISSeuropa.github.io/compare/v2.26.0...HEAD
+[Unreleased]: https://github.com/EISSeuropa/EISSeuropa.github.io/compare/v2.27.0...HEAD
+[2.27.0]: https://github.com/EISSeuropa/EISSeuropa.github.io/compare/v2.26.0...v2.27.0
 [2.26.0]: https://github.com/EISSeuropa/EISSeuropa.github.io/compare/v2.25.0...v2.26.0
 [2.25.0]: https://github.com/EISSeuropa/EISSeuropa.github.io/compare/v2.24.0...v2.25.0
 [2.24.0]: https://github.com/EISSeuropa/EISSeuropa.github.io/compare/v2.23.1...v2.24.0

--- a/src/_data/roadmap.js
+++ b/src/_data/roadmap.js
@@ -171,10 +171,11 @@ const roadmap = {
       },
       entries: [
         {
-          status: "planned",
+          status: "shipped",
           version: "v2.27.0",
-          milestone: "v2.27.0",
-          when: { en: "September 2026 · v2.27.0", fr: "septembre 2026 · v2.27.0", de: "September 2026 · v2.27.0" },
+          notesUrl: notes("v2.27.0"),
+          changes: 83,
+          when: { en: "19 August 2026 · v2.27.0", fr: "19 août 2026 · v2.27.0", de: "19. August 2026 · v2.27.0" },
           title: {
             en: "The Anthology Atlas and the recovered back catalogue",
             fr: "L’Atlas de l’Anthologie et les résumés retrouvés",


### PR DESCRIPTION
The v2.27.0 release commit, routed through a PR.

`scripts/release.sh` ran, took the confirmation, promoted the CHANGELOG and made the commit and the tag locally, then hit the repo's `pre-push` hook: *"refusing to push 'master' directly — work on a claude/\* branch + PR"*. Nothing reached the remote, so the cut is intact and simply needs a path that respects the guard. I reset the local master back to `origin/master` and cherry-picked the release commit here instead.

## What's in it

- **CHANGELOG**: `[Unreleased]` → `[2.27.0] · 2026-08-19`, and `[Unreleased]` reset to empty category headings. Byte-for-byte what `release.sh` produced.
- **Roadmap card**: `/roadmap.html` (+ FR + DE) flips v2.27.0 from *Planned* to *Shipped*, dated 19 August, with the notes link and a change count of 83.

## Two things worth knowing

**The change count needed passing by hand.** `flip-roadmap-card.mjs` derives it from `[Unreleased]`, which the release commit had already emptied, so an unqualified flip wrote `changes: 0`. Passing `--changes 83` gives the real figure (54 Added, 11 Changed, 18 Fixed).

**`release.sh` never offers the flip.** It calls `node scripts/flip-roadmap-card.mjs "$VERSION"` with the bare `2.27.0`, but the script's usage is `vX.Y.Z`, so it prints usage instead of a diff, the `grep -q 'would flip'` misses, and the prompt is skipped silently. That has been true for every release since the offer was added in #280. One-line fix, filed separately.

## After this merges

Tag `v2.27.0` on the merged commit, push the tag (the hook only guards branch refs), and publish the GitHub Release from the `[2.27.0]` section.