### PR TITLE
chore(publications): judge review-band candidate (routine)

### DIFF
--- a/data/publication-candidates.json
+++ b/data/publication-candidates.json
@@ -13,6 +13,12 @@
     "publishedUrl": "https://doi.org/10.6084/m9.figshare.31056283",
     "titleScore": 0.667,
     "band": "review",
-    "verified": false
+    "verified": false,
+    "llmVerdict": {
+      "verdict": "different_work",
+      "rationale": "Same author (ORCID match) and topic (de facto states, nuclear security, same year), but the figshare DOI resolves to a dataset deposit, not a journal article or book chapter, so it is not a later-published version of the paper's text.",
+      "model": "claude-sonnet-5",
+      "judgedOn": "2026-09-01"
+    }
   }
 ]


### PR DESCRIPTION
Routine run of the #805 Phase 3 review-band judge, done as a manual pre-assessment instead of an API call.

## Verdict

- **2026-fragile-control-how-de-facto-states-degrade-nuclear-security-in-the-donbas** → `different_work`. Same author (ORCID match) and topic (de facto states, nuclear security, same year), but the figshare DOI (`10.6084/m9.figshare.31056283`) resolves to a dataset deposit, not a journal article or book chapter, so it isn't a later-published version of the paper.

Advisory only, no change to `src/_data/paperLinks.json` or the matcher's bands/thresholds. The maintainer still confirms or rejects the match.