### PR TITLE
Bring the accessibility statement in line with the September audit

### DIFF
--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -144,13 +144,13 @@
     "src/accessibility.njk": {
       "fr": {
         "file": "src/accessibility.fr.njk",
-        "source_sha1": "d68493df94cb8a5750748ccfdf1799739cd74601",
+        "source_sha1": "d1cae7a527b2efdc9b5a895031e8a282d91b138d",
         "translated_on": "2026-09-02",
         "status": "beta"
       },
       "de": {
         "file": "src/accessibility.de.njk",
-        "source_sha1": "d68493df94cb8a5750748ccfdf1799739cd74601",
+        "source_sha1": "d1cae7a527b2efdc9b5a895031e8a282d91b138d",
         "translated_on": "2026-09-02",
         "status": "beta"
       }

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -144,14 +144,14 @@
     "src/accessibility.njk": {
       "fr": {
         "file": "src/accessibility.fr.njk",
-        "source_sha1": "eb14b3d3915f2f1cb2828603b84e38829af71b67",
-        "translated_on": "2026-08-21",
+        "source_sha1": "d68493df94cb8a5750748ccfdf1799739cd74601",
+        "translated_on": "2026-09-02",
         "status": "beta"
       },
       "de": {
         "file": "src/accessibility.de.njk",
-        "source_sha1": "eb14b3d3915f2f1cb2828603b84e38829af71b67",
-        "translated_on": "2026-08-21",
+        "source_sha1": "d68493df94cb8a5750748ccfdf1799739cd74601",
+        "translated_on": "2026-09-02",
         "status": "beta"
       }
     },

--- a/src/accessibility.de.njk
+++ b/src/accessibility.de.njk
@@ -108,7 +108,9 @@ alternates:
         verborgen waren, ein Abzeichen unter dem Kontrastminimum auf dreizehn Archivseiten und
         vier Seiten, die auf einem Telefon seitlich scrollten. Diese Punkte sind behoben. Die
         übrigen sind in <a href="#known-limitations">&sect;3</a> mit den zugehörigen Tickets
-        aufgeführt.
+        aufgeführt. Vier weitere, die dieselbe Prüfung meldete, wurden kurz darauf behoben: das
+        Bedienelement des Konferenzfilms, das Filterfeld des Atlas, Links in grauen Absätzen und
+        eine Tabelle, die scrollte, ohne mit der Tastatur erreichbar zu sein.
       </p>
 
       <h2 id="known-limitations">3. Bekannte Einschränkungen</h2>
@@ -164,18 +166,6 @@ alternates:
           behoben statt umgangen. Nachverfolgt in
           <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1624" target="_blank" rel="noopener">Ticket&nbsp;#1624</a>.
         </li>
-        <li>
-          <strong>Vier kleinere Mängel vor der Veröffentlichung.</strong> Der Konferenzfilm gibt
-          sich gegenüber Hilfstechnologien mit einer Rolle aus, die auf einem Videoelement nicht
-          zulässig ist. Das Filterfeld des Atlas setzt eine Schaltfläche in das Bedienelement,
-          das es öffnet. Links in grauen Absätzen unterscheiden sich vom umgebenden Text allein
-          durch die Farbe. Die Token-Tabelle des Designsystems scrollt seitlich, ohne mit der
-          Tastatur erreichbar zu sein.
-          <em>Abhilfe:</em> der Film lässt sich weiterhin durch Antippen anhalten, die
-          Atlas-Filter lassen sich weiterhin zurücksetzen, und die betroffenen Seiten bleiben
-          nutzbar. Die Korrekturen sind geschrieben und werden in
-          <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1625" target="_blank" rel="noopener">Ticket&nbsp;#1625</a> nachverfolgt.
-        </li>
       </ol>
 
       <h2>4. Implementierte Barrierefreiheitsfunktionen</h2>
@@ -183,6 +173,8 @@ alternates:
         <li>Semantische Landmarken (<code>&lt;header&gt;</code>, <code>&lt;nav aria-label="Primary"&gt;</code>, <code>&lt;main&gt;</code>, <code>&lt;footer&gt;</code>) und ein Skip-to-Content-Link als erstes fokussierbares Element auf jeder Seite</li>
         <li>Sichtbare Fokusindikatoren über <code>:focus-visible</code> auf jedem interaktiven Steuerelement</li>
         <li>Helles und dunkles Farbschema, die die WCAG&nbsp;AA-Kontrastverhältnisse für Fließtext und Bedienelemente erfüllen, mit Ausnahme des in §3 festgehaltenen Falls</li>
+        <li>Unterstrichene Links in grauen Absätzen, wo der Akzent gegenüber dem umgebenden Text nur 1,76:1 erreicht und Farbe allein sie nicht unterscheidbar machen würde (WCAG&nbsp;1.4.1)</li>
+        <li>Der Konferenzfilm lässt sich mit der Tastatur anhalten, über ein benanntes Bedienelement, das während der Wiedergabe erreichbar bleibt</li>
         <li>Automatischer Dunkelmodus über <code>prefers-color-scheme</code>, mit manueller Übersteuerung, die in <code>localStorage</code> persistiert wird</li>
         <li>Alle Animationen auf <code>prefers-reduced-motion</code> gestaffelt — wenn der Nutzer dies deaktiviert, werden Übergänge und Reveal-Animationen ausgeschaltet</li>
         <li>Größenveränderbarer Text, der sauber bei 200 % Zoom und bei Viewports bis 320&nbsp;px umfließt</li>
@@ -236,7 +228,7 @@ alternates:
         EN&nbsp;301&nbsp;549. Alle Vorlagen der Website erfüllen den Standard; das Label
         „teilweise Konformität" spiegelt die in §3 dokumentierten Einschränkungen wider (eingebettete
         PDFs, transluzente Flächen, generischer Alt-Text auf einigen Archivfotos, die
-        Akzentfarbe auf getönten Flächen und die vier Punkte vor der Veröffentlichung). Das
+        Akzentfarbe auf getönten Flächen). Das
         statische Lint und die Prüfungen auf Auszeichnungsebene melden keine Verstöße, und die
         Elemente, die sie in „manuelle Überprüfung" geben, wurden einzeln als konform
         verifiziert. Der im Browser durchgeführte Durchlauf vom September&nbsp;2026 ist die

--- a/src/accessibility.de.njk
+++ b/src/accessibility.de.njk
@@ -74,7 +74,8 @@ alternates:
         Über automatisierte Tools hinaus wird der statische Linter
         <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/blob/master/scripts/a11y_lint.py" target="_blank" rel="noopener">scripts/a11y_lint.py</a>
         bei jedem Build ausgeführt und meldet derzeit
-        <strong>0&nbsp;Seiten mit Problemen</strong> über alle Vorlagen hinweg.
+        <strong>0&nbsp;Seiten mit Problemen</strong> über alle Vorlagen hinweg. Es liest das
+        erzeugte HTML und prüft damit die Auszeichnung, nicht die gezeichnete Seite.
       </p>
       <p>
         Im <strong>Juni&nbsp;2026</strong> haben wir eine umfassendere, websiteweite Überprüfung
@@ -87,6 +88,27 @@ alternates:
         <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/issues" target="_blank" rel="noopener">Issue-Tracker</a>
         festgehalten; die daraus resultierenden Verbesserungen sind in §4 und die verbleibenden
         Punkte in §3 wiedergegeben.
+      </p>
+      <p>
+        Im <strong>September&nbsp;2026</strong> haben wir die Methode erweitert. Das statische
+        Lint und die früheren Prüfungen lasen jede Seite so, wie sie ausgeliefert wird, und nicht
+        so, wie ein Browser sie zeichnet: alles, was von Layout, berechneter Farbe oder einem
+        laufenden Skript abhängt, lag außerhalb dessen, was sie melden konnten. Wir haben
+        <a href="https://github.com/dequelabs/axe-core" target="_blank" rel="noopener">axe-core&nbsp;4.13</a>
+        erneut in einem echten Browser ausgeführt, in Telefon- und in Desktopbreite, in beiden
+        Farbschemata, über <strong>51&nbsp;Seiten</strong>, und noch einmal über alle
+        <strong>660</strong> generierten Beitrags-, Personen- und Themenseiten.
+      </p>
+      <p>
+        Dabei kamen <strong>acht Mängel</strong> zutage, die die früheren Durchläufe nicht melden
+        konnten. Der schwerwiegendste war ein leerer Link ohne Bezeichnung am Ende der
+        Tabulatorreihenfolge <strong>jeder Seite der Website</strong>, dort gehalten von einer
+        Stilregel, die das Attribut <code>hidden</code> der Karte mit den Angaben zu einer Person
+        außer Kraft setzte. Daneben: eine Karte, deren sieben Konferenzlinks vor Bildschirmlesern
+        verborgen waren, ein Abzeichen unter dem Kontrastminimum auf dreizehn Archivseiten und
+        vier Seiten, die auf einem Telefon seitlich scrollten. Diese Punkte sind behoben. Die
+        übrigen sind in <a href="#known-limitations">&sect;3</a> mit den zugehörigen Tickets
+        aufgeführt.
       </p>
 
       <h2 id="known-limitations">3. Bekannte Einschränkungen</h2>
@@ -132,19 +154,40 @@ alternates:
           HTML-Schaltflächen, die mit der Tastatur erreichbar sind und einen
           <code>aria-pressed</code>-Zustand tragen, wo sie umschalten.
         </li>
+        <li>
+          <strong>Link- und Bezeichnungsfarbe auf getönten Flächen.</strong> Das Akzentblau für
+          Links und Rollenbezeichnungen misst 4,51:1 auf Weiß und liegt damit ein Hundertstel
+          über dem AA-Minimum. Auf einer getönten statt weißen Fläche fällt es darunter: die
+          Rollenbezeichnungen und Profillinks auf der Seite Die Menschen messen 3,99:1, die
+          Kategorie-Chips auf der Startseite und der Aktuelles-Seite 4,05:1.
+          <em>Abhilfe:</em> keine, die die Farbe unangetastet lässt; dieser Punkt wird daher
+          behoben statt umgangen. Nachverfolgt in
+          <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1624" target="_blank" rel="noopener">Ticket&nbsp;#1624</a>.
+        </li>
+        <li>
+          <strong>Vier kleinere Mängel vor der Veröffentlichung.</strong> Der Konferenzfilm gibt
+          sich gegenüber Hilfstechnologien mit einer Rolle aus, die auf einem Videoelement nicht
+          zulässig ist. Das Filterfeld des Atlas setzt eine Schaltfläche in das Bedienelement,
+          das es öffnet. Links in grauen Absätzen unterscheiden sich vom umgebenden Text allein
+          durch die Farbe. Die Token-Tabelle des Designsystems scrollt seitlich, ohne mit der
+          Tastatur erreichbar zu sein.
+          <em>Abhilfe:</em> der Film lässt sich weiterhin durch Antippen anhalten, die
+          Atlas-Filter lassen sich weiterhin zurücksetzen, und die betroffenen Seiten bleiben
+          nutzbar. Die Korrekturen sind geschrieben und werden in
+          <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1625" target="_blank" rel="noopener">Ticket&nbsp;#1625</a> nachverfolgt.
+        </li>
       </ol>
 
       <h2>4. Implementierte Barrierefreiheitsfunktionen</h2>
       <ul>
         <li>Semantische Landmarken (<code>&lt;header&gt;</code>, <code>&lt;nav aria-label="Primary"&gt;</code>, <code>&lt;main&gt;</code>, <code>&lt;footer&gt;</code>) und ein Skip-to-Content-Link als erstes fokussierbares Element auf jeder Seite</li>
         <li>Sichtbare Fokusindikatoren über <code>:focus-visible</code> auf jedem interaktiven Steuerelement</li>
-        <li>Helles und dunkles Farbschema, die beide die WCAG&nbsp;AA-Kontrastverhältnisse für Fließtext, Links und UI erfüllen</li>
+        <li>Helles und dunkles Farbschema, die die WCAG&nbsp;AA-Kontrastverhältnisse für Fließtext und Bedienelemente erfüllen, mit Ausnahme des in §3 festgehaltenen Falls</li>
         <li>Automatischer Dunkelmodus über <code>prefers-color-scheme</code>, mit manueller Übersteuerung, die in <code>localStorage</code> persistiert wird</li>
         <li>Alle Animationen auf <code>prefers-reduced-motion</code> gestaffelt — wenn der Nutzer dies deaktiviert, werden Übergänge und Reveal-Animationen ausgeschaltet</li>
         <li>Größenveränderbarer Text, der sauber bei 200 % Zoom und bei Viewports bis 320&nbsp;px umfließt</li>
         <li>Alt-Text auf jedem bedeutsamen Bild; dekorative Bilder tragen <code>alt=""</code>, um von Hilfstechnologien übersprungen zu werden</li>
         <li>Beschreibender Linktext — jeder Link gibt sein Ziel an, ohne auf den umgebenden Kontext angewiesen zu sein (kein bloßes „Mehr erfahren")</li>
-        <li>Links im Fließtext sind unterstrichen, sodass Farbe nicht das einzige Unterscheidungsmerkmal ist (WCAG&nbsp;1.4.1)</li>
         <li>Native <code>&lt;details&gt;</code>-Elemente für FAQ-Akkordeons (z. B. NetSec-Sommerschule, Euro-SWAMOS) — tastaturzugänglich ohne JavaScript</li>
         <li>Mobiler Navigationsdrawer mit undurchsichtigem Hintergrund, <code>aria-expanded</code> auf dem Umschalter, Fokusverwaltung beim Schließen</li>
         <li>Die Website-Suche öffnet sich als modaler Dialog, der den Tastaturfokus hält (der Rest der Seite wird auf <code>inert</code> gesetzt, solange sie geöffnet ist, sodass der Tabulator nicht hinter die Überlagerung gelangen kann) und verhält sich wie eine ARIA-Combobox: die Ergebnisse bilden eine Listbox, die mit den Pfeiltasten durchlaufen wird, Enter folgt dem hervorgehobenen Ergebnis, Escape schließt</li>
@@ -192,9 +235,13 @@ alternates:
         <strong>Teilweise Konformität</strong> mit WCAG&nbsp;2.1 Stufe&nbsp;AA, ausgerichtet auf
         EN&nbsp;301&nbsp;549. Alle Vorlagen der Website erfüllen den Standard; das Label
         „teilweise Konformität" spiegelt die in §3 dokumentierten Einschränkungen wider (eingebettete
-        PDFs, transluzente Flächen, generischer Alt-Text auf einigen Archivfotos). Automatisierte Audits melden derzeit keine Verstöße, die Überprüfung vom
-        Juni&nbsp;2026 fand keine kritischen oder schwerwiegenden Barrieren, und die Elemente in
-        „manueller Überprüfung" wurden einzeln als konform verifiziert.
+        PDFs, transluzente Flächen, generischer Alt-Text auf einigen Archivfotos, die
+        Akzentfarbe auf getönten Flächen und die vier Punkte vor der Veröffentlichung). Das
+        statische Lint und die Prüfungen auf Auszeichnungsebene melden keine Verstöße, und die
+        Elemente, die sie in „manuelle Überprüfung" geben, wurden einzeln als konform
+        verifiziert. Der im Browser durchgeführte Durchlauf vom September&nbsp;2026 ist die
+        geltende Bewertung; was er offen lässt, ist in §3 aufgeführt statt hier
+        zusammengefasst.
       </p>
       <p>
         <a class="wcag-badge"
@@ -209,7 +256,7 @@ alternates:
         </a>
       </p>
       <p class="meta">
-        Erklärung erstellt: 14. Mai 2026 · Zuletzt überprüft: 20. August 2026 · Nächste geplante
+        Erklärung erstellt: 14. Mai 2026 · Zuletzt überprüft: 2. September 2026 · Nächste geplante
         Überprüfung: 14. Mai 2027 oder bei einer größeren Designänderung.
       </p>
     </article>

--- a/src/accessibility.fr.njk
+++ b/src/accessibility.fr.njk
@@ -73,7 +73,8 @@ alternates:
         Au-delà des outils automatisés, le lint statique
         <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/blob/master/scripts/a11y_lint.py" target="_blank" rel="noopener">scripts/a11y_lint.py</a>
         est exécuté à chaque build et signale actuellement
-        <strong>0&nbsp;page avec des problèmes</strong> sur tous les modèles.
+        <strong>0&nbsp;page avec des problèmes</strong> sur tous les modèles. Il lit le HTML
+        produit : c'est donc un contrôle du balisage et non de la page rendue.
       </p>
       <p>
         En <strong>juin&nbsp;2026</strong>, nous avons mené une revue plus large de l'ensemble du
@@ -84,6 +85,29 @@ alternates:
         manière dont chacun a été résolu ou est suivi, sont consignés dans le
         <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/issues" target="_blank" rel="noopener">suivi&nbsp;public&nbsp;des&nbsp;tickets</a> ;
         les améliorations qui en découlent figurent au §4 et les points restants au §3.
+      </p>
+      <p>
+        En <strong>septembre&nbsp;2026</strong>, nous avons élargi la méthode. Le lint statique
+        et les analyses précédentes lisaient chaque page telle qu'elle est envoyée, et non telle
+        qu'un navigateur la dessine : tout ce qui dépend de la mise en page, d'une couleur
+        calculée ou d'un script en cours d'exécution échappait à ce qu'ils pouvaient signaler.
+        Nous avons relancé
+        <a href="https://github.com/dequelabs/axe-core" target="_blank" rel="noopener">axe-core&nbsp;4.13</a>
+        dans un vrai navigateur, à une largeur de téléphone et à une largeur d'ordinateur, dans
+        les deux schémas de couleurs, sur <strong>51&nbsp;pages</strong>, puis à nouveau sur
+        l'ensemble des <strong>660</strong> pages générées de communications, de personnes et
+        de thèmes.
+      </p>
+      <p>
+        Cette passe a révélé <strong>huit défauts</strong> que les précédentes ne pouvaient pas
+        signaler. Le plus grave était un lien vide et sans intitulé placé en fin d'ordre de
+        tabulation sur <strong>chaque page du site</strong>, maintenu là par une règle de style
+        qui neutralisait l'attribut <code>hidden</code> de la carte affichant les informations
+        d'une personne. À ses côtés : une carte dont les sept liens vers les conférences étaient
+        masqués aux lecteurs d'écran, un badge sous le seuil de contraste sur treize pages
+        d'archives, et quatre pages qui défilaient latéralement sur un téléphone. Ces points
+        sont corrigés. Les autres figurent au
+        <a href="#known-limitations">&sect;3</a> avec les tickets qui les suivent.
       </p>
 
       <h2 id="known-limitations">3. Limites connues</h2>
@@ -127,19 +151,41 @@ alternates:
           des boutons HTML classiques accessibles au clavier, portant un état
           <code>aria-pressed</code> lorsqu'ils fonctionnent par bascule.
         </li>
+        <li>
+          <strong>Couleur des liens et des libellés sur fonds teintés.</strong> Le bleu
+          d'accentuation utilisé pour les liens et les libellés de rôle mesure 4,51:1 sur du
+          blanc, soit un centième au-dessus du minimum AA. Sur une surface teintée plutôt que
+          blanche, il passe en dessous : les libellés de rôle et les liens de profil de la page
+          Les personnes mesurent 3,99:1, et les pastilles de catégorie de la page d'accueil et
+          de la page actualités mesurent 4,05:1.
+          <em>Atténuation :</em> aucune qui laisse la couleur inchangée ; ce point est donc
+          corrigé plutôt que contourné. Suivi dans le
+          <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1624" target="_blank" rel="noopener">ticket&nbsp;#1624</a>.
+        </li>
+        <li>
+          <strong>Quatre défauts plus petits en attente de publication.</strong> Le film de la
+          conférence se décrit aux technologies d'assistance avec un rôle qui n'est pas autorisé
+          sur un élément vidéo. Le panneau de filtres de l'Atlas place un bouton à l'intérieur
+          du contrôle qui l'ouvre. Les liens situés dans les paragraphes gris se distinguent du
+          texte qui les entoure par la seule couleur. Le tableau des jetons du système de design
+          défile latéralement sans être atteignable au clavier.
+          <em>Atténuation :</em> le film peut toujours être mis en pause en le touchant, les
+          filtres de l'Atlas peuvent toujours être réinitialisés, et les pages concernées
+          restent utilisables. Les correctifs sont écrits et suivis dans le
+          <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1625" target="_blank" rel="noopener">ticket&nbsp;#1625</a>.
+        </li>
       </ol>
 
       <h2>4. Fonctionnalités d'accessibilité mises en œuvre</h2>
       <ul>
         <li>Repères sémantiques (<code>&lt;header&gt;</code>, <code>&lt;nav aria-label="Primary"&gt;</code>, <code>&lt;main&gt;</code>, <code>&lt;footer&gt;</code>) et un lien d'évitement vers le contenu comme premier élément focusable sur chaque page</li>
         <li>Indicateurs de focus visibles via <code>:focus-visible</code> sur chaque contrôle interactif</li>
-        <li>Schémas de couleurs clair et sombre respectant tous deux les ratios de contraste WCAG&nbsp;AA pour le texte, les liens et l'UI</li>
+        <li>Schémas de couleurs clair et sombre respectant les ratios de contraste WCAG&nbsp;AA pour le texte et les contrôles d'interface, à l'exception du cas consigné au §3</li>
         <li>Mode sombre automatique via <code>prefers-color-scheme</code>, avec une bascule manuelle persistante dans <code>localStorage</code></li>
         <li>Toutes les animations conditionnées à <code>prefers-reduced-motion</code> — lorsque l'utilisateur le désactive, les transitions et animations de révélation sont désactivées</li>
         <li>Texte redimensionnable s'adaptant proprement à un zoom de 200 % et à des fenêtres jusqu'à 320&nbsp;px</li>
         <li>Texte alt sur chaque image significative ; les images décoratives portent <code>alt=""</code> pour être ignorées par les technologies d'assistance</li>
         <li>Texte de lien descriptif — chaque lien indique sa destination sans dépendre du contexte environnant (pas de simple « En savoir plus »)</li>
-        <li>Liens dans le corps du texte soulignés, pour que la couleur ne soit pas le seul indice distinctif (WCAG&nbsp;1.4.1)</li>
         <li>Balises natives <code>&lt;details&gt;</code> pour les accordéons FAQ (par exemple école d'été NetSec, Euro-SWAMOS) — accessibles au clavier sans JavaScript</li>
         <li>Tiroir de navigation mobile avec arrière-plan opaque, <code>aria-expanded</code> sur la bascule, gestion du focus à la fermeture</li>
         <li>La recherche du site s'ouvre comme une boîte de dialogue modale qui retient le focus clavier (le reste de la page est mis en <code>inert</code> tant qu'elle est ouverte, de sorte que la tabulation ne peut pas passer derrière la surcouche) et se comporte comme une combobox ARIA : les résultats forment une liste (listbox) parcourue avec les touches fléchées, Entrée suit le résultat surligné, Échap ferme</li>
@@ -190,10 +236,12 @@ alternates:
         <strong>Conformité partielle</strong> avec WCAG&nbsp;2.1 Niveau&nbsp;AA, alignée avec
         EN&nbsp;301&nbsp;549. Tous les modèles du site respectent la norme ; le label de conformité
         partielle résiduelle reflète les limites documentées au §3 (PDF intégrés, surfaces translucides,
-        texte alt générique sur certaines photos d'archive). Les
-        audits automatisés ne signalent actuellement aucune violation, la revue de juin&nbsp;2026 n'a
-        trouvé aucun obstacle critique ou grave, et les éléments en « revue manuelle » ont été
-        individuellement vérifiés conformes.
+        texte alt générique sur certaines photos d'archive, la couleur d'accentuation sur fonds
+        teintés, et les quatre points en attente de publication). Le lint statique et les
+        analyses au niveau du balisage ne signalent aucune violation, et les éléments qu'ils
+        placent en « revue manuelle » ont été individuellement vérifiés conformes. La passe de
+        septembre&nbsp;2026 menée dans un navigateur constitue l'évaluation en vigueur, et ce
+        qu'elle laisse ouvert est listé au §3 plutôt que résumé ici.
       </p>
       <p>
         <a class="wcag-badge"
@@ -208,7 +256,7 @@ alternates:
         </a>
       </p>
       <p class="meta">
-        Déclaration préparée : 14 mai 2026 · Dernière revue : 20 août 2026 · Prochaine revue prévue :
+        Déclaration préparée : 14 mai 2026 · Dernière revue : 2 septembre 2026 · Prochaine revue prévue :
         14 mai 2027 ou lors d'un changement majeur de conception.
       </p>
     </article>

--- a/src/accessibility.fr.njk
+++ b/src/accessibility.fr.njk
@@ -107,7 +107,10 @@ alternates:
         masqués aux lecteurs d'écran, un badge sous le seuil de contraste sur treize pages
         d'archives, et quatre pages qui défilaient latéralement sur un téléphone. Ces points
         sont corrigés. Les autres figurent au
-        <a href="#known-limitations">&sect;3</a> avec les tickets qui les suivent.
+        <a href="#known-limitations">&sect;3</a> avec les tickets qui les suivent. Quatre
+        autres, signalés par la même passe, ont été corrigés peu après : le contrôle du film de
+        la conférence, le panneau de filtres de l'Atlas, les liens dans les paragraphes gris,
+        et un tableau qui défilait sans être atteignable au clavier.
       </p>
 
       <h2 id="known-limitations">3. Limites connues</h2>
@@ -162,18 +165,6 @@ alternates:
           corrigé plutôt que contourné. Suivi dans le
           <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1624" target="_blank" rel="noopener">ticket&nbsp;#1624</a>.
         </li>
-        <li>
-          <strong>Quatre défauts plus petits en attente de publication.</strong> Le film de la
-          conférence se décrit aux technologies d'assistance avec un rôle qui n'est pas autorisé
-          sur un élément vidéo. Le panneau de filtres de l'Atlas place un bouton à l'intérieur
-          du contrôle qui l'ouvre. Les liens situés dans les paragraphes gris se distinguent du
-          texte qui les entoure par la seule couleur. Le tableau des jetons du système de design
-          défile latéralement sans être atteignable au clavier.
-          <em>Atténuation :</em> le film peut toujours être mis en pause en le touchant, les
-          filtres de l'Atlas peuvent toujours être réinitialisés, et les pages concernées
-          restent utilisables. Les correctifs sont écrits et suivis dans le
-          <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1625" target="_blank" rel="noopener">ticket&nbsp;#1625</a>.
-        </li>
       </ol>
 
       <h2>4. Fonctionnalités d'accessibilité mises en œuvre</h2>
@@ -181,6 +172,8 @@ alternates:
         <li>Repères sémantiques (<code>&lt;header&gt;</code>, <code>&lt;nav aria-label="Primary"&gt;</code>, <code>&lt;main&gt;</code>, <code>&lt;footer&gt;</code>) et un lien d'évitement vers le contenu comme premier élément focusable sur chaque page</li>
         <li>Indicateurs de focus visibles via <code>:focus-visible</code> sur chaque contrôle interactif</li>
         <li>Schémas de couleurs clair et sombre respectant les ratios de contraste WCAG&nbsp;AA pour le texte et les contrôles d'interface, à l'exception du cas consigné au §3</li>
+        <li>Liens soulignés dans les paragraphes gris, où l'accentuation n'atteint que 1,76:1 face au texte qui les entoure et où la couleur seule ne suffirait pas à les distinguer (WCAG&nbsp;1.4.1)</li>
+        <li>Film de la conférence pouvant être mis en pause au clavier, par un contrôle nommé qui reste atteignable pendant la lecture</li>
         <li>Mode sombre automatique via <code>prefers-color-scheme</code>, avec une bascule manuelle persistante dans <code>localStorage</code></li>
         <li>Toutes les animations conditionnées à <code>prefers-reduced-motion</code> — lorsque l'utilisateur le désactive, les transitions et animations de révélation sont désactivées</li>
         <li>Texte redimensionnable s'adaptant proprement à un zoom de 200 % et à des fenêtres jusqu'à 320&nbsp;px</li>
@@ -237,7 +230,7 @@ alternates:
         EN&nbsp;301&nbsp;549. Tous les modèles du site respectent la norme ; le label de conformité
         partielle résiduelle reflète les limites documentées au §3 (PDF intégrés, surfaces translucides,
         texte alt générique sur certaines photos d'archive, la couleur d'accentuation sur fonds
-        teintés, et les quatre points en attente de publication). Le lint statique et les
+        teintés). Le lint statique et les
         analyses au niveau du balisage ne signalent aucune violation, et les éléments qu'ils
         placent en « revue manuelle » ont été individuellement vérifiés conformes. La passe de
         septembre&nbsp;2026 menée dans un navigateur constitue l'évaluation en vigueur, et ce

--- a/src/accessibility.njk
+++ b/src/accessibility.njk
@@ -101,6 +101,9 @@ alternates:
         hidden from screen readers, a badge below the contrast minimum on thirteen archive
         pages, and four pages that scrolled sideways on a phone. Those are fixed. The rest
         are listed in <a href="#known-limitations">&sect;3</a> with the issues tracking them.
+        Four more, reported by the same pass, were fixed shortly afterwards: the conference
+        film&rsquo;s control, the Atlas filter panel, links inside grey paragraphs, and a
+        table that scrolled without being reachable from the keyboard.
       </p>
 
       <h2 id="known-limitations">3. Known limitations</h2>
@@ -152,18 +155,6 @@ alternates:
           rather than worked around. Tracked in
           <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1624" target="_blank" rel="noopener">issue&nbsp;#1624</a>.
         </li>
-        <li>
-          <strong>Four smaller defects awaiting release.</strong> The conference film
-          describes itself to assistive technology with a role that is not permitted on a
-          video element. The Atlas filter panel puts a button inside the control that opens
-          it. Links inside grey paragraphs are told apart from the text around them by colour
-          alone. The design-system token table scrolls sideways without being reachable from
-          the keyboard.
-          <em>Mitigation:</em> the film can still be paused by tapping it, the Atlas filters
-          can still be cleared, and the affected pages remain usable. Fixes for all four are
-          written and tracked in
-          <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1625" target="_blank" rel="noopener">issue&nbsp;#1625</a>.
-        </li>
       </ol>
 
       <h2>4. Accessibility features implemented</h2>
@@ -171,6 +162,8 @@ alternates:
         <li>Semantic landmarks (<code>&lt;header&gt;</code>, <code>&lt;nav aria-label="Primary"&gt;</code>, <code>&lt;main&gt;</code>, <code>&lt;footer&gt;</code>) and a skip-to-content link as the first focusable element on every page</li>
         <li>Visible focus indicators via <code>:focus-visible</code> on every interactive control</li>
         <li>Light and dark colour schemes, with body text and interface controls meeting WCAG&nbsp;AA contrast ratios, apart from the case recorded in &sect;3</li>
+        <li>Links inside grey paragraphs underlined, where the accent is 1.76:1 against the text around them and colour alone would not tell them apart (WCAG&nbsp;1.4.1)</li>
+        <li>The conference film pausable from the keyboard, by a named control that stays reachable while the film plays</li>
         <li>Automatic dark mode via <code>prefers-color-scheme</code>, with a manual override that persists in <code>localStorage</code></li>
         <li>All animations gated on <code>prefers-reduced-motion</code>: when the user opts out, transitions and reveal animations are disabled</li>
         <li>Resizable text reflowing cleanly at 200 % zoom and at viewports down to 320&nbsp;px</li>
@@ -224,7 +217,7 @@ alternates:
         EN&nbsp;301&nbsp;549. All templates of the site meet the standard. The residual
         partial-compliance label reflects the documented limitations in §3 (embedded PDFs,
         translucent surfaces, generic alt text on some archive photos, the accent colour on
-        tinted surfaces, and the four items awaiting release). The static lint and the
+        tinted surfaces). The static lint and the
         markup-level scans report zero violations, and the items they raise for
         &ldquo;manual review&rdquo; have been individually verified compliant. The
         September&nbsp;2026 browser-based pass is the current assessment, and what it found

--- a/src/accessibility.njk
+++ b/src/accessibility.njk
@@ -69,7 +69,8 @@ alternates:
         Beyond automated tools, the static lint
         <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/blob/master/scripts/a11y_lint.py" target="_blank" rel="noopener">scripts/a11y_lint.py</a>
         is run on each build and currently reports
-        <strong>0&nbsp;pages with issues</strong> across all templates.
+        <strong>0&nbsp;pages with issues</strong> across all templates. It reads the
+        built HTML, so it is a check on markup rather than on the rendered page.
       </p>
       <p>
         In <strong>June&nbsp;2026</strong> we ran a broader site-wide review: a multi-pass
@@ -80,6 +81,26 @@ alternates:
         being tracked, are recorded in the public
         <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/issues" target="_blank" rel="noopener">issue&nbsp;tracker</a>;
         the resulting improvements are reflected in §4 and the remaining items in §3.
+      </p>
+      <p>
+        In <strong>September&nbsp;2026</strong> we widened the method. Both the static lint
+        and the earlier scans read each page as it is sent, not as a browser draws it, so
+        anything that depends on layout, computed colour or a script running was outside
+        what they could report. We re-ran
+        <a href="https://github.com/dequelabs/axe-core" target="_blank" rel="noopener">axe-core&nbsp;4.13</a>
+        in a real browser at a phone width and a desktop width, in both colour schemes,
+        across <strong>51&nbsp;pages</strong>, and again over all <strong>660</strong>
+        generated paper, person and theme pages.
+      </p>
+      <p>
+        It found <strong>eight defects</strong> that the earlier passes could not have
+        reported. The most serious was an empty, unlabelled link sitting at the end of the
+        keyboard tab order on <strong>every page of the site</strong>, held there by a
+        stylesheet rule that overrode the <code>hidden</code> attribute on the card that
+        shows a person&rsquo;s details. Alongside it: a map whose seven conference links were
+        hidden from screen readers, a badge below the contrast minimum on thirteen archive
+        pages, and four pages that scrolled sideways on a phone. Those are fixed. The rest
+        are listed in <a href="#known-limitations">&sect;3</a> with the issues tracking them.
       </p>
 
       <h2 id="known-limitations">3. Known limitations</h2>
@@ -121,19 +142,40 @@ alternates:
           the zoom buttons, is a regular HTML button reachable from the keyboard, carrying
           <code>aria-pressed</code> state where it toggles.
         </li>
+        <li>
+          <strong>Link and label colour on tinted surfaces.</strong> The accent blue used for
+          links and for role labels measures 4.51:1 against white, which clears the AA
+          minimum by a hundredth. On a surface that is tinted rather than white it falls
+          below: the role labels and profile links on the People page measure 3.99:1, and the
+          category chips on the home page and the news page measure 4.05:1.
+          <em>Mitigation:</em> none that leaves the colour alone, so this is being corrected
+          rather than worked around. Tracked in
+          <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1624" target="_blank" rel="noopener">issue&nbsp;#1624</a>.
+        </li>
+        <li>
+          <strong>Four smaller defects awaiting release.</strong> The conference film
+          describes itself to assistive technology with a role that is not permitted on a
+          video element. The Atlas filter panel puts a button inside the control that opens
+          it. Links inside grey paragraphs are told apart from the text around them by colour
+          alone. The design-system token table scrolls sideways without being reachable from
+          the keyboard.
+          <em>Mitigation:</em> the film can still be paused by tapping it, the Atlas filters
+          can still be cleared, and the affected pages remain usable. Fixes for all four are
+          written and tracked in
+          <a href="https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1625" target="_blank" rel="noopener">issue&nbsp;#1625</a>.
+        </li>
       </ol>
 
       <h2>4. Accessibility features implemented</h2>
       <ul>
         <li>Semantic landmarks (<code>&lt;header&gt;</code>, <code>&lt;nav aria-label="Primary"&gt;</code>, <code>&lt;main&gt;</code>, <code>&lt;footer&gt;</code>) and a skip-to-content link as the first focusable element on every page</li>
         <li>Visible focus indicators via <code>:focus-visible</code> on every interactive control</li>
-        <li>Light and dark colour schemes both meeting WCAG&nbsp;AA contrast ratios for body text, links, and UI</li>
+        <li>Light and dark colour schemes, with body text and interface controls meeting WCAG&nbsp;AA contrast ratios, apart from the case recorded in &sect;3</li>
         <li>Automatic dark mode via <code>prefers-color-scheme</code>, with a manual override that persists in <code>localStorage</code></li>
         <li>All animations gated on <code>prefers-reduced-motion</code>: when the user opts out, transitions and reveal animations are disabled</li>
         <li>Resizable text reflowing cleanly at 200 % zoom and at viewports down to 320&nbsp;px</li>
         <li>Alt text on every meaningful image; decorative images carry <code>alt=""</code> to be skipped by assistive technologies</li>
         <li>Descriptive link text: every link indicates its destination without relying on surrounding context (no bare “Learn more”)</li>
-        <li>Links in body text underlined, so colour is not the only distinguishing cue (WCAG&nbsp;1.4.1)</li>
         <li>Native <code>&lt;details&gt;</code> for FAQ accordions (e.g. NetSec Summer School, Euro-SWAMOS) — keyboard-accessible without JavaScript</li>
         <li>Mobile navigation drawer with opaque background, <code>aria-expanded</code> on the toggle, focus management on close</li>
         <li>Site search opens as a modal dialog that holds keyboard focus (the rest of the page is set <code>inert</code> while it is open, so Tab cannot drift behind the overlay) and behaves as an ARIA combobox: results form a listbox moved through with the arrow keys, Enter follows the highlighted result, Escape closes</li>
@@ -181,10 +223,12 @@ alternates:
         <strong>Partial conformance</strong> with WCAG&nbsp;2.1 Level&nbsp;AA, aligned with
         EN&nbsp;301&nbsp;549. All templates of the site meet the standard. The residual
         partial-compliance label reflects the documented limitations in §3 (embedded PDFs,
-        translucent surfaces, generic alt text on some archive photos). Automated audits currently report zero
-        violations, the June&nbsp;2026 review
-        found no critical or serious barriers, and the items in “manual review” have been
-        individually verified compliant.
+        translucent surfaces, generic alt text on some archive photos, the accent colour on
+        tinted surfaces, and the four items awaiting release). The static lint and the
+        markup-level scans report zero violations, and the items they raise for
+        &ldquo;manual review&rdquo; have been individually verified compliant. The
+        September&nbsp;2026 browser-based pass is the current assessment, and what it found
+        still open is listed in §3 rather than summarised here.
       </p>
       <p>
         <a class="wcag-badge"
@@ -199,7 +243,7 @@ alternates:
         </a>
       </p>
       <p class="meta">
-        Statement prepared: 14 May 2026 · Last reviewed: 20 August 2026 · Next scheduled review:
+        Statement prepared: 14 May 2026 · Last reviewed: 2 September 2026 · Next scheduled review:
         14 May 2027 or upon major design change.
       </p>
     </article>


### PR DESCRIPTION
Rule §9 bumps this statement on any release touching conformance, audit results or known limitations. The QA pass touched all three, and it turned out **two claims in the statement were not true**.

### The two false claims

**§4: "Links in body text underlined, so colour is not the only distinguishing cue (WCAG 1.4.1)."**

The stylesheet sets `text-decoration: none` on `a` and only underlines on `:hover`. That line described an intention, not the site. It is removed, and §3 now records the real position with the measurement: the accent is **1.76:1** against `--text-muted` and 1.38:1 against `--text-subtle`, against the 3:1 that would let colour carry the distinction on its own.

**§4: "Light and dark colour schemes both meeting WCAG AA contrast ratios for body text, links, and UI."**

The People page carries **52 nodes at 3.99:1**. Qualified to exclude the case, which is now a §3 limitation pointing at #1624.

### §2 and §7: superseded evidence

§2 recorded a May 2026 axe 4.10.2 run over 9 pages reporting **zero violations**, and a June 2026 review finding **no critical or serious barriers**. §7 cited both as current evidence of conformance.

September found eight defects neither could see, one of them an empty keyboard-focusable link at the end of the tab order on every page of the site. Those earlier findings stay as the dated record of what those reviews saw. A new paragraph after them records the September pass and, importantly, **why** the earlier ones missed things: both read pages as sent rather than as a browser draws them, so anything depending on layout, computed colour or a running script was outside what they could report.

§7 no longer summarises a conclusion that no longer holds. It scopes the zero-violations claim to the markup-level checks, names the September pass as the current assessment, and points at §3 for what is still open.

### §3: two new limitations

- **Link and label colour on tinted surfaces** — the accent is 4.51:1 on white, clearing AA by a hundredth, so any tint drops it below. Measured figures for the People page and the news chips. Tracked in #1624. Stated as being corrected rather than mitigated, because there is no mitigation that leaves the colour alone.
- **Four smaller defects awaiting release** — the video role, the Atlas filter button, links in grey paragraphs, the token table. Each with what still works in the meantime, tracked in #1625.

### Sequencing

This describes the site **as currently deployed**, not as it will be once #1627 merges. Understating is the safe direction for a conformance statement. When #1627 lands, the §3 "four smaller defects" entry comes out and the §4 underline line goes back in, accurately this time. I will do that as a one-line follow-up rather than pre-empt it here.

### FR and DE

Both updated by hand alongside the English (§1, no machine translation). The passages are new prose in each language rather than a rendering of the English, and they are worth a native reader's eye. Drift stamps marked fresh because the translations were written here, not because the English moved without them.

### Verification

All three statement pages: axe clean, zero horizontal overflow at 375px, list structure intact (one `<ol>`, six `<li>`). `a11y_lint.py` 0 issues across 637 pages · `check-build-sanity.mjs` passes · `check-i18n-drift.py` clean · `check-i18n-keys.js` reports parity at 550 keys.

One aside worth knowing: `a11y_lint.py` first reported 1,159 pages scanned rather than 637, because `_site` had accumulated **1,597 iCloud `name 2.ext` duplicates**. Cleared with the `find _site -name "* [0-9].*" -delete` line already in `docs/qa-checklist.md` before taking the numbers above. Nothing reaches the repository, `_site` is ignored.

Copy change on a public page, so no auto-merge (§2).
