### PR TITLE
Link check: a cut TLS connection is unreachable, not broken

### DIFF
--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -308,12 +308,14 @@ def check_external(url, _retry=True, _attempt=1):
         with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
             return resp.status
 
-    def _again():
-        """Next timeout attempt, or the verdict once patience runs out."""
+    def _again(verdict="timeout"):
+        """Next attempt on the widening clock, or the verdict once patience
+        runs out. `verdict` distinguishes a host that never answered from one
+        that cut the connection, so the report can say which happened."""
         if _attempt < len(TIMEOUT_SCHEDULE):
             time.sleep(TIMEOUT_PAUSES[_attempt - 1])
             return check_external(url, _retry=_retry, _attempt=_attempt + 1)
-        return (url, "timeout")
+        return (url, verdict)
 
     try:
         return (url, _do(method, _make_ssl_ctx(verify=True)))
@@ -375,6 +377,17 @@ def check_external(url, _retry=True, _attempt=1):
                 return (url, _do(method, _make_ssl_ctx(verify=False)))
             except Exception as e2:
                 return (url, f"err: {e2.__class__.__name__}: {e2}")
+        # A TLS connection cut mid-handshake or mid-read is the same class of
+        # event as a timeout: the runner could not complete a conversation
+        # with the host, which says nothing about whether the link is right.
+        # europeangovernanceandpolitics.eui.eu does this from GitHub's runners
+        # intermittently (the scheduled run on master passed the same morning
+        # a pull request went red on it) while answering in half a second from
+        # a laptop. It was on the skip list for the same underlying reason
+        # until #1423 took it off, and a skip is a permanent blind spot, so it
+        # gets patience and a warning instead of a skip or a red build.
+        if "UNEXPECTED_EOF_WHILE_READING" in str(e) or "SSLEOFError" in e.__class__.__name__:
+            return _again("unreachable")
         # A connect timeout arrives wrapped in URLError; a read timeout does
         # not (see the TimeoutError branch below). Both go to the schedule.
         # Matched on the message as well as the type: urllib does not promise
@@ -436,6 +449,15 @@ if not internal_only and external_links:
                 print(
                     f"  ⚠ {url}  (timed out on {len(TIMEOUT_SCHEDULE)} attempts, "
                     f"last at {TIMEOUT_SCHEDULE[-1]}s — slow host, not counted as broken)"
+                )
+            elif status == "unreachable":
+                # The runner could not hold a TLS connection open long enough
+                # to get an answer. Same treatment as a timeout, and printed
+                # unconditionally for the same reason: a host that does this
+                # every run should be visible, not quietly excused (#1423).
+                print(
+                    f"  ⚠ {url}  (connection cut on {len(TIMEOUT_SCHEDULE)} attempts — "
+                    f"unreachable from CI, not counted as broken)"
                 )
             elif isinstance(status, int) and 200 <= status < 400:
                 if not quiet:

--- a/scripts/test-check-links.py
+++ b/scripts/test-check-links.py
@@ -10,6 +10,7 @@ SKIP_HOSTS are pinned:
     404            -> still broken (the fix must not swallow real failures)
     ENETUNREACH    -> retried once, then takes the second answer
     5xx that clears -> retried on a widening pause, then passes (#1423)
+    TLS cut        -> retried, then reported unreachable rather than broken
     5xx every time -> still broken, after every attempt is spent
     hanging host   -> every attempt in TIMEOUT_SCHEDULE is made, then reported
                       as slow rather than broken (#1417)
@@ -93,6 +94,22 @@ u, st = check_external(f'http://127.0.0.1:{port3}/down')
 print(f'  503 every time -> {st!r} after {down["n"]} attempt(s)')
 fails += [] if st == 'HTTP 503' else ['a host that 5xxs every attempt must still be broken']
 
+# A TLS connection cut mid-read must be retried and then reported as
+# unreachable, not counted as broken (#1423). Simulated by raising the same
+# URLError urllib produces, on every attempt.
+import ssl as _ssl
+calls = {'n': 0}
+def tls_cut(req, **kw):
+    calls['n'] += 1
+    raise urllib.error.URLError(
+        _ssl.SSLError(1, '[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol'))
+ns['TIMEOUT_PAUSES'] = (0.05, 0.05)
+urllib.request.urlopen = ns['urllib'].request.urlopen = tls_cut
+u, st = check_external(f'{base}/ok')
+urllib.request.urlopen = ns['urllib'].request.urlopen = real
+print(f'  TLS cut every time -> {st!r} after {calls["n"]} attempt(s)')
+fails += [] if st == 'unreachable' else ['a cut TLS connection should report unreachable, not broken']
+
 # A host that accepts the connection and never answers must exhaust the
 # schedule and come back as the "timeout" sentinel, which the report prints as
 # a slow host rather than counting as broken (#1417). The clock is shrunk here
@@ -116,5 +133,5 @@ fails += [] if (st == 'timeout' and len(connections) == 3) else \
     ['a hanging host should exhaust TIMEOUT_SCHEDULE and report "timeout", not broken']
 
 srv.shutdown()
-print('\nFAIL: ' + '; '.join(fails) if fails else '\nall seven behaviours correct')
+print('\nFAIL: ' + '; '.join(fails) if fails else '\nall eight behaviours correct')
 sys.exit(1 if fails else 0)


### PR DESCRIPTION
Fixes the link-check failure on #1553, which is a regression I introduced in #1538.

### What happened

#1423 asked me to take three timeout-motivated hosts off the skip list and see what they did under the new schedule. Two are fine. The third, `europeangovernanceandpolitics.eui.eu`, turns out not to have a timeout problem at all: from GitHub's runners it intermittently **cuts the TLS connection mid-read**, which arrives as `URLError(SSL: UNEXPECTED_EOF_WHILE_READING)` and was counted as broken.

That failed #1553 and would have failed every HTML-touching PR until someone looked.

### Why it is the same class as a timeout

It is intermittent, not constant, and it is about the runner rather than the link:

- The **scheduled run on master passed at 07:49** this morning.
- A **pull request went red at 20:06 last night** on the same two URLs.
- The host answers in **0.56s from a laptop**.

That is the CI-side reachability pattern the original skip comment described, and exactly what #1423 predicted as one of the three possible outcomes.

### The fix

A cut TLS connection now gets the same patience as a timeout — three attempts on the widening clock — and is then reported as **unreachable from CI, not counted as broken**. The warning prints unconditionally, so a host doing this every run stays visible rather than quietly excused, which is the point of keeping the skip list short.

I did not restore the skip. A skip is a permanent blind spot on a URL that backs the Global Risks report, and this keeps the link under observation while refusing to fail the build for the runner's own networking.

### Verification

`test-check-links.py` gains the case, raising the `URLError` urllib itself produces, and the run pins eight behaviours:

```
  429 -> 429
  200 -> 200
  404 -> 'HTTP 404'
  ENETUNREACH then 200 -> 200 after 2 attempt(s)
  503, 503, then 200 -> 200 after 3 attempt(s)
  503 every time -> 'HTTP 503' after 3 attempt(s)
  TLS cut every time -> 'unreachable' after 3 attempt(s)
  hanging host -> 'timeout' after 3 attempt(s)

all eight behaviours correct
```

CI runs that self-check before trusting the checker with 700-odd links, so the new behaviour is gated.

Backend only — no user-facing change — so I will merge this once it is green, per your standing instruction, to unblock #1553.

🤖 Generated with [Claude Code](https://claude.com/claude-code)