### PR TITLE
State the theme vocabulary's version and issue date in the SKOS files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,9 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ## [Unreleased]
 
-_Nothing yet._
+### Changed
+
+- The SKOS theme vocabulary states its own version and issue date. The concept scheme in `/vocab/themes.ttl` and `/vocab/themes.jsonld` now carries `owl:versionInfo` and `dct:issued`, so a deposited or downloaded copy can be dated and told apart from another copy without the record it came from. The version is the vocabulary's own, moving when a concept is added, retired or relabelled rather than when the site releases, and a build-time guard fails the build if the concepts move and the version does not.
 
 ## [2.28.0] · 2026-08-29 — A usable Atlas, and a citable theme vocabulary
 

--- a/docs/anthology-machine-readable.md
+++ b/docs/anthology-machine-readable.md
@@ -378,13 +378,38 @@ unaffected.
 
 `themeVocab.js` builds the graph once and emits both Turtle and JSON-LD from
 it, so a label fix lands in both or in neither. Verified isomorphic with
-`rdflib` at 161 triples each when the feature shipped.
+`rdflib` at 163 triples each (161 when the feature shipped, before the two
+versioning predicates below).
 
 | Surface | URL |
 |---|---|
 | Turtle | `/vocab/themes.ttl` |
 | JSON-LD | `/vocab/themes.jsonld` |
 | Human-readable | `/vocab/themes/` |
+
+### Stating its own version
+
+The scheme node carries `owl:versionInfo` and a `dct:issued` typed as
+`xsd:date`, both from constants at the top of `themeVocab.js`. That is
+invisible when the file is fetched from the site, where the URL is the current
+version by definition, and it stops being invisible the moment a `.ttl` is
+deposited or downloaded: a copy in somebody's folder cannot otherwise be dated
+or ordered against another copy (#1607).
+
+The version is **the vocabulary's own SemVer, not the site's**, so it moves
+when a concept is added, retired or relabelled and stays put across every other
+release (docs/corpus-archiving.md). `SCHEME_ISSUED` is the date that version
+was cut, deliberately not the build date: a value that changed on every rebuild
+would make two builds of one vocabulary look like two versions, which is the
+opposite of what versioning an artefact is for.
+
+A hand-maintained constant drifts the moment somebody edits `THEME_RULES` and
+forgets it, so `SCHEME_DIGEST` pins a short hash of the meaning-bearing content
+(every key, its tier, and its label in all three languages). Any change to that
+content fails the build with the digest to paste in, which forces the version
+and its date to be reconsidered in the same PR. The digest is not the version:
+a hash cannot be ordered by a human, it only detects that a bump is owed.
+Adding a paper does not trip it, because papers are not vocabulary.
 
 **Where a reader meets it.** A vocabulary nobody can find is barely better
 than one never minted, and the map is where the people who would reuse this

--- a/docs/corpus-archiving.md
+++ b/docs/corpus-archiving.md
@@ -406,6 +406,16 @@ onto these concepts cares about exactly one thing: whether the concepts
 moved. Versioning by site release would flood them with versions that
 say nothing.
 
+The artefacts state this themselves, so a deposited or downloaded copy
+can be dated and ordered without the record it came from: the scheme
+node in both serialisations carries `owl:versionInfo` and `dct:issued`,
+from `SCHEME_VERSION` and `SCHEME_ISSUED` in `src/_data/themeVocab.js`
+(#1607). Bump both in the same PR that changes a concept. A digest guard
+in that file fails the build if the concepts move and the version does
+not, so the two cannot silently disagree. Set `SCHEME_ISSUED` to the day
+the new version is cut, not to the day it is deposited, and make the
+Zenodo record's version and publication date match what the files say.
+
 ### The Zenodo form, field by field
 
 Ready to paste. Everything here is settled apart from the ORCID, which

--- a/src/_data/themeVocab.js
+++ b/src/_data/themeVocab.js
@@ -17,6 +17,7 @@
  * theme's English name: the name is display text and is translated, the key
  * is not. See docs/anthology-machine-readable.md §4.
  */
+const { createHash } = require("node:crypto");
 const site = require("./site.js");
 const corpus = require("./corpus.js");
 const themePages = require("./atlasThemePages.js");
@@ -24,6 +25,17 @@ const themePages = require("./atlasThemePages.js");
 const SCHEME_URI = `${site.url}/vocab/themes`;
 const LICENCE_URI = "http://creativecommons.org/licenses/by/4.0/";
 const SCHEME_TITLE = "European security studies research themes";
+// The vocabulary carries its own SemVer, which moves when a concept is added,
+// retired or relabelled, not when the site releases
+// (docs/corpus-archiving.md). Stating it in the file is what lets a .ttl
+// sitting in somebody's downloads folder be dated and ordered against another
+// copy, which is the whole point of versioning it (#1607). SCHEME_ISSUED is
+// the date that version was cut, never the build date: a value that moved on
+// every rebuild would make two builds of one vocabulary look like two
+// versions. SCHEME_DIGEST is the guard, see checkDigest below.
+const SCHEME_VERSION = "1.0.0";
+const SCHEME_ISSUED = "2026-08-29";
+const SCHEME_DIGEST = "d3d49c2e954f399e";
 const COLLECTIONS = {
   permanent: {
     uri: `${SCHEME_URI}/collection/permanent-sections`,
@@ -70,17 +82,45 @@ module.exports = function () {
     };
   });
 
+  // A hand-maintained version drifts the moment somebody edits THEME_RULES and
+  // forgets to bump it, so the meaning-bearing content is digested and pinned.
+  // Anything that changes what the vocabulary says (a key, a label in any
+  // language, a collection membership) fails the build until SCHEME_VERSION,
+  // SCHEME_ISSUED and this digest are all reconsidered together. The digest is
+  // not the version: it cannot be ordered by a human, it only detects that one
+  // is owed.
+  const digest = createHash("sha256")
+    .update(
+      JSON.stringify(
+        concepts.map((x) => [x.key, x.tier, x.prefLabel.en, x.prefLabel.fr, x.prefLabel.de])
+      )
+    )
+    .digest("hex")
+    .slice(0, 16);
+  if (digest !== SCHEME_DIGEST) {
+    throw new Error(
+      `themeVocab: the vocabulary content changed but SCHEME_VERSION is still ${SCHEME_VERSION}.\n` +
+        `  Bump SCHEME_VERSION, set SCHEME_ISSUED to today, and set SCHEME_DIGEST to "${digest}"\n` +
+        "  in src/_data/themeVocab.js. A relabelled or retired concept is a new version of the\n" +
+        "  vocabulary (docs/corpus-archiving.md). Adding a paper is not."
+    );
+  }
+
   const membersOf = (tier) => concepts.filter((x) => x.tier === tier);
 
   const turtle = [
     "@prefix skos: <http://www.w3.org/2004/02/skos/core#> .",
     "@prefix dct:  <http://purl.org/dc/terms/> .",
     "@prefix foaf: <http://xmlns.com/foaf/0.1/> .",
+    "@prefix owl:  <http://www.w3.org/2002/07/owl#> .",
+    "@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .",
     "",
     `<${SCHEME_URI}> a skos:ConceptScheme ;`,
     `  dct:title ${ttl(SCHEME_TITLE)}@en ;`,
     `  dct:creator ${ttl(site.fullName)} ;`,
     `  dct:license <${LICENCE_URI}> ;`,
+    `  owl:versionInfo ${ttl(SCHEME_VERSION)} ;`,
+    `  dct:issued "${SCHEME_ISSUED}"^^xsd:date ;`,
     "  skos:hasTopConcept",
     concepts.map((x) => `    <${x.uri}>`).join(" ,\n") + " .",
     "",
@@ -110,6 +150,8 @@ module.exports = function () {
       skos: "http://www.w3.org/2004/02/skos/core#",
       dct: "http://purl.org/dc/terms/",
       foaf: "http://xmlns.com/foaf/0.1/",
+      owl: "http://www.w3.org/2002/07/owl#",
+      xsd: "http://www.w3.org/2001/XMLSchema#",
     },
     "@graph": [
       {
@@ -118,6 +160,8 @@ module.exports = function () {
         "dct:title": { "@value": SCHEME_TITLE, "@language": "en" },
         "dct:creator": site.fullName,
         "dct:license": { "@id": LICENCE_URI },
+        "owl:versionInfo": SCHEME_VERSION,
+        "dct:issued": { "@value": SCHEME_ISSUED, "@type": "xsd:date" },
         "skos:hasTopConcept": concepts.map((x) => ({ "@id": x.uri })),
       },
       ...Object.entries(COLLECTIONS).map(([tier, col]) => ({
@@ -143,6 +187,8 @@ module.exports = function () {
   return {
     schemeUri: SCHEME_URI,
     title: SCHEME_TITLE,
+    version: SCHEME_VERSION,
+    issued: SCHEME_ISSUED,
     concepts,
     // English theme name to its concept URI, for the surfaces that hold a
     // theme's name rather than its key (#1571). The name is the join key


### PR DESCRIPTION
Closes #1607.

`/vocab/themes.ttl` and `/vocab/themes.jsonld` described the concept scheme with `dct:title`, `dct:creator` and `dct:license` and nothing else. Invisible while the file is fetched from the site, where the URL is the current version by definition. Not invisible once it is deposited: a `.ttl` in a downloads folder, or copied out of a Zenodo record, could not be dated or ordered against another copy.

### What changed

The scheme node in both serialisations now carries `owl:versionInfo` and a `dct:issued` typed as `xsd:date`, emitted from the one structure so they cannot disagree. Both come from constants at the top of `src/_data/themeVocab.js`:

- `SCHEME_VERSION = "1.0.0"`, the vocabulary's own SemVer per the deposit decision recorded in `docs/corpus-archiving.md`. It moves when a concept is added, retired or relabelled, not when the site releases.
- `SCHEME_ISSUED = "2026-08-29"`, the date 1.0.0 was cut. Deliberately not the build date: a value that changed on every rebuild would make two builds of one vocabulary look like two versions.

This is the issue's option 1 plus its option 2 gate. `SCHEME_DIGEST` pins a short hash of the meaning-bearing content (every key, its tier, its label in all three languages). Any change to that content fails the build with the digest to paste in, so the version and its date get reconsidered in the same PR that moved the concepts. The digest is not the version, a hash cannot be ordered by a human, it only detects that a bump is owed. Adding a paper does not trip it.

`docs/anthology-machine-readable.md` §4 gains a *Stating its own version* subsection, and `docs/corpus-archiving.md`'s versioning section now points at the constants and the guard (rule §11, inline at PR time).

### Verification

- Both serialisations parse with `rdflib` at **163 triples each** (161 before, plus the two new predicates), and both report `versionInfo=1.0.0` and `issued=2026-08-29` typed `xsd:date` on the scheme URI.
- Guard fires: relabelling a theme's **French** label makes the build fail with the bump instruction. Chosen over the English label because an English relabel trips the older Atlas-page guard first, so this proves the digest covers all three languages rather than riding on an existing check.
- Guard stays quiet on the unmodified tree: `npx @11ty/eleventy` writes 1431 files clean.
- `scripts/check-i18n-drift.py`: zero drift.
- Working tree restored clean after the guard test (rule §8).

Not visual, so auto-merge is armed.