### PR TITLE
Treat a reset connection like a cut TLS session in the link checker

### DIFF
--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -386,7 +386,22 @@ def check_external(url, _retry=True, _attempt=1):
         # a laptop. It was on the skip list for the same underlying reason
         # until #1423 took it off, and a skip is a permanent blind spot, so it
         # gets patience and a warning instead of a skip or a red build.
-        if "UNEXPECTED_EOF_WHILE_READING" in str(e) or "SSLEOFError" in e.__class__.__name__:
+        # A reset is the same event one layer down: the peer dropped the
+        # connection rather than closing the TLS session, and urllib surfaces
+        # it as ConnectionResetError (errno 104) rather than an SSL error. It
+        # was missing from this list, so the same host could produce a warning
+        # for one URL and a red build for another in a single run: on 2 Sep
+        # 2026 europeangovernanceandpolitics.eui.eu was excused for its page
+        # and failed the build for a 5 MB PDF beside it, which answers 200
+        # from a laptop. The larger the response the likelier the cut, so the
+        # split was arbitrary rather than meaningful.
+        reason_e = getattr(e, "reason", e)
+        if (
+            "UNEXPECTED_EOF_WHILE_READING" in str(e)
+            or "SSLEOFError" in e.__class__.__name__
+            or isinstance(reason_e, ConnectionResetError)
+            or "connection reset by peer" in str(e).lower()
+        ):
             return _again("unreachable")
         # A connect timeout arrives wrapped in URLError; a read timeout does
         # not (see the TimeoutError branch below). Both go to the schedule.

--- a/scripts/test-check-links.py
+++ b/scripts/test-check-links.py
@@ -11,6 +11,7 @@ SKIP_HOSTS are pinned:
     ENETUNREACH    -> retried once, then takes the second answer
     5xx that clears -> retried on a widening pause, then passes (#1423)
     TLS cut        -> retried, then reported unreachable rather than broken
+    conn reset     -> same, one layer down (#1628)
     5xx every time -> still broken, after every attempt is spent
     hanging host   -> every attempt in TIMEOUT_SCHEDULE is made, then reported
                       as slow rather than broken (#1417)
@@ -110,6 +111,21 @@ urllib.request.urlopen = ns['urllib'].request.urlopen = real
 print(f'  TLS cut every time -> {st!r} after {calls["n"]} attempt(s)')
 fails += [] if st == 'unreachable' else ['a cut TLS connection should report unreachable, not broken']
 
+# The same event one layer down: the peer resets the connection instead of
+# closing the TLS session, so urllib raises ConnectionResetError rather than an
+# SSL error. It was not classified, so one flaky host could warn for its page
+# and fail the build for a large PDF beside it in a single run (#1628).
+resets = {'n': 0}
+def conn_reset(req, **kw):
+    resets['n'] += 1
+    raise urllib.error.URLError(ConnectionResetError(104, 'Connection reset by peer'))
+ns['TIMEOUT_PAUSES'] = (0.05, 0.05)
+urllib.request.urlopen = ns['urllib'].request.urlopen = conn_reset
+u, st = check_external(f'{base}/ok')
+urllib.request.urlopen = ns['urllib'].request.urlopen = real
+print(f'  connection reset every time -> {st!r} after {resets["n"]} attempt(s)')
+fails += [] if st == 'unreachable' else ['a reset connection should report unreachable, not broken']
+
 # A host that accepts the connection and never answers must exhaust the
 # schedule and come back as the "timeout" sentinel, which the report prints as
 # a slow host rather than counting as broken (#1417). The clock is shrunk here
@@ -133,5 +149,5 @@ fails += [] if (st == 'timeout' and len(connections) == 3) else \
     ['a hanging host should exhaust TIMEOUT_SCHEDULE and report "timeout", not broken']
 
 srv.shutdown()
-print('\nFAIL: ' + '; '.join(fails) if fails else '\nall eight behaviours correct')
+print('\nFAIL: ' + '; '.join(fails) if fails else '\nall nine behaviours correct')
 sys.exit(1 if fails else 0)


### PR DESCRIPTION
The external link check failed on #1627 for a reason that has nothing to do with that PR, and the failure and the pass came from the **same host in the same run**:

```
⚠ https://europeangovernanceandpolitics.eui.eu/global-risks-eu/
   (connection cut on 3 attempts — unreachable from CI, not counted as broken)

EXTERNAL BROKEN (1):
✗ GlobalRisks.html → …/documents/QM-01-25-294-EN-N.pdf
   (err: URLError: <urlopen error [Errno 104] Connection reset by peer>)
```

Both are the runner failing to hold a conversation with the host. #1423 already settled that this deserves patience and a warning rather than a red build, and took this exact host off the skip list on that reasoning. The classifier only recognised the TLS-layer form of it (`UNEXPECTED_EOF_WHILE_READING`, `SSLEOFError`); a peer that resets the socket surfaces as `ConnectionResetError` (errno 104) instead and fell through to `broken`.

Which URL got excused and which failed the build was therefore arbitrary, and biased by size: the bigger the response the likelier the cut, so the 5 MB PDF was always the one to lose. It answers `200` with 5,150,802 bytes from a laptop.

`ConnectionResetError` now joins the same branch, matched on the exception type and on the message, since urllib does not promise which layer wraps it.

`scripts/test-check-links.py` gains the case as its ninth behaviour, and **fails without the fix**:

```
  TLS cut every time -> 'unreachable' after 3 attempt(s)
  connection reset every time -> 'unreachable' after 3 attempt(s)
  hanging host -> 'timeout' after 3 attempt(s)

all nine behaviours correct
```

Removing the fix turns that into `FAIL: a reset connection should report unreachable, not broken`.

CI tooling only, no site change, so no `[Unreleased]` bullet (rule §4).