### PR TITLE
Every PR carries a milestone, and ask when it is not obvious

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,9 @@ authoritative for EISS.
   `scripts/release.sh`, eyeball the lede + themes + index before
   confirming the publish prompt. Publication to GitHub Releases is
   harder to undo than a merge.
+- **Set the milestone when you open the PR** (rule §10). It goes in the
+  `gh pr create` command itself. If none fits or you are unsure which,
+  ask rather than leaving it blank.
 - **Squash, not merge commits.** Every PR ends as a single commit on
   `master`. The release-cutter then writes the release commit on top.
 - **Once a PR is opened, treat its branch as frozen.** Any commit
@@ -184,7 +187,8 @@ user-visible change adds at least one bullet under
 same PR. Reconstructing a release batch from the git log at release
 time loses nuance and burns time; capturing the bullet while the
 context is fresh is cheap. Exempt: Dependabot PRs, the automated
-`indico-sync/auto` and `bios-sync/auto` data refresh PRs, and any
+data-refresh PRs (`indico-sync/auto`, `bios-sync/auto`,
+`roadmap-refresh/auto`, `netsec-directory-sync/auto`), and any
 internal-only commit (docs-only refresh, CI tooling, working-tree
 hygiene). When in doubt, add the bullet. Cutting a release becomes:
 review what's already there, decide on the title,
@@ -333,10 +337,11 @@ is being edited anyway.
 
 ## 10. Milestone tagging
 
-Every open issue belongs to exactly one milestone. The milestone is
-the bridge between the *Milestone* line in the issue template (rule
-§3) and the planned releases on the roadmap; without it, the backlog
-drifts.
+Every open issue **and every pull request** belongs to exactly one
+milestone. The milestone is the bridge between the *Milestone* line in
+the issue template (rule §3) and the planned releases on the roadmap.
+Without it the backlog drifts, and a release cannot be assembled from a
+query.
 
 ### The milestone set (version-tied, SemVer)
 
@@ -390,11 +395,23 @@ Don't pre-create far-future majors.
 - **At issue creation.** Whenever rule §3 fires, set the milestone
   alongside the title and body. `gh issue create --milestone v2.25.0 ...`
   keeps it inline.
+- **At PR creation, every time.** `gh pr create --milestone v2.29.0 ...`,
+  in the same command that opens it, not afterwards. The usual answer is
+  the release that is currently open, since a PR ships in whatever
+  release is cut next.
+- **Ask when the answer is not obvious.** If no milestone fits, or the
+  right one does not exist yet, or the PR could reasonably belong to
+  either of two, stop and ask the maintainer rather than guessing or
+  leaving it blank. Creating a milestone is a roadmap decision (see the
+  set above) and is not yours to make.
+- **Exempt:** the automated data-refresh PRs (`indico-sync/auto`,
+  `bios-sync/auto`, `roadmap-refresh/auto`, `netsec-directory-sync/auto`)
+  and Dependabot. Same list as the §4 CHANGELOG exemption.
 - **When an issue slips to a later release.** Update the milestone in
   the same edit that records the reslip, with a one-line reason in
   the thread.
-- **Never leave an open issue without one.** A milestone-less open
-  issue is invisible to roadmap planning. If it has no committed
+- **Never leave an open issue or PR without one.** A milestone-less
+  open issue is invisible to roadmap planning. If it has no committed
   release, it belongs in `Backlog — Under watch`.
 
 ## 11. Documentation currency


### PR DESCRIPTION
New standing rule from the maintainer.

Issues have needed a milestone since §10 was written. PRs did not, and the gap was visible in the record: the last twelve merged PRs all carry `v2.29.0`, set **by the maintainer after the fact** rather than by whoever opened them. The only one without is #1629, the automated roadmap refresh, which is exactly the case that should be exempt.

### What §10 now says

- **At PR creation, every time.** In the `gh pr create` command itself, not afterwards. The default answer is the release that is currently open, since a PR ships in whatever release is cut next.
- **Ask when the answer is not obvious.** No milestone fits, the right one does not exist yet, or it could reasonably be either of two: stop and ask rather than guess or leave it blank. Creating a milestone is a roadmap decision under the set defined earlier in §10, and not mine to make.
- **Exempt:** the automated data-refresh PRs and Dependabot.

§2's pull-request workflow gets a one-line pointer, so the rule is read at the moment a PR is opened rather than only when someone reads §10.

### One correction folded in

The new text says the exemption list is "the same list as the §4 CHANGELOG exemption", and that was not true when I wrote it: §4 named only `indico-sync/auto` and `bios-sync/auto`, while `roadmap-refresh/auto` and `netsec-directory-sync/auto` have both been opening automated PRs for some time. Both added to §4, so the cross-reference holds and the two lists cannot drift apart silently.

Also dropped a semicolon from the §10 opening sentence, since §7 applies to prose being edited anyway.

Docs only. This PR sets its own milestone, which is the rule working.