### PR TITLE
Milestones stay SemVer, and the conference phases live on the roadmap (§10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,23 +347,30 @@ work is this?". The set:
   (Indico write-API access, NetSec coordination, source research) or
   with no committed release. Mirrors the *Under watch* section of the
   roadmap.
-- **Event-cycle milestones**, added in August 2026 for the ESSC 2027
-  preparation: one per phase of a dated conference cycle, named
-  `<Event> <year>: <phase>` (*save the date*, *call for papers*,
-  *selection and notifications*, *programme and logistics*,
-  *conference*). The prep deadlines are set by the joint organising
-  group and do not land on the release cadence, so folding them into
-  version milestones would drag release dates around an external
-  calendar. NetSec runs the same five titles with the same due dates,
-  since it is one conference tracked in two repositories. Their phase
-  rows live in [`docs/roadmap-2026.md`](docs/roadmap-2026.md) beside
-  the release timeline.
+
+**Every milestone title is a SemVer version, or the backlog.** No
+sentence-titled milestones. A conference cycle has phases with their own
+deadlines (*save the date*, *call for papers*, *selection and
+notifications*, *programme and logistics*, *conference*), and those are
+real, but they are named in the roadmap and in the issues rather than
+minted as milestones. The prep work rides whichever release is open when
+its deadline falls, which is what NetSec does and says in its own §10.
+
+This was tried the other way in August 2026 and reverted the same month:
+five `ESSC 2027: <phase>` milestones existed briefly, and the reason
+against them is that they answer a different question from the rest of
+the set. A milestone here answers "which release is this for?", and a
+board where some rows answer that and others answer "which phase of a
+conference is this?" cannot be read as one queue. The phase rows live in
+[`docs/roadmap-2026.md`](docs/roadmap-2026.md) beside the release
+timeline, which is where a date owned by somebody else belongs.
 
 Due dates on the version milestones come from the roadmap timeline.
 When the roadmap shifts a planned release, **bump the milestone's due
 date in the same commit that updates the roadmap row**: they are two
-views of one schedule. The same rule applies to the event milestones
-and their phase rows.
+views of one schedule. A conference deadline that lands between releases
+moves the nearest release's date or waits for it, and the roadmap says
+which.
 
 Create a new version milestone when the roadmap gains a release row.
 Don't pre-create far-future majors.

--- a/docs/roadmap-2026.md
+++ b/docs/roadmap-2026.md
@@ -53,6 +53,8 @@ other way round, so this is where a new release first appears.
 | v2.26.0 | 25 Jun 2026 | **Shipped** | Introducing the Anthology |
 | v2.27.0 | 19 Aug 2026 | **Shipped** | The Anthology Atlas and the recovered back catalogue |
 | v2.28.0 | 8 Dec 2026 | Planned | The corpus in French, and the data behind it |
+| v2.29.0 | 30 Apr 2027 | Planned | ESSC 2027 programme and logistics |
+| v2.30.0 | 11 Jun 2027 | Planned | ESSC 2027, and the archive rollover after it |
 
 (`v2.24.1` was planned as a pre-ESSC patch but the work grew into a feature-rich minor, so it shipped as the **v2.25.0** *Ready for Stockholm* release instead; the `v2.24.1` milestone is closed as superseded.)
 
@@ -65,17 +67,20 @@ organising group met in August 2026 and meets again on 7 September
 confirmed at that meeting, and this repository carries two different
 placeholder editions until then (see issue #1522).
 
-The cycle runs on the organising group's calendar rather than the
-release cadence, so it carries five event milestones (CLAUDE.md §10),
-mirrored title for title on the NetSec side.
+The prep work rides the release milestones rather than a calendar of
+its own (CLAUDE.md §10), so each phase lands in whichever release is
+open when its deadline falls. The deadlines themselves live in the
+issues, and they are the organising group's, not ours.
 
-| Due | Milestone | EISS-side work |
+| Release | Due | Conference work in it |
 | --- | --- | --- |
-| 30 Sep 2026 | *ESSC 2027: save the date* | The edition settled and entered in `conferences.js` (#1522) · the runbook's contradictory worked example fixed (#1523) |
-| 6 Nov 2026 | *ESSC 2027: call for papers* | The parked 2027 page activated (#1524) · the edition share cards generated (#1525) · the call published and announced (#1526) |
-| 31 Dec 2026 | *ESSC 2027: selection and notifications* | The prize jury confirmed and the terms published (#1527) |
-| 30 Apr 2027 | *ESSC 2027: programme and logistics* | Programme content once the accepted papers are known (#1528) |
-| 11 Jun 2027 | *ESSC 2027: conference* | The archive rollover and the abstract pull (#1529) |
+| v2.28.0 | 8 Dec 2026 | *Save the date*, due 30 September: the edition settled and entered in `conferences.js` (#1522) · *Call for papers*, due 6 November: the parked 2027 page activated (#1524), the edition share cards generated (#1525), the call published and announced (#1526) · *Selection and notifications*, due 31 December: the prize jury confirmed and the terms published (#1527) |
+| v2.29.0 | 30 Apr 2027 | *Programme and logistics*: programme content once the accepted papers are known (#1528) |
+| v2.30.0 | 11 Jun 2027 | *The conference itself*: the archive rollover and the abstract pull afterwards (#1529) |
+
+The phase names are the joint group's vocabulary and the NetSec
+roadmap uses the same five, so a deadline can be named across the two
+repositories without either of them minting a milestone for it.
 
 **Versioning rules**: see the *Versioning* section of
 [`README.md`](../README.md) for the canonical definition of MAJOR /


### PR DESCRIPTION
Reverts the five `ESSC 2027: <phase>` milestones I created earlier today, on the maintainer's call: **every milestone title is a version or the backlog, and no sentence-titled milestones.** Docs and rules only, so no CHANGELOG bullet (§4), and auto-merge is armed.

## Why they were wrong

They answer a different question from the rest of the set. A milestone here answers "which release is this for?". A board where some rows answer that and others answer "which phase of a conference is this?" cannot be read as one queue.

**NetSec had already settled this**, and says so in its own §10, quoted from its roadmap: "The prep work rides the release milestones rather than a calendar of its own." Its milestone set has been version-only throughout, with the conference phases named in prose against `v1.14.0` … `v1.18.0`. EISS §10 was the outlier, and this brings the two back into line. That matters more than it looks: EISS's roadmap claimed the five titles were "mirrored title for title on the NetSec side", and they never were.

## What changed

**GitHub, already done:**

- The seven ESSC 2027 issues are back where they sat this morning: #1522, #1524, #1525, #1526 and #1527 on v2.28.0, #1528 on v2.29.0, #1529 on v2.30.0.
- The five milestones are deleted, each empty at the time of deletion.
- The set is back to `Backlog — Under watch`, v2.28.0, v2.29.0, v2.30.0.

**In this PR:**

- `docs/roadmap-2026.md`: the ESSC 2027 prep table is rekeyed by release, in the shape NetSec uses, with the phase names and their deadlines kept as prose. The deadlines belong to the joint organising group and live in the issues.
- The release timeline gains **v2.29.0 (30 Apr 2027)** and **v2.30.0 (11 Jun 2027)** rows. Both milestones existed with no roadmap row, which §10 forbids in the other direction: "Milestones are created from this table, not the other way round."
- `CLAUDE.md` §10: the event-cycle subsection is replaced by the SemVer-only rule, with the August 2026 attempt recorded as tried and reverted, so the next session does not re-derive it from the old text. That is exactly what happened to me here.

## Note on the two later releases

v2.29.0 and v2.30.0 still carry conference dates rather than a release cadence, because the only work committed to them is conference work. Under this scheme that is the accepted trade-off and it matches NetSec, whose v1.17.0 and v1.18.0 carry the same two dates. Worth revisiting when the release schedule past v2.28.0 is real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)