### PR TITLE
Fix four accessibility defects found in a full-site QA pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,12 +97,17 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ## [Unreleased]
 
+### Fixed
+
+- Every page carried an invisible link at the end of its tab order. The shared hovercard that shows a person's role when their name appears in prose was built empty on page load and marked hidden, but a stylesheet rule outranked that, so the placeholder link inside it stayed reachable by keyboard and the empty card stayed audible to screen readers on all 1,159 pages. The card behaves as before when a name is hovered or focused.
+- The host-city map on `/initiative` and the partner strip on `/prizes` were each described to assistive technology as a single image, which hid the seven conference links inside the map and the partner link beside it. Both now expose their links while keeping their descriptions.
+- The archive banner's "Archive" badge failed the AA contrast floor at 4.44:1 against its own background. Now 5.13:1, same colour.
+- Four pages scrolled sideways on a phone, pushed out by an identifier or a web address too long to break: `/licensing` by 153px, `/vocab/themes` by 49px, `/policy` by 21px and `/anthology-atlas` by 16px. Long identifiers now wrap.
+- Sanne Verschuren's website link points at the address her site actually answers on. Her site serves no working HTTPS, so the `https://` form was dead in a browser, and the correction made once by hand had been overwritten by the board-bios sync. The sync now holds a small table of links to pin, so the correction survives every future run.
+
 ### Removed
 
 - 102 orphaned images from the Mobirise era, about 25 MB, no longer cloned on checkout or served to the site. They were passthrough-copied into every deploy while no page, stylesheet, feed or serialisation referenced them: AMP-era screen captures, superseded logo files and stray crops. Verified against the built output rather than by name, so the share cards that are assembled at build time and never named literally were not caught in it.
-### Fixed
-
-- Sanne Verschuren's website link points at the address her site actually answers on. Her site serves no working HTTPS, so the `https://` form was dead in a browser, and the correction made once by hand had been overwritten by the board-bios sync. The sync now holds a small table of links to pin, so the correction survives every future run.
 
 ### Changed
 

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -18,14 +18,14 @@
     "src/initiative.njk": {
       "fr": {
         "file": "src/initiative.fr.njk",
-        "source_sha1": "c7f2fe4fe3aebafc3ccac2633bc8d1000de22901",
-        "translated_on": "2026-08-18",
+        "source_sha1": "65c59f1da3e151563ffbfcfddfd6a88629d102cf",
+        "translated_on": "2026-09-02",
         "status": "beta"
       },
       "de": {
         "file": "src/initiative.de.njk",
-        "source_sha1": "c7f2fe4fe3aebafc3ccac2633bc8d1000de22901",
-        "translated_on": "2026-08-18",
+        "source_sha1": "65c59f1da3e151563ffbfcfddfd6a88629d102cf",
+        "translated_on": "2026-09-02",
         "status": "beta"
       }
     },

--- a/src/_includes/prizes-body.njk
+++ b/src/_includes/prizes-body.njk
@@ -11,7 +11,7 @@
        award the prize. Both are the real brand SVGs, inlined so they inherit
        the theme text colour (jss-logo.svg uses currentColor, cropped to the
        wordmark from the prize-certificate master). #}
-    <div class="prize-partners" role="img" aria-label="{{ t.prizes.partner }}">
+    <div class="prize-partners" role="group" aria-label="{{ t.prizes.partner }}">
       <span class="prize-partner prize-partner--eiss" aria-hidden="true">{% inlineSvg "assets/images/brand/logo-lockup.svg" %}</span>
       <span class="prize-partner-sep" aria-hidden="true"></span>
       <a class="prize-partner prize-partner--jss" href="https://www.tandfonline.com/journals/fjss20" target="_blank" rel="noopener" aria-label="Journal of Strategic Studies (opens in a new tab)">{% inlineSvg "assets/images/brand/jss-logo.svg" %}</a>

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -741,7 +741,9 @@ h4 { font-size: var(--fs-lg); }
   display: inline-block;
   padding: 2px 10px;
   border-radius: 999px;
-  background: hsl(220, 18%, 50%);
+  /* 50% lightness gave white 4.44:1, a hair under the 4.5:1 AA floor for
+     11px bold. 46% is the same grey-blue at 5.05:1. */
+  background: hsl(220, 18%, 46%);
   color: white;
   font-size: 11px;
   font-weight: 700;
@@ -1823,6 +1825,18 @@ h4 { font-size: var(--fs-lg); }
 
 .pdf-doc-meta {
   min-width: 0;
+}
+
+/* Long unbreakable tokens (a SWHID, a concept URI, a repository URL written
+   out as its own link text) were pushing the page wider than a phone screen:
+   /licensing by 153px at 375px, /vocab/themes by 49px, /policy by 21px. These
+   are the places such tokens appear (the citation blockquotes carry a bare
+   DOI URL as plain text), so they break anywhere rather than forcing the whole
+   document to scroll sideways. */
+code,
+blockquote,
+a[href^="http"]:not([class]) {
+  overflow-wrap: anywhere;
 }
 
 .pdf-doc-title {
@@ -7325,9 +7339,20 @@ a.joint-orgs-card:hover .joint-orgs-name {
   transform: translateY(4px);
   pointer-events: none;
   transition: opacity var(--motion-fast) var(--ease-out),
-              transform var(--motion-fast) var(--ease-out);
+              transform var(--motion-fast) var(--ease-out),
+              visibility 0s linear var(--motion-fast);
 }
-.person-hovercard.is-visible { opacity: 1; transform: none; pointer-events: auto; }
+/* `hidden` alone does nothing here: the `display: flex` above outranks the UA
+   `[hidden] { display: none }`, so the idle card stayed in the accessibility
+   tree and its empty placeholder link stayed in the tab order on every page
+   that loads people-hovercards.js. Driving AT visibility off `visibility`
+   removes both, and the delayed transition keeps the fade-out playing (the
+   flip happens after the opacity has finished). */
+.person-hovercard { visibility: hidden; }
+.person-hovercard.is-visible {
+  opacity: 1; transform: none; pointer-events: auto; visibility: visible;
+  transition-delay: 0s;
+}
 .person-hovercard-media {
   flex: 0 0 auto;
   inline-size: 56px;
@@ -7767,7 +7792,11 @@ a.profile-pub-title:hover { text-decoration: underline; }
 }
 .atlas-matrix__summary {
   cursor: pointer;
+  /* max-content alone made the marker sit at its intrinsic 371px on a 375px
+     phone, which pushed the page 16px sideways. Capping it lets the label
+     wrap instead. */
   width: max-content;
+  max-inline-size: 100%;
   font-size: var(--fs-sm);
   color: var(--accent);
 }

--- a/src/initiative.de.njk
+++ b/src/initiative.de.njk
@@ -271,7 +271,7 @@ alternates:
     <figure class="essc-map-figure card" style="padding: var(--space-5); margin-top: var(--space-5);">
       {#- See EN file for projection-correction rationale (viewBox 1000 ×
           980, outline scaled in y by 1.4). -#}
-      <svg viewBox="0 0 1000 980" class="essc-map" role="img" aria-labelledby="essc-map-title essc-map-desc" preserveAspectRatio="xMidYMid meet">
+      <svg viewBox="0 0 1000 980" class="essc-map" role="group" aria-labelledby="essc-map-title essc-map-desc" preserveAspectRatio="xMidYMid meet">
         <title id="essc-map-title">Gastgeberstädte der ESSC in Europa, 2017 - 2026</title>
         <desc id="essc-map-desc">Stilisierte Karte mit den europäischen Städten, die seit 2017 die jährliche ESSC-Konferenz ausgerichtet haben, mit Punkten für jeden Veranstaltungsort.</desc>
 

--- a/src/initiative.fr.njk
+++ b/src/initiative.fr.njk
@@ -269,7 +269,7 @@ alternates:
     <figure class="essc-map-figure card" style="padding: var(--space-5); margin-top: var(--space-5);">
       {#- See EN file for projection-correction rationale (viewBox 1000 ×
           980, outline scaled in y by 1.4). -#}
-      <svg viewBox="0 0 1000 980" class="essc-map" role="img" aria-labelledby="essc-map-title essc-map-desc" preserveAspectRatio="xMidYMid meet">
+      <svg viewBox="0 0 1000 980" class="essc-map" role="group" aria-labelledby="essc-map-title essc-map-desc" preserveAspectRatio="xMidYMid meet">
         <title id="essc-map-title">Villes hôtes de l'ESSC en Europe, 2017 - 2026</title>
         <desc id="essc-map-desc">Carte stylisée montrant les villes européennes qui ont accueilli la conférence annuelle ESSC depuis 2017, avec des points marquant chaque lieu d'accueil.</desc>
 

--- a/src/initiative.njk
+++ b/src/initiative.njk
@@ -299,7 +299,7 @@ alternates:
           viewBox to 1000×980 while keeping country proportions close
           to what people are used to seeing. Dot cy and text y are
           pre-multiplied by 1.4 to match the outline scaling. -#}
-      <svg viewBox="0 0 1000 980" class="essc-map" role="img" aria-labelledby="essc-map-title essc-map-desc" preserveAspectRatio="xMidYMid meet">
+      <svg viewBox="0 0 1000 980" class="essc-map" role="group" aria-labelledby="essc-map-title essc-map-desc" preserveAspectRatio="xMidYMid meet">
         <title id="essc-map-title">ESSC host cities across Europe, 2017 - 2026</title>
         <desc id="essc-map-desc">A stylized map showing the European cities that have hosted the annual ESSC conference since 2017, with dots marking each host location.</desc>
 


### PR DESCRIPTION
Four accessibility defects found in a full-site QA pass, all verified fixed in a real browser rather than by a green build (rule §14).

The pass ran axe-core 4.13 three ways, because no single one covers everything: headless Chrome at a true 375px and 1280px viewport in both colour schemes (Chrome's `--window-size` has a 500px floor, so this drives CDP `Emulation.setDeviceMetricsOverride` directly), axe under jsdom across all 660 generated pages, and the repo's own `a11y_lint.py`, `check-links.sh` and `check-build-sanity.mjs`.

### 1. An invisible link at the end of the tab order, on all 1,159 pages

The worst of the four, and invisible to every gate the repo has.

`people-hovercards.js` builds its shared card empty on page load and sets `card.hidden = true`. But `.person-hovercard` sets `display: flex`, which outranks the user-agent `[hidden] { display: none }`. So the card was never hidden from assistive technology at all, only made transparent: `visibility: visible`, `opacity: 0`, a real 336×90 box in the layout, and inside it an empty `<a href="#">` with `tabIndex: 0`.

Measured on the homepage: that link is focusable and sits at index **85 of 86** focusables. Every keyboard user tabbing to the end of any page on the site lands on an invisible link that goes nowhere, and a screen reader meets a `role="tooltip"` with no name. axe reported `link-name` and `aria-tooltip-name`, both serious, on every page.

`a11y_lint.py` did not catch it because the card does not exist in the built HTML: it is created by script at runtime. This is the §14 failure mode exactly, markup and JS both correct and the CSS defeating them.

The fix drives AT visibility off `visibility` rather than the `hidden` attribute, with a delayed transition so the fade-out still plays.

**Verified:** idle → `visibility: hidden`, the empty link no longer accepts focus. On hover → visible, opacity 1, "Dr Hugo Meijer / Founding and Honorary Director", link text "View profile" pointing at `/board/dr-hugo-meijer.html`, `aria-describedby` wired, card positioned 336×185. On leave → hidden again. Behaviour unchanged, defect gone.

### 2. `role="img"` was hiding real links

The ESSC host-city map on `/initiative` is an `<svg role="img">` containing **seven `<a href>` links** to the edition pages. `role="img"` declares the whole thing one image, so those seven links were not in the accessibility tree. The same pattern on `/prizes`: `.prize-partners` is a `role="img"` wrapping the Journal of Strategic Studies link.

Both become `role="group"`, which keeps the existing `aria-labelledby` / `aria-label` and exposes the contents.

**Verified:** 7 of 7 map links and 1 of 1 partner link now focusable, `nested-interactive` clear, on EN, FR and DE.

### 3. The archive badge missed AA by 0.06

`.archive-ribbon-badge` is white on `hsl(220 18% 50%)` = **4.44:1**. It is 11px bold, which is not large text, so AA needs 4.5:1. On 13 archive pages in three locales. Dropping to 46% lightness gives **5.13:1** in the same hue.

### 4. Four pages scrolled sideways on a phone

At a true 375px viewport: `/licensing` **+153px**, `/vocab/themes` +49px, `/policy` +21px, `/anthology-atlas` +16px.

Four different unbreakable tokens: the Software Heritage SWHID in a `<code>`, the concept URIs, `github.com/EISSeuropa/EISSeuropa.github.io` written out as its own link text, and a bare DOI URL as plain text inside the citation blockquote. The Atlas case was different, `.atlas-matrix__summary { width: max-content }` sitting at its intrinsic 371px.

**Verified:** all four at 0 overflow, all three locales of `/licensing` included.

### Gates

`a11y_lint.py` 0 issues across 637 pages · `check-build-sanity.mjs` passes · `check-i18n-drift.py` clean · `check-links.sh` zero internal broken (two external failures are this machine's DNS: both resolve and answer when queried through 1.1.1.1).

The FR and DE `initiative` pages received the identical attribute change, so their drift stamps are marked fresh rather than re-translated. No copy was translated (rule §1).

### Visual review

The only visible change is the archive badge going one notch darker. The map, the partner strip and the hovercard render identically. Not arming auto-merge, per §2, since a badge colour is still a thing a human sees.

### What this pass found but did not fix

Filed separately rather than folded in here, because each is a decision rather than a defect: the brand accent's contrast headroom, `role="button"` on `<video>`, the Atlas filter summary, and links distinguished from prose by colour alone.
