### PR TITLE
Run the board-bios sync weekly instead of on demand

### DIFF
--- a/.github/workflows/sync-board.yml
+++ b/.github/workflows/sync-board.yml
@@ -15,10 +15,12 @@
 #      state), the script no-ops cleanly so this workflow stays green
 #      while the Google Form is still being set up.
 #
-# Why manual-only (no cron)
-#   The board changes a few times a year, not weekly. A weekly cron
-#   would produce mostly-empty no-op runs. Run this when you know
-#   submissions are in.
+# Why weekly
+#   The board changes a few times a year, so most runs are no-ops that
+#   exit silently without opening a PR. The weekly tick means a
+#   submission lands on the site within days rather than waiting for
+#   someone to remember to dispatch the workflow. Manual dispatch stays
+#   available for when submissions are known to be in.
 #
 # Where to look
 #   - The sync logic lives in scripts/sync-board.py.
@@ -30,7 +32,9 @@
 name: Sync board bios from Google Form
 
 on:
-  workflow_dispatch: # Manual run from the Actions tab — no cron.
+  schedule:
+    - cron: '30 5 * * 1' # 05:30 UTC every Monday, ahead of the other Monday syncs.
+  workflow_dispatch: # Manual run from the Actions tab.
 
 permissions:
   contents: write

--- a/docs/board-bios-setup.md
+++ b/docs/board-bios-setup.md
@@ -1,19 +1,20 @@
 # Setting up the board-bios Google Form
 
 This guide walks through creating the Google Form, linking it to a Sheet,
-and wiring the published Sheet into the manual sync workflow.
+and wiring the published Sheet into the sync workflow.
 **One-time setup, ~30 minutes.** After this, board updates are:
 
 1. A board / support-team member submits or updates their bio via the Form.
-2. You go to Actions → *Sync board bios from Google Form* → *Run
-   workflow*.
+2. The workflow runs itself every Monday at 05:30 UTC. To pick a
+   submission up sooner, go to Actions → *Sync board bios from Google
+   Form* → *Run workflow*.
 3. A PR appears. You review the diff (one file, `src/_data/board.json`)
    and click Merge.
 
 ## How the pipeline works
 
 ```
-Google Form ──► Google Sheet ──► sync-board.yml (manual) ──► PR ──► review + merge ──► /board.html
+Google Form ──► Google Sheet ──► sync-board.yml (weekly) ──► PR ──► review + merge ──► /board.html
 ```
 
 Two repo-side moving parts:
@@ -212,7 +213,7 @@ the values in `columns` (e.g. your Google account's locale renamed
 *Timestamp* to *Horodateur*), update `columns` to match the exact
 header text in the Sheet.
 
-Commit. The workflow will pick it up on the next manual run.
+Commit. The workflow will pick it up on its next run.
 
 ## Step 5 · Photo permissions — the one Google quirk
 


### PR DESCRIPTION
`sync-board.yml` was manual-dispatch only. It now also runs on a weekly cron (Mondays, 05:30 UTC, ahead of the other Monday syncs), with manual dispatch kept.

The board changes a few times a year, so most runs will no-op and exit without opening a PR. The weekly tick means a Form submission reaches the site within days rather than waiting for someone to remember to dispatch the workflow. `failure-alarm.yml` already watches this workflow, so an unattended failure files an alarm issue.

`docs/board-bios-setup.md` updated inline (rule §11): the pipeline diagram, the setup lede and the two 'next manual run' pointers.

No user-visible change, so no `[Unreleased]` bullet (rule §4 internal-only exemption).