### PR TITLE
Atlas: All and None on the chip rows, and a live region for the map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,12 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ## [Unreleased]
 
+### Added
+
+- **The Atlas chip rows have All and None, and a filtered view has a way out.** Every edition and theme chip starts switched on, so isolating a single edition meant switching off the other eleven by hand, and a single theme meant sixteen. Each row now leads with All and None, so it takes two presses, and the filter summary carries a Clear action whenever anything is filtering. The summary is the only filter control visible while the rows are collapsed, which is where a reader who has filtered the map down to nothing goes looking. Closes [#1442](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1442).
+
+- **The Atlas tells a screen reader what the map just did.** The card pinned by a tap is a canvas overlay that nothing announced, and a search that landed on a paper moved the map silently. Both now speak through a polite live region, alongside the Find messages added earlier in this release. Part of [#1446](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1446), whose remaining half is a keyboard path into the map itself.
+
 ### Changed
 
 - **The Atlas map now opens on the map.** The top edge of the canvas sat at y=1074 on a 1280x900 desktop and y=1275 on a 375px phone, so the page a reader landed on was a column of filter chips with the map somewhere below it. The filter rows now start collapsed at every width, not just on phones, with the active-filter count on the disclosure summary, and the corpus figures have moved below the map, where they read as context rather than as a control. The map top is now at y=501 on that desktop and y=679 on that phone. The guided tour opens the filters for itself, so its editions and themes steps still have something to point at. Closes [#1430](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1430).

--- a/src/_includes/atlas-body.njk
+++ b/src/_includes/atlas-body.njk
@@ -115,16 +115,31 @@
      otherwise push the map below the fold. The summary is hidden on
      desktop by CSS. #}
   <details class="atlas-filters" id="atlas-filters" open>
-    <summary class="atlas-filters__summary" id="atlas-filters-summary">Filters</summary>
+    {# The label is its own element so the active-filter count can be rewritten
+       without taking the Clear button with it. Clear only appears once
+       something is actually filtering (#1442). #}
+    <summary class="atlas-filters__summary" id="atlas-filters-summary">
+      <span id="atlas-filters-label">Filters</span>
+      <button class="atlas-filters__clear" type="button" id="atlas-filters-clear" hidden>Clear</button>
+    </summary>
     <div class="atlas-controls" id="atlas-years" role="group" aria-label="Filter by edition year">
       <span class="lbl">Editions</span>
+      {# Every chip starts on, so isolating one edition meant switching off the
+         other eleven by hand (#1442). These two do it in one press. #}
+      <span class="atlas-bulk" id="atlas-years-bulk"><!-- All / None injected by anthology-atlas.js --></span>
       <!-- year chips injected by anthology-atlas.js -->
     </div>
     <div class="atlas-controls" id="atlas-themes" role="group" aria-label="Spotlight a research theme">
       <span class="lbl">Themes</span>
+      <span class="atlas-bulk" id="atlas-themes-bulk"><!-- All / None injected by anthology-atlas.js --></span>
       <!-- theme hub chips injected by anthology-atlas.js -->
     </div>
   </details>
+
+  {# Announcements for anyone who cannot see the map move: the card pinned by
+     a tap, and the node a search lands on (#1446). Visually hidden, so it
+     costs the sighted reader nothing. #}
+  <p class="sr-only" role="status" id="atlas-live"></p>
 
   <div class="atlas-stage">
     {# Zoom cluster (#1433). The map holds around a thousand dots in 640px of

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -7513,6 +7513,21 @@ a.profile-pub-title:hover { text-decoration: underline; }
   border-bottom: 1px solid var(--border);
 }
 .atlas-filters__summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+/* The summary is a flex row so the Clear action can sit beside the count
+   rather than under the marker (#1442). */
+.atlas-filters__summary { display: flex; align-items: center; gap: 10px; }
+.atlas-filters__clear {
+  font: inherit; font-size: .72rem; font-weight: 700;
+  letter-spacing: .06em; text-transform: uppercase;
+  padding: 3px 10px; border-radius: var(--radius-full); cursor: pointer;
+  background: transparent; color: var(--accent);
+  border: 1px solid var(--accent);
+}
+.atlas-filters__clear:hover { background: var(--accent-soft); }
+.atlas-filters__clear:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.atlas-filters__clear[hidden] { display: none; }
+/* All / None sit with the row's label, ahead of the chips they act on. */
+.atlas-bulk { display: inline-flex; gap: 6px; margin-right: 4px; }
 /* Find-and-spotlight input (#1154), shaped like the chips beside it. */
 .atlas-find {
   font: inherit;

--- a/src/assets/js/anthology-atlas.js
+++ b/src/assets/js/anthology-atlas.js
@@ -35,7 +35,11 @@
   const findListEl = document.getElementById('atlas-find-list');
   const findMsgEl = document.getElementById('atlas-find-msg');
   const filtersEl = document.getElementById('atlas-filters');
-  const filtersSummaryEl = document.getElementById('atlas-filters-summary');
+  const filtersSummaryEl = document.getElementById('atlas-filters-label') || document.getElementById('atlas-filters-summary');
+  const filtersClearEl = document.getElementById('atlas-filters-clear');
+  const yearsBulkEl = document.getElementById('atlas-years-bulk');
+  const themesBulkEl = document.getElementById('atlas-themes-bulk');
+  const liveEl = document.getElementById('atlas-live');
   const legendPapers = document.getElementById('atlas-legend');
   const legendAuthors = document.getElementById('atlas-legend-authors');
   // Welcome strip + guided-tour controls (#1134).
@@ -727,6 +731,8 @@
       hovered = n;
       card.classList.add('is-pinned');
       showCard(n, toScreenX(n.x), toScreenY(n.y));
+      // The card is a canvas overlay, so nothing announces it on its own.
+      announce(card.textContent.replace(/\s+/g, ' ').trim());
       draw();
       return;
     }
@@ -794,13 +800,20 @@
   // non-default state is written, so the bare URL stays canonical.
   // Filter disclosure summary (#1191): on phones the rows are collapsed, so
   // the summary has to say whether anything is filtering.
+  const bulkRefreshers = [];   // All/None buttons that follow the chip state (#1442)
+
   function updateFilterSummary() {
-    if (!filtersSummaryEl) return;
     const eds = activeEditions.size, ths = activeHubs.size;
     const all = eds === editions.length && ths === hubs.length;
-    filtersSummaryEl.textContent = all
-      ? 'Filters'
-      : 'Filters · ' + eds + '/' + editions.length + ' editions, ' + ths + '/' + hubs.length + ' themes';
+    if (filtersSummaryEl) {
+      filtersSummaryEl.textContent = all
+        ? 'Filters'
+        : 'Filters · ' + eds + '/' + editions.length + ' editions, ' + ths + '/' + hubs.length + ' themes';
+    }
+    // The summary is the only filter control visible while the rows are
+    // collapsed, so the way out of a filtered view belongs beside the count.
+    if (filtersClearEl) filtersClearEl.hidden = all;
+    bulkRefreshers.forEach((fn) => fn());
   }
 
   function syncUrl() {
@@ -853,6 +866,37 @@
     abstractsOnly = sp.get('abstracts') === '1';
     paperEdgesOn = sp.get('links') === '1';
     return sp.get('lens') === 'authors' ? 'authors' : null;
+  }
+
+  // "All" and "None" for a chip row (#1442). They reuse the plain chip style
+  // (no colour dot, no pressed state) because they name no series: they are
+  // actions, not a filter that can be on or off.
+  function buildBulk(host, apply, isAll, isNone) {
+    if (!host) return function () {};
+    const all = document.createElement('button');
+    const none = document.createElement('button');
+    [all, none].forEach((b) => { b.type = 'button'; b.className = 'atlas-chip is-plain'; });
+    all.textContent = 'All';
+    none.textContent = 'None';
+    const refresh = function () { all.disabled = isAll(); none.disabled = isNone(); };
+    all.addEventListener('click', () => { apply(true); refresh(); });
+    none.addEventListener('click', () => { apply(false); refresh(); });
+    host.append(all, none);
+    refresh();
+    return refresh;
+  }
+
+  // Every chip in a row set at once, with the pressed state on each button
+  // brought along, since the chips are the readable record of the filter.
+  function setAllChips(host, set, keys, on) {
+    if (on) keys.forEach((k) => set.add(k)); else set.clear();
+    if (host) {
+      host.querySelectorAll('.atlas-chip[aria-pressed]').forEach((b) => {
+        b.setAttribute('aria-pressed', on ? 'true' : 'false');
+      });
+    }
+    syncUrl();
+    draw();
   }
 
   function buildEditionChips() {
@@ -940,14 +984,29 @@
     }
   }
 
+  // Anyone who cannot see the map move gets told what happened (#1446). The
+  // region is polite, so it waits its turn rather than cutting across.
+  function announce(text) {
+    if (!liveEl) return;
+    liveEl.textContent = text || '';
+  }
+
   function applyFind(q) {
     const node = resolveFind(q);
     spotlight = node;
     spotlightSet = null; // an explicit Find supersedes a pinned author
-    if (!String(q || '').trim()) setFindMsg('');
-    else if (!node) setFindMsg('No match in the corpus.');
-    else if (!nodeVisible(node)) setFindMsg('Found, but hidden by the current filters.');
-    else setFindMsg('');
+    // The Find message is a status region of its own, so the failure paths
+    // announce through it and this one is cleared rather than left holding a
+    // stale spotlight.
+    if (!String(q || '').trim()) { setFindMsg(''); announce(''); }
+    else if (!node) { setFindMsg('No match in the corpus.'); announce(''); }
+    else if (!nodeVisible(node)) { setFindMsg('Found, but hidden by the current filters.'); announce(''); }
+    else {
+      setFindMsg('');
+      announce(node.type === 'author'
+        ? 'Spotlighting ' + node.name + ', ' + node.paperCount + (node.paperCount === 1 ? ' paper.' : ' papers.')
+        : 'Spotlighting ' + node.title + '.');
+    }
     if (node) {
       const wantLens = node.type === 'author' ? 'authors' : 'papers';
       if (lens !== wantLens) { switchLens(wantLens); return; } // switchLens syncs + draws
@@ -1136,6 +1195,27 @@
       buildStats();
       buildEditionChips();
       buildThemeChips();
+      bulkRefreshers.push(buildBulk(
+        yearsBulkEl,
+        (on) => setAllChips(yearsEl, activeEditions, editions.map((e) => e.key), on),
+        () => activeEditions.size === editions.length,
+        () => activeEditions.size === 0));
+      bulkRefreshers.push(buildBulk(
+        themesBulkEl,
+        (on) => setAllChips(themesEl, activeHubs, hubs.map((h) => h.id), on),
+        () => activeHubs.size === hubs.length,
+        () => activeHubs.size === 0));
+      if (filtersClearEl) {
+        filtersClearEl.addEventListener('click', (e) => {
+          // The button lives inside the <summary>, so its click would
+          // otherwise toggle the disclosure on the way up.
+          e.preventDefault();
+          e.stopPropagation();
+          setAllChips(yearsEl, activeEditions, editions.map((x) => x.key), true);
+          setAllChips(themesEl, activeHubs, hubs.map((h) => h.id), true);
+          announce('Filters cleared. The whole corpus is on the map.');
+        });
+      }
       buildLensChips();
       buildAuthorOpts();
       buildPaperOpts();


### PR DESCRIPTION
The pass offered at the end of the brainstorm: #1442 in full, and the first half of #1446.

Closes #1442.

### #1442 — isolating one edition took eleven clicks

Every edition and theme chip starts switched on, so narrowing to one edition meant switching off the other eleven by hand, and one theme meant sixteen. Two changes, both additive:

- **All / None at the head of each row.** Isolating an edition is now None then one chip. They reuse the existing plain chip style (no colour dot, no pressed state) because they name no series: they are actions, not filters. Each disables at its end of the range.
- **Clear on the filter summary**, appearing only once something is filtering. The summary already carries the active-filter count and is the only filter control visible while the rows are collapsed, so it is where a reader who has filtered the map down to nothing will look. The button sits inside the `<summary>`, so its click is stopped from toggling the disclosure on the way up.

What I did **not** do is the solo-on-click / modifier-to-add option from the brainstorm. It is the faster gesture, but it reinterprets what a plain chip click means, which drags in the welcome strip and the tour copy. Worth doing on its own if you want it, on top of this.

### #1446 — first half

A polite `role="status"` live region announces the card pinned by a tap (a canvas overlay that nothing announced before) and the node a search lands on. The remaining half of that issue, a real keyboard path into the map, stays open: the substantive option there is a visually-hidden, filter-synced list of the visible nodes, which also gives #1445 something to point at.

### Verification

At 1280×900 and 375×812:

- All and None move every chip's `aria-pressed` and the summary count with them; the buttons disable at the ends (All greyed when everything is on, None when nothing is).
- Isolating one edition is two presses, and the summary then reads "Filters · 1/12 editions, 18/18 themes".
- Clear restores all 12 editions and all 18 themes, hides itself, announces, and leaves the disclosure open, by pointer and by keyboard alike.
- The live region measures 1px, carries `role="status"`, receives a pinned card's text on a coarse pointer and "Spotlighting …" on a successful find, and is cleared rather than left stale when a find fails.
- `check-build-sanity.mjs` passes, including the undefined-class and cross-block collision gates for the new `atlas-bulk` and `atlas-filters__clear` classes. `check-i18n-drift.py` clean.

Not armed for auto-merge: new visible controls, so CLAUDE.md §2 wants an eye on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)