### PR TITLE
docs: open the ESSC 2027 prep cycle, with event-cycle milestones

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,11 +347,23 @@ work is this?". The set:
   (Indico write-API access, NetSec coordination, source research) or
   with no committed release. Mirrors the *Under watch* section of the
   roadmap.
+- **Event-cycle milestones**, added in August 2026 for the ESSC 2027
+  preparation: one per phase of a dated conference cycle, named
+  `<Event> <year>: <phase>` (*save the date*, *call for papers*,
+  *selection and notifications*, *programme and logistics*,
+  *conference*). The prep deadlines are set by the joint organising
+  group and do not land on the release cadence, so folding them into
+  version milestones would drag release dates around an external
+  calendar. NetSec runs the same five titles with the same due dates,
+  since it is one conference tracked in two repositories. Their phase
+  rows live in [`docs/roadmap-2026.md`](docs/roadmap-2026.md) beside
+  the release timeline.
 
 Due dates on the version milestones come from the roadmap timeline.
 When the roadmap shifts a planned release, **bump the milestone's due
 date in the same commit that updates the roadmap row**: they are two
-views of one schedule.
+views of one schedule. The same rule applies to the event milestones
+and their phase rows.
 
 Create a new version milestone when the roadmap gains a release row.
 Don't pre-create far-future majors.

--- a/docs/roadmap-2026.md
+++ b/docs/roadmap-2026.md
@@ -56,6 +56,27 @@ other way round, so this is where a new release first appears.
 
 (`v2.24.1` was planned as a pre-ESSC patch but the work grew into a feature-rich minor, so it shipped as the **v2.25.0** *Ready for Stockholm* release instead; the `v2.24.1` milestone is closed as superseded.)
 
+### ESSC 2027 preparation
+
+The next European Security Studies Conference is jointly organised
+with the COST Action NetSec and its host university. The joint
+organising group met in August 2026 and meets again on 7 September
+2026 to settle the panels and the roundtables. Dates and venue are
+confirmed at that meeting, and this repository carries two different
+placeholder editions until then (see issue #1522).
+
+The cycle runs on the organising group's calendar rather than the
+release cadence, so it carries five event milestones (CLAUDE.md §10),
+mirrored title for title on the NetSec side.
+
+| Due | Milestone | EISS-side work |
+| --- | --- | --- |
+| 30 Sep 2026 | *ESSC 2027: save the date* | The edition settled and entered in `conferences.js` (#1522) · the runbook's contradictory worked example fixed (#1523) |
+| 6 Nov 2026 | *ESSC 2027: call for papers* | The parked 2027 page activated (#1524) · the edition share cards generated (#1525) · the call published and announced (#1526) |
+| 31 Dec 2026 | *ESSC 2027: selection and notifications* | The prize jury confirmed and the terms published (#1527) |
+| 30 Apr 2027 | *ESSC 2027: programme and logistics* | Programme content once the accepted papers are known (#1528) |
+| 11 Jun 2027 | *ESSC 2027: conference* | The archive rollover and the abstract pull (#1529) |
+
 **Versioning rules**: see the *Versioning* section of
 [`README.md`](../README.md) for the canonical definition of MAJOR /
 MINOR / PATCH (the feature test, not size). `scripts/release.sh`


### PR DESCRIPTION
Mirrors the ESSC 2027 preparation cycle set up on the NetSec side (EISSeuropa/netsec.github.io#1576). One conference, two repositories, the same five milestone titles and due dates.

## What changed

**CLAUDE.md §10** allowed version-numbered milestones plus `Backlog — Under watch`. It now allows a third kind, event-cycle milestones, one per phase of a dated conference cycle. The prep deadlines are set by the joint organising group (save the date after the 7 September meeting, a call draft by the end of October, publication in early November, notifications by the end of December) and folding them into version milestones would drag release dates around an external calendar.

**docs/roadmap-2026.md** gains an *ESSC 2027 preparation* section in *At a glance*, with the EISS-side work behind each due date.

## Milestones and issues

| Due | Milestone | Issues |
| --- | --- | --- |
| 30 Sep 2026 | ESSC 2027: save the date | #1522, #1523 |
| 6 Nov 2026 | ESSC 2027: call for papers | #1524, #1525, #1526 |
| 31 Dec 2026 | ESSC 2027: selection and notifications | #1527 |
| 30 Apr 2027 | ESSC 2027: programme and logistics | #1528 |
| 11 Jun 2027 | ESSC 2027: conference | #1529 |

## Worth knowing

This repository currently describes two different 2027 editions. The parked `src/2027.njk` says 11 to 12 June 2027 at Stockholm University, copied from the 2026 page. The worked example in `docs/new-conference.md` says 23 to 24 June 2027 at the University of Amsterdam, spelled out across the `conferences.js` entry, the share-card entry and the archive metadata in three languages, which reads as settled rather than illustrative. Neither is confirmed. #1523 covers the runbook, #1522 covers the data once the September meeting settles the edition.

Nothing user-visible changes here, so no CHANGELOG entry and no preview review needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)