### PR TITLE
Atlas: stop trapping the desktop scroll, and answer when the map is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,16 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ### Fixed
 
+- **Scrolling past the Atlas works again on a desktop.** The wheel zoom that shipped with the map claimed every wheel event over the canvas, so a trackpad flick that happened to cross 640px of map zoomed it instead of scrolling the page, which is the desktop version of the phone scroll trap fixed earlier in this release. Zooming now needs ctrl or command held, which is also what a trackpad pinch sends, so pinching behaves as it reads. A plain scroll belongs to the page again, and the buttons on the map cover anyone who would rather not use a modifier. The legend now says so.
+
+- **An Atlas filtered down to nothing now says what happened.** Switching off every edition, or every research theme, left a blank rectangle where the map had been and no account of why. The stage now carries a short message naming which set of chips emptied the map and what to do about it, in both lenses.
+
+- **A search on the Atlas that finds nothing now says so.** Typing a name the corpus does not hold, or one the current filters are hiding, moved nothing on the map and reported nothing either, which reads as a broken control. The Find box now answers in both cases, and the paper hidden by a filter is distinguished from the paper that is not there at all.
+
+- **The Atlas failure message is back where the reader can see it.** When the map's data cannot be loaded the page used to say so in the corpus figures, which moved below the map earlier in this release, leaving the notice under an empty stage and off the fold. The message is now drawn on the stage itself, where the map should have been, and points at the Anthology as the way to browse the same papers.
+
+- **The Atlas zoom buttons are big enough for a thumb.** They were sized for a cursor at 34px square, and are now 42px on a touchscreen, where they matter most.
+
 - **A tap on the Atlas no longer navigates away before the reader has seen what they tapped.** Touch has no hover, so the card that tells you what a dot is appeared for the single frame between a tap landing and the browser leaving for the paper page, and with a hit radius sized for a mouse cursor the paper that opened was often not the one aimed at. On a touchscreen the first tap now pins the card, which becomes tappable and carries the paper's link, and a second tap on the same dot follows it. The hit radius is wider on a touchscreen, and zooming in (new in this release) narrows it in map terms, which is what makes picking one dot out of a cluster possible. Closes [#1431](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1431).
 
 - **The Atlas hover card no longer parks itself on top of the dot it describes.** Near the right-hand edge of the map the card stopped following the pointer and clamped, which put it over the dot the reader was pointing at and its neighbours. It now flips to the left of the pointer, the same treatment the bottom edge got in the previous fix. Part of [#1434](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1434).

--- a/src/_includes/atlas-body.njk
+++ b/src/_includes/atlas-body.njk
@@ -104,6 +104,9 @@
     <label class="lbl" for="atlas-find">Find</label>
     <input class="atlas-find" id="atlas-find" type="search" list="atlas-find-list" placeholder="Author or paper title" autocomplete="off" spellcheck="false">
     <datalist id="atlas-find-list"><!-- options injected by anthology-atlas.js (#1154) --></datalist>
+    {# Typing a name that is not in the corpus, or one the current filters
+       hide, used to do nothing at all. #}
+    <span class="atlas-find__msg" id="atlas-find-msg" role="status"></span>
   </div>
 
   {# Filter rows (#1191). A native <details>, open in the markup so the
@@ -149,6 +152,7 @@
     <span><span class="sw sw-ring sw-prize"></span>Best Paper Prize</span>
     <span><span class="sw sw-pub"></span>published version on record</span>
     <span>drag a theme hub to rearrange the map</span>
+    <span>pinch or ctrl-scroll to zoom, or use the buttons on the map</span>
   </div>
   <div class="atlas-legend" id="atlas-legend-authors" hidden>
     <span><span class="sw sw-collab"></span>author with a co-author</span>
@@ -156,6 +160,7 @@
     <span><span class="sw sw-coauthor"></span>co-authored a paper together</span>
     <span>dot size scales with paper count</span>
     <span>drag a theme hub to rearrange the map</span>
+    <span>pinch or ctrl-scroll to zoom, or use the buttons on the map</span>
   </div>
 
   {# The corpus figures read as context for the map, so they sit under it

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -7525,6 +7525,9 @@ a.profile-pub-title:hover { text-decoration: underline; }
   min-width: min(260px, 100%);
 }
 .atlas-find:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.atlas-find[aria-invalid="true"] { border-color: var(--warning); }
+.atlas-find__msg { font-size: .78rem; color: var(--text-muted); }
+.atlas-find__msg:empty { display: none; }
 .atlas-stage { position: relative; border-radius: var(--radius-lg); overflow: hidden; background: radial-gradient(120% 90% at 50% 0%, var(--accent-soft), transparent 60%), var(--bg-elev); border: 1px solid var(--border); }
 /* `touch-action: none` was here for hub dragging, and it made the map a
    scroll trap on phones: a 480px-tall canvas that neither scrolled the page
@@ -7563,6 +7566,11 @@ a.profile-pub-title:hover { text-decoration: underline; }
 .atlas-zoom__b:disabled { opacity: .4; cursor: default; }
 .atlas-zoom__b:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .atlas-zoom__reset { font-size: .78rem; letter-spacing: .04em; text-transform: uppercase; }
+/* A fingertip wants more than the 34px a cursor is happy with, and the reader
+   who most needs these buttons is the one on a phone. */
+@media (pointer: coarse) {
+  .atlas-zoom__b { min-width: 42px; height: 42px; }
+}
 .atlas-zoom__b[hidden] { display: none; }
 .atlas-card .nm { font-weight: 600; color: var(--text); font-size: var(--fs-sm); line-height: var(--lh-snug); }
 .atlas-card .meta { font-size: .8rem; color: var(--text-muted); margin-top: 3px; }

--- a/src/assets/js/anthology-atlas.js
+++ b/src/assets/js/anthology-atlas.js
@@ -33,6 +33,7 @@
   const paperOptsEl = document.getElementById('atlas-paperopts');
   const findEl = document.getElementById('atlas-find');
   const findListEl = document.getElementById('atlas-find-list');
+  const findMsgEl = document.getElementById('atlas-find-msg');
   const filtersEl = document.getElementById('atlas-filters');
   const filtersSummaryEl = document.getElementById('atlas-filters-summary');
   const legendPapers = document.getElementById('atlas-legend');
@@ -132,6 +133,7 @@
   // Touch (#1431): there is no hover, so the first tap on a node pins its card
   // and the second follows the link.
   let pinned = null;
+  let loadFailed = false;          // the fetch failed, so the stage says so
   const coarse = !!(window.matchMedia && window.matchMedia('(pointer: coarse)').matches);
   let spotlight = null;            // node pinned by the Find control (#1154)
   let spotlightSet = null;         // {ids:Set, label:string} pinned by an author click (#1190)
@@ -256,11 +258,40 @@
   }
 
   // ── Paint ──
+  // A message painted across the middle of the stage, in screen space, for
+  // the states where the map itself has nothing to say: every edition or
+  // every theme toggled off, or the data failing to load. Without it the
+  // reader gets a blank rectangle and no account of why.
+  function drawNotice(title, hint) {
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = theme.ink;
+    ctx.font = '600 15px system-ui, -apple-system, Segoe UI, sans-serif';
+    ctx.fillText(title, W / 2, H / 2 - 10);
+    if (hint) {
+      ctx.fillStyle = theme.muted;
+      ctx.font = '13px system-ui, -apple-system, Segoe UI, sans-serif';
+      ctx.fillText(hint, W / 2, H / 2 + 14);
+    }
+    ctx.textAlign = 'start';
+    ctx.textBaseline = 'alphabetic';
+  }
+
   function draw() {
     // Clear in screen space, then paint in world space (#1433). Everything
     // below this line keeps working in the layout's own coordinates.
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     ctx.clearRect(0, 0, W, H);
+    if (loadFailed) { drawNotice('The atlas data could not be loaded.', 'Every paper and author on this map is browsable in the Anthology.'); return; }
+    // Nothing passes the filters: say so rather than showing a blank stage.
+    if (items().length && !items().some(nodeVisible)) {
+      drawNotice(lens === 'authors' ? 'No authors match these filters.' : 'No papers match these filters.',
+        activeEditions.size === 0 ? 'Every edition is switched off. Turn one back on to see the map.'
+          : activeHubs.size === 0 ? 'Every research theme is switched off. Turn one back on to see the map.'
+            : 'Widen the editions or themes above to bring the map back.');
+      return;
+    }
     ctx.setTransform(dpr * view.k, 0, 0, dpr * view.k, dpr * view.x, dpr * view.y);
     // Focus = the hovered node, falling back to the Find spotlight (#1154):
     // both light the same neighbourhood and dim the rest.
@@ -712,9 +743,14 @@
     }
   });
 
-  // Wheel zoom about the cursor (#1433). Passive:false because a zoom over
-  // the map must not also scroll the page past it.
+  // Wheel zoom about the cursor, held behind a modifier. An unconditional
+  // preventDefault here turned 640px of the page into a desktop scroll trap:
+  // a trackpad flick that happened to cross the map zoomed it instead of
+  // scrolling past it, which is the same complaint as the phone trap the
+  // touch-action fix cured. A trackpad pinch arrives as ctrlKey, so pinching
+  // works as it reads, and the buttons cover everyone else.
   canvas.addEventListener('wheel', (e) => {
+    if (!e.ctrlKey && !e.metaKey) return; // plain scroll belongs to the page
     e.preventDefault();
     const r = canvas.getBoundingClientRect();
     zoomTo(view.k * Math.exp(-e.deltaY * 0.0015), e.clientX - r.left, e.clientY - r.top);
@@ -891,10 +927,27 @@
       || null;
   }
 
+  // Say what happened. A search that matches nothing, or matches a paper the
+  // current filters are hiding, reads as a broken control otherwise: the map
+  // simply does not move.
+  function setFindMsg(text) {
+    if (!findMsgEl) return;
+    findMsgEl.textContent = text || '';
+    findMsgEl.hidden = !text;
+    if (findEl) {
+      if (text) findEl.setAttribute('aria-invalid', 'true');
+      else findEl.removeAttribute('aria-invalid');
+    }
+  }
+
   function applyFind(q) {
     const node = resolveFind(q);
     spotlight = node;
     spotlightSet = null; // an explicit Find supersedes a pinned author
+    if (!String(q || '').trim()) setFindMsg('');
+    else if (!node) setFindMsg('No match in the corpus.');
+    else if (!nodeVisible(node)) setFindMsg('Found, but hidden by the current filters.');
+    else setFindMsg('');
     if (node) {
       const wantLens = node.type === 'author' ? 'authors' : 'papers';
       if (lens !== wantLens) { switchLens(wantLens); return; } // switchLens syncs + draws
@@ -1107,6 +1160,7 @@
         findEl.addEventListener('change', () => applyFind(findEl.value));
         findEl.addEventListener('keydown', (e) => { if (e.key === 'Enter') applyFind(findEl.value); });
         findEl.addEventListener('input', () => {
+          setFindMsg('');
           if (!findEl.value.trim() && (spotlight || spotlightSet)) {
             spotlight = null; spotlightSet = null; syncUrl(); draw();
           }
@@ -1121,7 +1175,16 @@
         } else if (urlFind) { findEl.value = urlFind; applyFind(urlFind); }
       }
     })
-    .catch(() => { statsEl.textContent = 'The atlas data could not be loaded.'; });
+    .catch(() => {
+      // The corpus figures moved below the map in #1430, so a failure message
+      // dropped in there would sit under an empty stage, off the fold. It
+      // belongs where the map should have been.
+      loadFailed = true;
+      statsEl.textContent = '';
+      readTheme();  // the success path reads the tokens; this path never got there
+      resize();
+      draw();
+    });
 
   window.addEventListener('resize', () => {
     resize(); seedPositions(); clampView(); reheat(140);


### PR DESCRIPTION
A second UX pass over the Atlas, after #1437. Mostly states that said nothing at all.

### The regression first

**The wheel zoom from #1437 was a desktop scroll trap.** It called `preventDefault()` on every wheel event over the canvas, so a trackpad flick that happened to cross 640px of map zoomed the map instead of scrolling the page. That is the same complaint as the phone `touch-action` trap fixed in #1428, arriving by the other door, and I introduced it. Zooming now needs ctrl or command held. A trackpad pinch sends `ctrlKey`, so pinch-to-zoom behaves as it reads, the buttons on the map cover anyone who would rather not hold a key, and the legend now mentions both.

### States that said nothing

- **Filtered down to nothing.** Switching off every edition, or every theme, left a blank rectangle. The stage now carries a message naming which set of chips emptied the map, in both lenses. (Isolating one edition currently means clicking eleven chips off, which is how I found this. Filed separately.)
- **A search with no match.** Typing a name the corpus does not hold moved nothing and said nothing. The Find box now answers, and distinguishes a paper that is hidden by the current filters from one that is not in the corpus at all. `aria-invalid` on the input, `role="status"` on the message.
- **A data-load failure.** The message lived in the corpus figures, which #1437 moved below the map, so a failed load showed an empty stage with the explanation somewhere below the fold. It now paints on the stage and points at the Anthology.

### Smaller

Zoom buttons go from 34px to 42px under `(pointer: coarse)`.

### Verification

At 1280×900 and 375×812, in the browser:

- A plain wheel over the canvas is no longer `defaultPrevented`; a ctrl-wheel still zooms.
- With every edition off, the canvas paints exactly two lines of text at the centre and nothing anywhere else; spying on `fillText` confirms the wording differs correctly for the no-editions and no-themes causes.
- Find reports "No match in the corpus." with `aria-invalid`, reports "Found, but hidden by the current filters." for a real author outside the active editions, and clears on input.
- Removing `anthology-atlas.json` from the served build paints the failure notice on the stage and leaves the stats row empty.
- Zoom buttons measure 42×42 under a coarse pointer, and Reset stays hidden until there is something to reset.
- `check-build-sanity.mjs` passes (including the undefined-class gate for `.atlas-find__msg`), `check-i18n-drift.py` clean.

Further findings from this pass are filed rather than fixed: #1442 (isolating one edition takes eleven clicks), #1444 (the welcome strip is now what stands between a first visit and the map), #1445 (a filtered view is shareable but unadvertised), #1446 (the map cannot be explored from the keyboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)