### PR TITLE
Report a failed roadmap-card flip instead of calling it nothing to do

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "clean": "rm -rf _site"
   },
   "devDependencies": {
-    "@11ty/eleventy": "^3.1.6"
+    "@11ty/eleventy": "^3.1.6",
+    "acorn": "^8.16.0"
   }
 }

--- a/scripts/flip-roadmap-card.mjs
+++ b/scripts/flip-roadmap-card.mjs
@@ -34,7 +34,18 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
-import * as acorn from "acorn";
+
+// acorn arrives transitively through Eleventy and is declared in
+// devDependencies so this script does not depend on that staying true. A
+// dynamic import is what lets a missing node_modules produce a sentence
+// instead of a module-loader stack trace (#1604).
+let acorn;
+try {
+  acorn = await import("acorn");
+} catch {
+  console.error("error: the `acorn` parser is not installed. Run `npm install` in the repo root, then re-run this script.");
+  process.exit(1);
+}
 
 const require = createRequire(import.meta.url);
 const FILE = new URL("../src/_data/roadmap.js", import.meta.url);

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -283,9 +283,19 @@ if [[ "$DRY_RUN" != "--dry-run" ]]; then
     # edit rather than a judgement, so offer to make it (#280). Shown as a diff
     # first and applied only on an explicit "y": this rewrites hand-translated
     # data during a release, which is the wrong moment to be surprised.
-    if node scripts/flip-roadmap-card.mjs "$VERSION" 2>/dev/null | grep -q 'would flip'; then
+    FLIP_OUT=$(node scripts/flip-roadmap-card.mjs "$VERSION" 2>&1) && FLIP_RC=0 || FLIP_RC=$?
+    if [[ "$FLIP_RC" -ne 0 ]]; then
+      # A broken tool is not a synonym for "already shipped". Reading the two
+      # the same way is how v2.28.0 shipped with a stale public card: the run
+      # had no node_modules, the flip died on its acorn import, and the
+      # cross-check reported that there was no problem (#1604).
+      printf '  Roadmap card: the flip tool failed (exit %s), so the card was NOT checked.\n' "$FLIP_RC"
+      printf '  Cross-check /roadmap by hand before publishing.\n\n'
+      printf '%s\n' "$FLIP_OUT" | sed 's/^/    /'
+      printf '\n'
+    elif printf '%s' "$FLIP_OUT" | grep -q 'would flip'; then
       printf '  The public /roadmap card for v%s is still unshipped:\n\n' "$VERSION"
-      node scripts/flip-roadmap-card.mjs "$VERSION" | sed 's/^/  /'
+      printf '%s\n' "$FLIP_OUT" | sed 's/^/  /'
       printf '\n  Apply this now? Type "y" to flip it, anything else to skip: '
       read -r FLIP
       case "$FLIP" in
@@ -297,10 +307,10 @@ if [[ "$DRY_RUN" != "--dry-run" ]]; then
         *) printf '\n  Skipped. Flip it by hand, or re-run the command above later.\n\n' ;;
       esac
     else
-      # Say so rather than skipping in silence. The guard above missing is
-      # usually benign (the card is already shipped), but when it was the
-      # version format that misfired, a silent skip meant nobody noticed the
-      # offer had been dead since #280 (#1415).
+      # Say so rather than skipping in silence. The tool ran and found nothing
+      # to do, which is usually benign (the card is already shipped), but when
+      # it was the version format that misfired, a silent skip meant nobody
+      # noticed the offer had been dead since #280 (#1415).
       printf '  Roadmap card: nothing to flip for v%s (already shipped, or no card).\n\n' "$VERSION"
     fi
   fi


### PR DESCRIPTION
Closes #1604.

`release.sh` treated any non-zero exit from `flip-roadmap-card.mjs` as a synonym for "nothing to flip (already shipped, or no card)". Cutting v2.28.0 from a checkout with no `node_modules` made the flip die on its `acorn` import, and the cross-check reported that there was no problem. The public roadmap then carried v2.28.0 as *planned*, with no notes link, after the release was live.

### What changed

- **`scripts/release.sh`** captures the tool's combined output and exit code once, then branches three ways: a non-zero exit prints the output and says plainly that the card was **not** checked, `would flip` in the output offers the flip as before, and anything else keeps the existing benign "nothing to flip" line. The maintainer decides whether to continue, so a broken tool no longer passes as a clean cross-check.
- **`scripts/flip-roadmap-card.mjs`** imports `acorn` dynamically and fails with one sentence naming `npm install` when it is missing, rather than an `ERR_MODULE_NOT_FOUND` stack trace.
- **`package.json`** declares `acorn` in `devDependencies`. It was reaching the script transitively through Eleventy, which is not a contract: nothing stops Eleventy dropping it and breaking the flip silently. No new install weight, the package is already in the tree.

Keeping acorn, per the issue's third bullet: it locates and validates the card by parse rather than by regex, which is what makes the textual edit safe.

### Verification

- Fresh checkout with no `node_modules`: `node scripts/flip-roadmap-card.mjs v2.29.0` now prints `error: the \`acorn\` parser is not installed. Run \`npm install\` in the repo root, then re-run this script.` and exits 1, where before it was an `ERR_MODULE_NOT_FOUND` trace.
- Normal run in the repo still emits the four-line `would flip` diff for v2.29.0 and exits 0.
- All three `release.sh` branches exercised against a stubbed tool (exit 1, `would flip`, already-shipped), each printing the intended message.
- `bash -n scripts/release.sh` clean.

Internal tooling only, so no `[Unreleased]` bullet (rule §4).