### PR TITLE
Release prep for v2.28.0: cross-check, notes, and the milestone shuffle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,35 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ## [Unreleased]
 
-### Added
+> The Atlas shipped in August as a map you could look at. This release makes it a map you can use: in French and German, from a keyboard, on a phone, and behind a link that carries what you were looking at. Alongside it, the seventeen research themes the Anthology indexes by are now published as a vocabulary anybody can cite and reuse.
+
+### The Atlas, from something to look at to something to work with
+
+Most of this release is the map catching up with the promise of it. It opens on the map rather than below a screen of chrome, zooms and pans, and holds still while you read it. Clicking a research theme now tells you about that theme: its papers, its years, the themes it most often shares papers with, and one press into any of them. A filtered view has a link, and so does an open theme panel, so a view you found is a view you can send. Under the map, a slider walks the nine annual editions one at a time, and a line of findings says what only the map's own structure knows, such as the busiest bridge between two fields.
+
+It is also readable now by people who were previously locked out of it. The whole current view exists as a list under the canvas, the map speaks its state through a live region, and the French and German Atlases are complete rather than an English core with translated edges, including the parts the script writes rather than the page.
+
+### A vocabulary other people can use
+
+The seventeen themes were a JavaScript constant inside a website's build. They are now a published SKOS vocabulary at `/vocab/themes/`, in Turtle and JSON-LD, each theme carrying a permanent identifier that resolves, with its labels in English, French and German. The map links to them, and each theme page prints its own identifier in full, ready to copy into a citation or a mapping file.
+
+Publishing it meant deciding what the vocabulary does not cover, which is a more useful statement than it sounds. The matching rules stay unpublished, because they are how a paper gets tagged rather than what a theme means. One rule turned out to be genuinely too narrow and was widened. The papers that still carry no theme were then gone through one by one, and what remains is keynotes, poster sessions, four 2019 panels titled only "Session I" to "Session IV", and two panels whose subject the vocabulary deliberately does not reach.
+
+### The Anthology says more about itself
+
+The header counted speakers, editions, papers and abstracts, none of which say whether the Initiative is meeting the same people again or new ones. It now sets out every annual edition against five figures, and two movements are visible in them: first-time presenters have fallen from 87% in 2018 to between 61% and 77%, and sole-authored papers from 89% to 69%. The page also stops calling itself a preview and names instead which editions are finished and which are still filling in.
+
+Two figures were quietly wrong and are not any more. Poster papers were counted in the abstract-coverage ratio in some editions and not in others, depending on how each programme was transcribed. And the corpus note described a tagging method the site stopped using when abstracts began feeding the themes.
+
+### The phone, and the reader without JavaScript
+
+A run of fixes that share one cause: the map was built at desktop width with scripts running. On a phone it now reaches the first screen in all three languages, a tap previews rather than navigating away, the hover card stays out from under the thing it describes and inside the map, and a scrolling finger is no longer trapped. Without JavaScript the list alternative still exists. The rest is the ordinary tail of a release: share cards that were blank, language switches that lost your place, and a licence line that contradicted the licence.
+
+### Index of changes
+
+The themed sections above are the story. The index below is the audit trail, same content, terser.
+
+#### Added
 
 - **Every research theme on the Atlas now carries its permanent identifier.** The seventeen themes were published as a citable vocabulary last week and nothing on the map said so, which left the identifiers reachable through the sitemap and the documentation and nowhere a reader actually goes. A theme's panel on the map now links to its identifier, each of the seventeen theme pages prints its own in full, ready to copy into a citation or a mapping file, and the theme list on every Atlas view links to the vocabulary itself. Closes [#1571](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1571).
 
@@ -125,7 +153,7 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 - **The Atlas tells a screen reader what the map just did.** The card pinned by a tap is a canvas overlay that nothing announced, and a search that landed on a paper moved the map silently. Both now speak through a polite live region, alongside the Find messages added earlier in this release. Part of [#1446](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1446), whose remaining half is a keyboard path into the map itself.
 
-### Changed
+#### Changed
 
 - **Four more papers now carry a research theme, and the untagged set is down to 29.** A panel on foreign information influence matched none of the seventeen themes, because the pattern behind "emerging domains" recognised information *operations* and not the influence and disinformation vocabulary the same literature uses. Widening it moves four papers, three of which carried no theme at all, and it changes nothing else: the words appear in 1.4% of abstracts on file, so they are topical rather than ambient. The remaining untagged papers are now keynotes and roundtables, poster sessions, four 2019 panels titled only "Session I" to "Session IV", and two panels whose subject the vocabulary genuinely does not cover. Closes [#1570](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1570).
 
@@ -153,7 +181,7 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 - **The public roadmap describes v2.28.0 as it now stands.** The card was written when persistent identifiers were the headline, and those shipped early in v2.27.0: the Zenodo DOI, the HAL note and the Software Heritage archive are all live and shown on the site, so the card was promising work already done. It now leads on what actually remains, the French Anthology leaving beta on a declared scope, an analytical export of the corpus, affiliations matched to the standard registry of research organisations, a citable theme vocabulary, and the accessibility declaration. Retitled "The corpus in French, and the data behind it" in all three locales, with `docs/roadmap-2026.md` brought into line.
 
-### Fixed
+#### Fixed
 
 - **Poster papers are counted the same way in every edition.** The abstract-coverage figure measures how completely the papers are documented, and it excludes the sessions that never have a submitted abstract, which is what the page has always said. Poster sessions were only half excluded: the 2025 programme records them one way and the 2024 and 2026 programmes another, so seven poster papers sat inside the denominator while three sat outside it. They are all outside it now, decided on what the session is rather than on how its edition happens to be transcribed. The figure reads 286 abstracts across 485 eligible papers, and the 2024 edition rises from 94% to 96%. No abstract has been removed, and the poster abstracts on file are still on the site.
 

--- a/docs/roadmap-2026.md
+++ b/docs/roadmap-2026.md
@@ -52,9 +52,10 @@ other way round, so this is where a new release first appears.
 | v2.25.0 | 9 Jun 2026 | **Shipped** | Ready for Stockholm (pre-conference release) |
 | v2.26.0 | 25 Jun 2026 | **Shipped** | Introducing the Anthology |
 | v2.27.0 | 19 Aug 2026 | **Shipped** | The Anthology Atlas and the recovered back catalogue |
-| v2.28.0 | 8 Dec 2026 | Planned | The corpus in French, and the data behind it |
-| v2.29.0 | 30 Apr 2027 | Planned | ESSC 2027 programme and logistics |
-| v2.30.0 | 11 Jun 2027 | Planned | ESSC 2027, and the archive rollover after it |
+| v2.28.0 | 29 Aug 2026 | **Shipped** | The Atlas you can read, and a vocabulary you can cite |
+| v2.29.0 | 8 Dec 2026 | Planned | The corpus in French, and the data behind it |
+| v2.30.0 | 30 Apr 2027 | Planned | ESSC 2027 programme and logistics |
+| v2.31.0 | 11 Jun 2027 | Planned | ESSC 2027, and the archive rollover after it |
 
 (`v2.24.1` was planned as a pre-ESSC patch but the work grew into a feature-rich minor, so it shipped as the **v2.25.0** *Ready for Stockholm* release instead; the `v2.24.1` milestone is closed as superseded.)
 
@@ -74,9 +75,9 @@ issues, and they are the organising group's, not ours.
 
 | Release | Due | Conference work in it |
 | --- | --- | --- |
-| v2.28.0 | 8 Dec 2026 | *Save the date*, due 30 September: the edition settled and entered in `conferences.js` (#1522) · *Call for papers*, due 6 November: the parked 2027 page activated (#1524), the edition share cards generated (#1525), the call published and announced (#1526) · *Selection and notifications*, due 31 December: the prize jury confirmed and the terms published (#1527) |
-| v2.29.0 | 30 Apr 2027 | *Programme and logistics*: programme content once the accepted papers are known (#1528) |
-| v2.30.0 | 11 Jun 2027 | *The conference itself*: the archive rollover and the abstract pull afterwards (#1529) |
+| v2.29.0 | 8 Dec 2026 | *Save the date*, due 30 September: the edition settled and entered in `conferences.js` (#1522) · *Call for papers*, due 6 November: the parked 2027 page activated (#1524), the edition share cards generated (#1525), the call published and announced (#1526) · *Selection and notifications*, due 31 December: the prize jury confirmed and the terms published (#1527) |
+| v2.30.0 | 30 Apr 2027 | *Programme and logistics*: programme content once the accepted papers are known (#1528) |
+| v2.31.0 | 11 Jun 2027 | *The conference itself*: the archive rollover and the abstract pull afterwards (#1529) |
 
 The phase names are the joint group's vocabulary and the NetSec
 roadmap uses the same five, so a deadline can be named across the two
@@ -233,7 +234,7 @@ crossfades, an acknowledgments / contributors page, a newsletter
 archive page, `rel="me"` verification if EISS gets a Mastodon or
 Bluesky account.
 
-### v2.28.0 — The corpus in French, and the data behind it · target 8 December 2026
+### v2.29.0 — The corpus in French, and the data behind it · target 8 December 2026
 
 The identifier strand that gave this release its old name shipped early,
 inside v2.27.0: the Zenodo DOI, the HAL note and the Software Heritage
@@ -243,7 +244,7 @@ large part of the network reads, together with the metadata work that
 turns the corpus into something other projects can analyse and cite.
 
 The
-[v2.28.0 milestone](https://github.com/EISSeuropa/EISSeuropa.github.io/milestone/11)
+[v2.29.0 milestone](https://github.com/EISSeuropa/EISSeuropa.github.io/milestone/24)
 is the queryable commitment (rule §10).
 
 - **Persistent identifiers and long-term archiving (shipped in v2.27.0)** — the corpus is

--- a/src/_data/roadmap.js
+++ b/src/_data/roadmap.js
@@ -187,6 +187,22 @@ const roadmap = {
             de: "Der Anthologie-Atlas kartiert das gesamte Konferenzkorpus als interaktiven Graphen, nach Beitrag und nach Ko-Autorschaft. Die Wiedergewinnung der Abstracts reicht bis in die Ausgaben vor Indico zurück, und die Anthologie zeigt nun die Abdeckung pro Jahr. Ebenfalls in diesem Zyklus: die Praktikumsseite, die Global-Risks-Umfrage 2026, die Ankündigung der neuen Leitung und die Ankündigung der ESSC 2027, sobald Datum und Ort feststehen.",
           },
         },
+        {
+          status: "shipped",
+          version: "v2.28.0",
+          notesUrl: notes("v2.28.0"),
+          when: { en: "29 August 2026 · v2.28.0", fr: "29 août 2026 · v2.28.0", de: "29. August 2026 · v2.28.0" },
+          title: {
+            en: "The Atlas you can read, and a vocabulary you can cite",
+            fr: "L’Atlas que l’on peut lire, et un vocabulaire que l’on peut citer",
+            de: "Der Atlas, den man lesen kann, und ein Vokabular, das man zitieren kann",
+          },
+          desc: {
+            en: "The seventeen research themes the Anthology indexes by are published as a vocabulary anyone can cite and reuse, each with a permanent identifier reachable from the map. The Atlas gains a grid of every pair of themes that share papers, and the Anthology now says how the conference is changing: how many presenters are there for the first time, and how much of the work is written alone.",
+            fr: "Les dix-sept thèmes de recherche qui indexent l’Anthologie sont publiés sous forme de vocabulaire que chacun peut citer et réutiliser, chacun doté d’un identifiant permanent accessible depuis la carte. L’Atlas reçoit une grille de toutes les paires de thèmes qui partagent des communications, et l’Anthologie indique désormais comment la conférence évolue : combien d’intervenants viennent pour la première fois, et quelle part du travail est signée seul.",
+            de: "Die siebzehn Forschungsthemen, nach denen die Anthologie indexiert ist, erscheinen als Vokabular, das sich zitieren und weiterverwenden lässt, jedes mit einer dauerhaften Kennung, die von der Karte aus erreichbar ist. Der Atlas erhält ein Raster aller Themenpaare, die sich Beiträge teilen, und die Anthologie zeigt nun, wie sich die Konferenz verändert: wie viele Vortragende zum ersten Mal dabei sind und wie viel der Arbeit allein verfasst wird.",
+          },
+        },
       ],
     },
     {
@@ -199,9 +215,9 @@ const roadmap = {
       entries: [
         {
           status: "planned",
-          version: "v2.28.0",
-          milestone: "v2.28.0",
-          when: { en: "8 December 2026 · v2.28.0", fr: "8 décembre 2026 · v2.28.0", de: "8. Dezember 2026 · v2.28.0" },
+          version: "v2.29.0",
+          milestone: "v2.29.0",
+          when: { en: "8 December 2026 · v2.29.0", fr: "8 décembre 2026 · v2.29.0", de: "8. Dezember 2026 · v2.29.0" },
           title: {
             en: "The corpus in French, and the data behind it",
             fr: "Le corpus en français, et les données qui le sous-tendent",
@@ -225,9 +241,9 @@ const roadmap = {
       entries: [
         {
           status: "planned",
-          version: "v2.29.0",
-          milestone: "v2.29.0",
-          when: { en: "30 April 2027 · v2.29.0", fr: "30 avril 2027 · v2.29.0", de: "30. April 2027 · v2.29.0" },
+          version: "v2.30.0",
+          milestone: "v2.30.0",
+          when: { en: "30 April 2027 · v2.30.0", fr: "30 avril 2027 · v2.30.0", de: "30. April 2027 · v2.30.0" },
           title: {
             en: "The 2027 programme on the page",
             fr: "Le programme 2027 sur la page",
@@ -256,9 +272,9 @@ const roadmap = {
         },
         {
           status: "planned",
-          version: "v2.30.0",
-          milestone: "v2.30.0",
-          when: { en: "11 June 2027 · v2.30.0", fr: "11 juin 2027 · v2.30.0", de: "11. Juni 2027 · v2.30.0" },
+          version: "v2.31.0",
+          milestone: "v2.31.0",
+          when: { en: "11 June 2027 · v2.31.0", fr: "11 juin 2027 · v2.31.0", de: "11. Juni 2027 · v2.31.0" },
           title: {
             en: "The edition joins the archive",
             fr: "L’édition rejoint les archives",

--- a/src/sitemap.de.njk
+++ b/src/sitemap.de.njk
@@ -42,6 +42,7 @@ alternates:
         <li><a href="/past.de.html">Alle vergangenen Konferenzen</a></li>
         <li><a href="/anthology.de.html">Die Anthologie der europäischen Sicherheitsstudien</a> — Vortragende und Beiträge aller Ausgaben</li>
         <li><a href="/anthology-atlas.de.html">Anthologie-Atlas</a> — dasselbe Korpus als Karte der Themen und Autor:innen</li>
+        <li><a href="/vocab/themes/">Vokabular der Forschungsthemen</a> — die siebzehn Themen, nach denen die Anthologie indexiert ist, als SKOS veröffentlicht</li>
       </ul>
 
       <h2>Aktivitäten</h2>

--- a/src/sitemap.fr.njk
+++ b/src/sitemap.fr.njk
@@ -42,6 +42,7 @@ alternates:
         <li><a href="/past.fr.html">Toutes les conférences passées</a></li>
         <li><a href="/anthology.fr.html">L'Anthologie des études de sécurité européennes</a> — intervenants et communications de toutes les éditions</li>
         <li><a href="/anthology-atlas.fr.html">Atlas de l'Anthologie</a> — le même corpus sous forme de carte des thèmes et des auteurs</li>
+        <li><a href="/vocab/themes/">Vocabulaire des thèmes de recherche</a> — les dix-sept thèmes qui indexent l'Anthologie, publiés en SKOS</li>
       </ul>
 
       <h2>Activités</h2>

--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -41,6 +41,7 @@ alternates:
         <li><a href="/past.html">All past conferences</a></li>
         <li><a href="/anthology.html">The European Security Studies Anthology</a> — speakers &amp; papers across all editions</li>
         <li><a href="/anthology-atlas.html">Anthology Atlas</a> — the same corpus as a map of themes and authors</li>
+        <li><a href="/vocab/themes/">Research theme vocabulary</a> — the seventeen themes the Anthology indexes by, published as SKOS</li>
       </ul>
 
       <h2>Activities</h2>


### PR DESCRIPTION
Prep only. **The release itself is yours to cut** — `scripts/release.sh` must run on `master`, which this worktree cannot check out, and its confirmation prompt is the §2 carve-out where you eyeball the notes before they reach the public release page.

## Why now

51 bullets since v2.27.0 on 19 August: 14 Added, 14 Changed, 23 Fixed. Several are user-visible features, so it is a minor by the feature test. The December milestone's headline strand, the corpus in French, is stalled on #1264 and #1265, which need review rather than code. Holding ten days of live work for three months to keep a title true is the wrong trade.

## The five-point cross-check

**1. Roadmap.** v2.28.0 becomes *The Atlas you can read, and a vocabulary you can cite*, dated today. The French strand keeps its content and its 8 December date and becomes **v2.29.0**, which pushes the conference releases to **v2.30.0** and **v2.31.0**. Timeline rows, the ESSC 2027 prep table, the section heading, the milestone link and the public cards in all three locales moved together (§10). Milestones on GitHub are already renumbered to match.

**2. Sitemap.** `/vocab/themes/` was in the XML sitemap and **missing from the hand-edited visual one**. Added in EN, FR and DE. The seventeen concept URIs stay out of both: they carry a canonical link to the theme view and exist to resolve, not to be crawled.

**3. Translations.** `check-i18n-drift.py` clean, key parity at 550.

**4. Repo docs.** Updated inline as the work landed. The only stale figures are in `docs/a11y-audit-2026-08.md`, which records what was on the page in August and should keep saying so.

**5. Abstract coverage.** Zero stranded across eight years.

**6. Milestone hygiene.** v2.28.0 ships holding no open work: 15 issues and 2 PRs moved to v2.29.0.

## The notes

`[Unreleased]` is rewritten into the hybrid format a minor needs: a lede, four themed sections, and the 51 bullets carried down verbatim under *Index of changes*. The themes are the Atlas becoming usable, the vocabulary becoming citable, the Anthology saying more about itself, and the phone-and-no-JavaScript tail. No em dashes or semicolons in the new prose (§7).

## To cut it

From the main checkout, on `master`:

```bash
scripts/release.sh 2.28.0 "The Atlas you can read, and a vocabulary you can cite" --dry-run
```

Then the same without `--dry-run`. It will offer to flip the public roadmap card; that card is already written and marked shipped here, so the flip should report nothing to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)