### PR TITLE
docs: the theme patterns live in three places, and counts need a {noun} slot

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,6 +51,42 @@ src/*.njk (pages)  +  src/_includes/*.njk (components)  +  src/_data/* (data)
 | `announcement.js` | The data-driven announcement/quote blocks. | Hand-maintained. |
 | `panels2022.js`, `countryFlags.js`, `site.js` | 2022 panels, flag lookup, site-wide config (nav array, URLs). | Hand-maintained. |
 
+## The theme vocabulary lives in three places
+
+The seventeen research themes are matched by regular expression, and the
+patterns are copied into **three** tables that must move together. Nothing
+fails if they drift, which is the whole problem: the Anthology filter and the
+Atlas would simply tag the same paper differently, and no build, gate or test
+would say so.
+
+| Table | File | What it matches |
+|---|---|---|
+| `THEME_RULES` | `src/_data/corpus.js` | Panel titles. Also the source of the labels, the stable keys and the published SKOS vocabulary. |
+| `THEME_MATCH` | `src/_data/paperIndex.js` | Panel titles again. A deliberate copy: the paper index does not depend on `corpus.js` for this. |
+| `ABSTRACT_OVERRIDE` | `src/_data/paperIndex.js` | Abstract prose, for three themes only. **Deliberately narrower**, see below. |
+
+**The invariant.** For all seventeen themes, the pattern in `THEME_RULES` and
+the pattern in `THEME_MATCH` are byte-identical. They were, as of the last
+check. A widening applied to one and not the other is the drift this section
+exists to prevent.
+
+**`ABSTRACT_OVERRIDE` is the exception, and is meant to differ.** Matching a
+curated panel title and matching free prose are different jobs. Three themes
+carry a prose-only pattern that drops vocabulary which is *ambient* in this
+literature rather than topical: `theor` fires in 27% of abstracts,
+`\bnato\b` in 19%, `\balliance` in 15%, and `\bspace\b` is a false friend
+("policy space"). Left in, those hubs swallowed the corpus. The reasoning is
+written out above the constant in `paperIndex.js`, and it is the reason a
+paper with an abstract full of NATO can still be untagged.
+
+**So: widening a pattern is a three-file edit**, or a two-file edit plus a
+deliberate decision to leave the prose side alone.
+
+Measure before applying one. Count the panel titles the widened pattern newly
+matches, the papers that move, and how often the new words appear across the
+abstracts on file. A word that fires in more than a few per cent of abstracts
+is ambient rather than topical, and belongs on the panel side only.
+
 ## Sync pipelines (scheduled GitHub Actions → auto-PR)
 
 - **`sync-indico.yml`** → `sync-indico.py` → `indico.json` (programme +

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -48,6 +48,7 @@ pasting it into a French page is the mistake this rule exists to prevent.
 | Translate chrome strings (nav, footer, buttons) | `src/_data/i18n.js` |
 | Translate a page's prose | duplicate `src/page.njk` → `src/page.fr.njk` (or `.de.njk`), translate, register in `data/i18n-state.json` |
 | Promote a beta translation to "reviewed" | flip `status` in `data/i18n-state.json` and drop `status: "beta"` from page front-matter |
+| Write a string that carries a count | put a `{noun}` slot in the string and fill it from an existing singular/plural pair, see below |
 
 ## How the system works
 
@@ -56,6 +57,25 @@ pasting it into a French page is the mistake this rule exists to prevent.
 Nav labels, footer labels, buttons, theme-toggle aria text, beta-ribbon copy live in `src/_data/i18n.js`. The base layout sets `t = i18n[lang]` (where `lang` comes from page front-matter). Every include reads `t.nav.home`, `t.footer.followUs`, etc.
 
 To add a chrome string: edit `src/_data/i18n.js`, add the key to **all three language objects** (`en`, `fr`, `de`), then use `{{ t.your.key }}` in the relevant template.
+
+#### Counts and plurals
+
+A string that interpolates a number must not hard-code the noun. Written as
+`"{n} papers"` it reads "1 papers" in English, "1 communications" in French
+and "1 Beiträge" in German, and the bug is invisible until the corpus happens
+to produce a one.
+
+The catalog already carries singular and plural pairs for the nouns that get
+counted (`atlas.paper` / `atlas.papers`, `atlas.author` / `atlas.authors`).
+Leave a `{noun}` slot in the string and fill it at the call site:
+
+```njk
+{{ a.matrixCell | replace("{n}", p.n) | replace("{noun}", a.paper if p.n == 1 else a.papers) }}
+```
+
+This keeps one string per language instead of two, and it is what
+`atlas.listSummary` has always done. Languages with more than two plural
+forms would need more than this. None of the three here do.
 
 ### 2. Page prose: sibling `.njk` files
 


### PR DESCRIPTION
Two traps hit while working on #1249, #1567 and #1570 that no doc named. Docs only, so no CHANGELOG bullet (§4).

## The theme patterns are copied three times

`docs/architecture.md` gains a section. The seventeen themes are matched by regular expression, and the patterns live in three tables:

| Table | File | Matches |
|---|---|---|
| `THEME_RULES` | `corpus.js` | panel titles, plus the labels, keys and the SKOS vocabulary |
| `THEME_MATCH` | `paperIndex.js` | panel titles again, a deliberate copy |
| `ABSTRACT_OVERRIDE` | `paperIndex.js` | abstract prose, three themes only, deliberately narrower |

The first two are byte-identical today, verified across all seventeen. **Nothing fails if they drift**, which is the point of writing it down: the Anthology filter and the Atlas would tag the same paper differently and no build, gate or test would say so. I found this out by reading both files while widening one pattern in #1570.

The section also says why `ABSTRACT_OVERRIDE` is meant to differ (`theor` fires in 27% of abstracts, `\bnato\b` in 19%, `\balliance` in 15%), since that is the reason a paper whose abstract is full of NATO can still be untagged, and it looks like a bug until you know.

## Counts need a `{noun}` slot

`docs/i18n.md` gains a subsection and a quick-reference row. A catalog string that hard-codes its noun around a number reads "1 papers", "1 communications" and "1 Beiträge". I shipped exactly that in three languages this week and caught it on the second pass. The fix is the `{noun}` slot filled from the singular and plural pairs the catalog already carries, which is what `atlas.listSummary` has always done.

## What I did not do

**A mechanical gate for the invariant.** A doc line does not stop drift, and the two tables could be compared at build time. That needs the tables exported and a check added, so it is filed rather than smuggled in here.

Auto-merge armed: docs only, nothing user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)