### PR TITLE
Three scheduled meetings on the internship page, not a weekly call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,9 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ### Changed
 
+- The internship page sets out three meetings across the two months rather than a weekly call: onboarding in the first week, a review at the halfway point, and an exit review with a short feedback survey. Updated in all three languages.
+
+
 - The SKOS theme vocabulary states its own version and issue date. The concept scheme in `/vocab/themes.ttl` and `/vocab/themes.jsonld` now carries `owl:versionInfo` and `dct:issued`, so a deposited or downloaded copy can be dated and told apart from another copy without the record it came from. The version is the vocabulary's own, moving when a concept is added, retired or relabelled rather than when the site releases, and a build-time guard fails the build if the concepts move and the version does not.
 
 ## [2.28.0] · 2026-08-29 — A usable Atlas, and a citable theme vocabulary

--- a/data/i18n-state.json
+++ b/data/i18n-state.json
@@ -214,14 +214,14 @@
     "src/internship.njk": {
       "fr": {
         "file": "src/internship.fr.njk",
-        "source_sha1": "738a0493ba7bbce6c39e12fafaacc5be11ba4f01",
-        "translated_on": "2026-08-18",
+        "source_sha1": "77b9fe920af881f118001b4dcc2f162c559d618a",
+        "translated_on": "2026-09-02",
         "status": "beta"
       },
       "de": {
         "file": "src/internship.de.njk",
-        "source_sha1": "738a0493ba7bbce6c39e12fafaacc5be11ba4f01",
-        "translated_on": "2026-08-18",
+        "source_sha1": "77b9fe920af881f118001b4dcc2f162c559d618a",
+        "translated_on": "2026-09-02",
         "status": "beta"
       }
     }

--- a/src/internship.de.njk
+++ b/src/internship.de.njk
@@ -61,9 +61,10 @@ alternates:
       </article>
       <article class="tile">
         <div class="tile-icon" aria-hidden="true">{{ icon("calendar") }}</div>
-        <h3>Ein wöchentlicher Austausch mit den anderen</h3>
+        <h3>Drei Termine über die zwei Monate</h3>
         <p>
-          Die Gruppe trifft sich wöchentlich kurz. Einen Termin zu verpassen ist kein Problem.
+          Ein Einführungsgespräch in der ersten Woche, ein Zwischengespräch zur Halbzeit und ein
+          Abschlussgespräch am Ende mit einer kurzen Rückmeldeumfrage.
         </p>
       </article>
     </div>
@@ -162,7 +163,7 @@ alternates:
       <div>
         <dt>Jemand zum Fragen</dt>
         <dd>
-          Vom ersten Tag an haben Sie eine feste Ansprechperson, dazu den wöchentlichen Austausch.
+          Vom ersten Tag an haben Sie eine feste Ansprechperson, dazu drei vereinbarte Termine.
           Dazwischen zählt hier niemand Ihre Stunden und verlangt niemand einen Statusbericht.
         </dd>
       </div>
@@ -198,7 +199,7 @@ alternates:
       <div>
         <dt>Februar bis April · Die inhaltliche Phase</dt>
         <dd>
-          Die geschützte Phase. Arbeit am eigenen Bereich, der wöchentliche Austausch und eine erste
+          Die geschützte Phase. Arbeit am eigenen Bereich, Ihr Zwischengespräch und eine erste
           Fassung vor April.
         </dd>
       </div>
@@ -288,8 +289,8 @@ alternates:
             gemeinsam mit Ihnen ein, und es ist für nichts Voraussetzung.
           </li>
           <li>
-            <strong>Tragen Sie den wöchentlichen Austausch in Ihren Kalender ein.</strong> Er ist
-            kurz, und einen Termin zu verpassen verlangt keine Erklärung.
+            <strong>Tragen Sie die drei Termine in Ihren Kalender ein.</strong> Einführung,
+            Zwischengespräch und Abschlussgespräch. Die Einladungen verschicken wir.
           </li>
           <li>
             <strong>Wählen Sie etwas aus der

--- a/src/internship.fr.njk
+++ b/src/internship.fr.njk
@@ -61,10 +61,10 @@ alternates:
       </article>
       <article class="tile">
         <div class="tile-icon" aria-hidden="true">{{ icon("calendar") }}</div>
-        <h3>Un point hebdomadaire avec les autres</h3>
+        <h3>Trois rendez-vous sur les deux mois</h3>
         <p>
-          Le groupe se retrouve chaque semaine pour un échange bref. En manquer un ne pose aucun
-          problème.
+          Un accueil la première semaine, un point à mi-parcours, et un entretien de fin de stage
+          accompagné d'un court questionnaire de retour.
         </p>
       </article>
     </div>
@@ -161,9 +161,9 @@ alternates:
       <div>
         <dt>Quelqu'un à qui demander</dt>
         <dd>
-          Vous disposez d'un interlocuteur désigné dès le premier jour, ainsi que du point
-          hebdomadaire. Entre les deux, personne ici ne comptabilise vos heures ni ne réclame de
-          compte rendu.
+          Vous disposez d'un interlocuteur désigné dès le premier jour, ainsi que de trois
+          rendez-vous programmés. Entre eux, personne ici ne comptabilise vos heures ni ne réclame
+          de compte rendu.
         </dd>
       </div>
       <div>
@@ -195,8 +195,8 @@ alternates:
       <div>
         <dt>De février à avril · La période de fond</dt>
         <dd>
-          La période protégée. Travail sur l'axe, point hebdomadaire, et un premier jet attendu
-          avant avril.
+          La période protégée. Travail sur l'axe, votre point à mi-parcours, et un premier jet
+          attendu avant avril.
         </dd>
       </div>
       <div>
@@ -285,8 +285,8 @@ alternates:
             vous, et ce n'est un prérequis pour rien.
           </li>
           <li>
-            <strong>Inscrivez le point hebdomadaire à votre agenda.</strong> Il est bref, et en
-            manquer un n'appelle aucune explication.
+            <strong>Inscrivez les trois rendez-vous à votre agenda.</strong> L'accueil, le point
+            à mi-parcours et l'entretien de fin de stage. Nous envoyons les invitations.
           </li>
           <li>
             <strong>Choisissez une tâche sur la

--- a/src/internship.njk
+++ b/src/internship.njk
@@ -58,9 +58,10 @@ alternates:
       </article>
       <article class="tile">
         <div class="tile-icon" aria-hidden="true">{{ icon("calendar") }}</div>
-        <h3>A weekly call with the others</h3>
+        <h3>Three meetings across the two months</h3>
         <p>
-          The group meets for a short call each week. Missing one is fine.
+          Onboarding in your first week, a review at the halfway point, and an exit review at
+          the end with a short feedback survey.
         </p>
       </article>
     </div>
@@ -156,8 +157,8 @@ alternates:
       <div>
         <dt>Someone to ask</dt>
         <dd>
-          You get a named point of contact from your first day, and the weekly call. Between those
-          two, nobody here monitors your hours or asks for a status report.
+          You get a named point of contact from your first day, and three scheduled meetings.
+          Between those, nobody here monitors your hours or asks for a status report.
         </dd>
       </div>
       <div>
@@ -189,7 +190,8 @@ alternates:
       <div>
         <dt>February to April · The substantive window</dt>
         <dd>
-          The protected stretch. Track work, the weekly call, and a first draft due before April.
+          The protected stretch. Track work, your mid-term review, and a first draft due before
+          April.
         </dd>
       </div>
       <div>
@@ -278,8 +280,8 @@ alternates:
             Never used GitHub? Say so. We set it up with you, and it is not a prerequisite.
           </li>
           <li>
-            <strong>Put the weekly call in your calendar.</strong> It is short, and missing one
-            needs no explanation.
+            <strong>Put the three meetings in your calendar.</strong> Onboarding, the mid-term
+            review, and the exit review at the end. We send the invitations.
           </li>
           <li>
             <strong>Pick something from the


### PR DESCRIPTION
The placement is about a day a week over two months, and the page described **a weekly call** in four places. That is roughly eight meetings for a two-month commitment, and it read as an ongoing group rhythm rather than a structure with a beginning and an end.

Three meetings replace it:

- **Onboarding** in the first week
- **A review at the halfway point**
- **An exit review** at the end, carrying a short feedback survey

### Where it changed

Four places per locale, twelve in total:

1. The calendar tile, *A weekly call with the others* → *Three meetings across the two months*.
2. *Someone to ask*: "a named point of contact from your first day, and the weekly call" → "and three scheduled meetings".
3. The *February to April* row of the annual cycle: "Track work, the weekly call, and a first draft" → "Track work, your mid-term review, and a first draft".
4. The practical steps for a first week: *Put the weekly call in your calendar* → *Put the three meetings in your calendar*, naming all three and saying we send the invitations.

No reference to a weekly call remains in any locale.

The exit survey is new to the page. The existing *July · Publication and credit* row keeps its group retrospective, which is a different thing: that asks the cohort what was worth doing, this asks each person about their own placement.

FR and DE written by hand alongside the English (rule §1). The mid-term and exit vocabulary is *point à mi-parcours* / *entretien de fin de stage* and *Zwischengespräch* / *Abschlussgespräch*, which are the conventional terms, but worth a native reader's eye.

### Verification

All three pages: axe clean, zero horizontal overflow at 375px. `check-i18n-drift.py` clean after marking the stamps fresh, since the translations were written here rather than left behind. Build clean at 1431 files.

Copy change on a public page, so no auto-merge (§2).