### PR TITLE
roadmap: mark v2.28.0 shipped, which release.sh could not do

### DIFF
--- a/docs/roadmap-2026.md
+++ b/docs/roadmap-2026.md
@@ -52,7 +52,7 @@ other way round, so this is where a new release first appears.
 | v2.25.0 | 9 Jun 2026 | **Shipped** | Ready for Stockholm (pre-conference release) |
 | v2.26.0 | 25 Jun 2026 | **Shipped** | Introducing the Anthology |
 | v2.27.0 | 19 Aug 2026 | **Shipped** | The Anthology Atlas and the recovered back catalogue |
-| v2.28.0 | 29 Aug 2026 | In progress | A usable Atlas, and a citable theme vocabulary |
+| v2.28.0 | 29 Aug 2026 | **Shipped** | A usable Atlas, and a citable theme vocabulary |
 | v2.29.0 | 8 Dec 2026 | Planned | The corpus in French, and the data behind it |
 | v2.30.0 | 30 Apr 2027 | Planned | ESSC 2027 programme and logistics |
 | v2.31.0 | 11 Jun 2027 | Planned | ESSC 2027, and the archive rollover after it |

--- a/src/_data/roadmap.js
+++ b/src/_data/roadmap.js
@@ -191,9 +191,10 @@ const roadmap = {
           // Planned until the release exists. scripts/release.sh offers to flip
           // this card, which is what adds the notes link, and a notesUrl written
           // ahead of the tag is a 404 the link checker rightly fails on.
-          status: "planned",
+          status: "shipped",
           version: "v2.28.0",
-          milestone: "v2.28.0",
+          notesUrl: notes("v2.28.0"),
+          changes: 51,
           when: { en: "29 August 2026 · v2.28.0", fr: "29 août 2026 · v2.28.0", de: "29. August 2026 · v2.28.0" },
           title: {
             en: "A usable Atlas, and a citable theme vocabulary",


### PR DESCRIPTION
Post-release tidy. Docs and roadmap data only, auto-merge armed.

`release.sh` offers to flip the public roadmap card and reported:

```
Roadmap card: nothing to flip for v2.28.0 (already shipped, or no card).
```

It was neither. The release ran from a fresh clone with no `node_modules`, so `flip-roadmap-card.mjs` died on its `acorn` import, and `release.sh` treats any failure of that tool as "nothing to do". **A cross-check step that skips itself silently is the real problem here**, and it is filed separately.

Run properly, the flip does what it should, in all three locales from one edit:

```
  - status: "planned",
  - milestone: "v2.28.0",
  + status: "shipped",
  + notesUrl: notes("v2.28.0"),
  + changes: 51,
```

The tag exists now, so the notes link the checker rightly failed on before the release resolves (verified 200).

`docs/roadmap-2026.md` moves the *At a glance* row from *In progress* to **Shipped**, which is the hand-maintained half of the same fact (§5 point 1).

## Verified

- Build clean. All three roadmap pages carry the notes link and the shipped card.
- `npm install acorn` was needed to run the flip in a bare clone. `package.json` and `package-lock.json` are **not** in this diff, deliberately: acorn arrives through the Eleventy tree and `check-build-sanity.mjs` already relies on it that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)