### PR TITLE
Gate the theme-pattern invariant across its two copies (#1577)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,9 +68,12 @@ would say so.
 | `ABSTRACT_OVERRIDE` | `src/_data/paperIndex.js` | Abstract prose, for three themes only. **Deliberately narrower**, see below. |
 
 **The invariant.** For all seventeen themes, the pattern in `THEME_RULES` and
-the pattern in `THEME_MATCH` are byte-identical. They were, as of the last
-check. A widening applied to one and not the other is the drift this section
-exists to prevent.
+the pattern in `THEME_MATCH` are byte-identical. `checkThemeRuleDrift()` in
+`scripts/check-build-sanity.mjs` now asserts it on every PR, reporting a
+changed pattern, a theme present in one table only, and a reformat that
+defeats its own extraction. It reads the tables out of the source rather than
+importing them: exporting them would put regexes into the data cascade, and
+from there into the published JSON exports, for the benefit of a check.
 
 **`ABSTRACT_OVERRIDE` is the exception, and is meant to differ.** Matching a
 curated panel title and matching free prose are different jobs. Three themes

--- a/scripts/check-build-sanity.mjs
+++ b/scripts/check-build-sanity.mjs
@@ -488,6 +488,86 @@ function checkThemeSpread() {
 }
 
 // ---------------------------------------------------------------------------
+// The theme patterns agree across their two copies (#1577).
+//
+// The seventeen theme patterns live twice, on purpose: THEME_RULES in
+// corpus.js and THEME_MATCH in paperIndex.js, which must not depend on
+// corpus.js for this (see the comment above THEME_MATCH). They are meant to be
+// identical, and nothing enforces it. A widening applied to one and not the
+// other leaves the Anthology by-paper filter and the Atlas tagging the same
+// paper differently, with no build, gate or test saying so. It nearly happened
+// in #1570, which had to edit both by hand.
+//
+// ABSTRACT_OVERRIDE, the third copy, is DELIBERATELY narrower for three themes
+// and is not compared here. See the ambient-vocabulary reasoning above it.
+//
+// Read out of the source rather than imported: exporting the tables would put
+// regexes into the data cascade, and from there into the published JSON
+// exports, for the benefit of a check.
+const THEME_COUNT = 17;
+function checkThemeRuleDrift() {
+  const read = (f) => {
+    try {
+      return readFileSync(f, "utf8");
+    } catch (e) {
+      problems.push(`${f}: could not read (${e.message})`);
+      return null;
+    }
+  };
+  const corpusSrc = read("src/_data/corpus.js");
+  const indexSrc = read("src/_data/paperIndex.js");
+  if (!corpusSrc || !indexSrc) return;
+
+  // THEME_RULES: { key: "...", label: { en: "..." }, re: /.../i }
+  const rules = new Map();
+  for (const m of corpusSrc.matchAll(
+    /key:\s*"([^"]+)",[\s\S]*?en:\s*"([^"]+)"[\s\S]*?re:\s*(\/[\s\S]*?\/i),/g
+  )) {
+    rules.set(m[2], { key: m[1], source: m[3] });
+  }
+  // THEME_MATCH: ["Name", /.../i],
+  const match = new Map();
+  for (const m of indexSrc.matchAll(/\["([^"]+)",\s*(\/[\s\S]*?\/i)\],/g)) {
+    match.set(m[1], m[2]);
+  }
+
+  // A reformat that defeats the extraction must fail loudly rather than pass
+  // with nothing to compare.
+  if (rules.size !== THEME_COUNT || match.size !== THEME_COUNT) {
+    problems.push(
+      `theme patterns: read ${rules.size} from THEME_RULES and ${match.size} from THEME_MATCH, ` +
+        `expected ${THEME_COUNT} each — the tables were reformatted and this check can no longer ` +
+        "read them, so update the patterns in checkThemeRuleDrift()"
+    );
+    return;
+  }
+
+  for (const [name, rule] of rules) {
+    const other = match.get(name);
+    if (other === undefined) {
+      problems.push(
+        `theme "${name}" (${rule.key}) is in corpus.js THEME_RULES and missing from ` +
+          "paperIndex.js THEME_MATCH — the Atlas and the by-paper filter would tag differently"
+      );
+    } else if (other !== rule.source) {
+      problems.push(
+        `theme "${name}" (${rule.key}) has drifted between its two copies. ` +
+          `corpus.js: ${rule.source}  paperIndex.js: ${other}. ` +
+          "Widening a pattern is a two-file edit (three, if the prose side should move too)"
+      );
+    }
+  }
+  for (const name of match.keys()) {
+    if (!rules.has(name)) {
+      problems.push(
+        `theme "${name}" is in paperIndex.js THEME_MATCH and missing from corpus.js THEME_RULES, ` +
+          "so it has no key, no labels and no entry in the published vocabulary"
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Every paper page is in the sitemap (#1293).
 //
 // This failed silently for months. Eleventy adds only a paginated template's
@@ -693,6 +773,7 @@ checkUndefinedClasses();
 checkCssCollisions();
 checkPeopleIndex();
 checkThemeSpread();
+checkThemeRuleDrift();
 checkSitemapCoverage();
 checkNoDuplicateInputs();
 checkOrphanShareCards();
@@ -704,4 +785,4 @@ if (problems.length) {
   console.error("");
   process.exit(1);
 }
-console.log("✓ build-sanity check passed (no duplicate data keys, no scheme-less board links, no empty/junk href/src, no undefined CSS classes, no cross-block CSS class collisions, people hovercard index resolvable, theme spread within bounds, every paper page in the sitemap, no duplicate build inputs, no orphaned or missing share cards, Anthology corpus citation metadata intact).");
+console.log("✓ build-sanity check passed (no duplicate data keys, no scheme-less board links, no empty/junk href/src, no undefined CSS classes, no cross-block CSS class collisions, people hovercard index resolvable, theme spread within bounds, theme patterns identical across their two copies, every paper page in the sitemap, no duplicate build inputs, no orphaned or missing share cards, Anthology corpus citation metadata intact).");


### PR DESCRIPTION
Closes #1577. Internal only, so no CHANGELOG bullet (§4), and auto-merge is armed.

`THEME_RULES` (corpus.js) and `THEME_MATCH` (paperIndex.js) hold the same seventeen patterns and are meant to stay identical. Nothing enforced it, and a widening applied to one and not the other leaves the Anthology by-paper filter and the Atlas tagging the same paper differently, with no build, gate or test saying so. #1570 had to edit both by hand to avoid exactly that.

## What it checks

`checkThemeRuleDrift()` reports three failures:

- a pattern that differs between the two tables;
- a theme present in one table only, in either direction;
- a reformat that defeats its own extraction, which fails loudly rather than passing with nothing to compare.

`ABSTRACT_OVERRIDE`, the third copy, is deliberately narrower for three themes and is not compared. The check says so where a reader will meet it.

## Why it reads the source instead of importing the tables

Neither table is exported today. Exporting them would put regexes into the data cascade, and from there into the published JSON exports, which is a production surface changed for the benefit of a check. The gate already parses `src/_data/*.js` for the duplicate-key check, so source-level reading is in-house.

The cost of that choice is that the extraction is regex-shaped and a reformat could defeat it, which is why a count mismatch is itself a reported problem rather than a silent pass.

## Tested

Both failure paths, by drifting `paperIndex.js` and restoring:

```
theme "Gender and security" (gender-security) has drifted between its two copies.
  corpus.js: /gender/i  paperIndex.js: /gender|feminis/i
```
```
theme "Gender and security" (gender-security) is in corpus.js THEME_RULES and missing from paperIndex.js THEME_MATCH
theme "Gender & security" is in paperIndex.js THEME_MATCH and missing from corpus.js THEME_RULES
```

Silent on the current source. The source-only checks run in 0.4s with no build present, so this costs nothing in the gate.

`docs/architecture.md`, which documented the invariant last week, now says it is enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)