### PR TITLE
Make the help-wanted lane real for incoming interns

### DIFF
--- a/docs/internship-handbook.md
+++ b/docs/internship-handbook.md
@@ -41,7 +41,7 @@ Everything there is real outstanding work with a tracked issue behind
 it. None of it is an exercise invented for a volunteer, and if we run
 out of real work we will tell you rather than making some up.
 
-**Two labels, and they mean different things.**
+**The labels, and what each one is telling you.**
 
 - **`help wanted`** is the pickup signal. Somebody has checked that the
   issue is still true, that it does not need a password or an account
@@ -54,6 +54,10 @@ out of real work we will tell you rather than making some up.
   This is not a comment on you. It is on every task we delegate, and it
   is why you can take something on without carrying the risk of getting
   it wrong.
+- **`good first issue`** is a subset of `help wanted`, not a separate
+  queue: the tasks that assume no knowledge of this repository. Start
+  here if you want one, but nothing stops you taking anything else on
+  the list instead.
 
 Each tagged issue also carries a comment saying what was verified and
 what to settle before starting. **Read that comment before the issue

--- a/docs/internship-handbook.md
+++ b/docs/internship-handbook.md
@@ -26,8 +26,9 @@ it. That is the whole of the expectation.
 2. **Send us your GitHub account name.** We add you to the repository
    with it. If you have never used GitHub, say so. We set it up with
    you on a call, and it is not a prerequisite for anything.
-3. **Put the weekly call in your calendar.** It is short. Missing one
-   is fine and needs no explanation.
+3. **Put the three meetings in your calendar.** Onboarding in your
+   first week, a review at the halfway point, and an exit review at the
+   end with a short feedback survey. We send the invitations.
 4. **Have a look around the corpus.** [The Anthology](https://eiss-europa.com/anthology.html)
    is what most of the work here touches. Ten minutes clicking through
    it will make the task list mean something.
@@ -39,6 +40,29 @@ Open work lives on the
 Everything there is real outstanding work with a tracked issue behind
 it. None of it is an exercise invented for a volunteer, and if we run
 out of real work we will tell you rather than making some up.
+
+**Two labels, and they mean different things.**
+
+- **`help wanted`** is the pickup signal. Somebody has checked that the
+  issue is still true, that it does not need a password or an account
+  you will not have, and that it is finishable by one person. If it is
+  not on this label, it is not because we forgot: it is because it
+  needs a decision that is not ours to delegate, or nobody has checked
+  it recently enough to hand it over.
+- **`needs-review`** says what happens at the end. Your work gets read
+  by a maintainer who accepts it, asks for changes, or declines it.
+  This is not a comment on you. It is on every task we delegate, and it
+  is why you can take something on without carrying the risk of getting
+  it wrong.
+
+Each tagged issue also carries a comment saying what was verified and
+what to settle before starting. **Read that comment before the issue
+body**, because where the two disagree the comment is newer.
+
+If you find that an issue is already done, or that its premise no longer
+holds, say so on the issue. That is a real contribution and it is
+credited like any other. Three issues were closed or re-scoped that way
+while this label set was being prepared.
 
 **To take something**, comment on the issue or pull request saying you
 are picking it up. That is the whole protocol. Nobody assigns you work

--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -32,8 +32,8 @@ module.exports = {
   // three locales (#1352). Kept here so the three hand-maintained language
   // variants cannot drift apart on a URL.
   //
-  // The label page, not `/issues?q=`: `help wanted` currently sits on pull
-  // requests rather than issues, and the issues search hides PRs.
+  // The label page, not `/issues?q=`: `help wanted` sits on both issues and
+  // pull requests, and the issues search hides PRs.
   helpWantedUrl:
     "https://github.com/EISSeuropa/EISSeuropa.github.io/labels/help%20wanted",
   handbookUrl:


### PR DESCRIPTION
`help wanted` and `needs-review` both existed and **neither had ever been applied to an issue**. The label page the handbook sends volunteers to returned two pull requests. An intern arriving today had nothing to pick up.

### The triage mattered more than the tagging

I checked each candidate's premise against the current build before tagging it, and three of the shortlist were stale:

- **#282** (docs/design-system.md) — **closed.** The doc exists and is 395 lines, covering tokens, component vocabulary and the interaction inventory. It landed in #1279 and #1321, neither of which referenced the issue.
- **#328** (/JPW2019 + /joint-2024 programmes) — **closed.** /JPW2019 renders 37 programme slots, not the flat screenshot the issue describes, and /joint-2024 exists with 30. It was carrying **v2.29.0**, so this also takes an item off a release #1619 flagged as overfull.
- **#1254** (BibTeX/RIS/Zotero) — **re-scoped.** `paper-cite.js` already does per-paper BibTeX copy and `.bib`/`.ris` download. What remains is bulk export and Zotero capture from the page.

Two more are not intern-ready and are commented rather than tagged:

- **#474** — the premise is wrong. It says /2017, /2018 and /joint-2024 lack a bespoke card "unlike their /2019–/2025 siblings". Checked: **every** archive page serves the shared `past-meta.jpg`. The job is eleven pages and a decision, not three pages catching up.
- **#415** — `perf-01` cites a 10.9 MB Flickr original that is **0.3 MB** today. The checklist needs re-measuring first.

Also corrected #886, which #1498 describes as close to done: **2024 is 72% (49 of 68), not 94%.**

### The six tagged

| Issue | Why it is safe to delegate |
|---|---|
| **#1273** Declare what each Nunjucks partial expects | 49 partials, no credentials, no judgement about what the site should do. The gentlest start. |
| **#902** EISS 2025 duplicate poster session | Verified byte-identical slots. The hard part is checking a source, not writing code. |
| **#732** Responsive images, 2019–2022 galleries | /2019–/2022 carry zero `srcset`, /2025 has ten. Premise exact. |
| **#601** Test harness for the sync scripts | `test-check-links.py` is the pattern to copy, and it is current after #1628. |
| **#645** Partners page | Well specified, but only 3 of 6 logos exist and a logo is somebody's trademark. Flagged on the issue. |
| **#1498** Abstract coverage, 2017–2022 | Figures re-measured and holding. Flagged that the source material must be confirmed to exist first. |

Each carries a comment with what was verified and what to settle before starting. Nothing needing a password, an external account, a brand call or a roadmap decision is in the set.

### Labels

Both had GitHub's default or a narrow description. Now:

- **`help wanted`** — *Delegable: an intern or volunteer can pick this up. Comment to claim it.*
- **`needs-review`** — *The output needs a maintainer accept/reject call before it lands.*

The second wording deliberately covers the existing automated use as well: `sync-publications.yml` puts `needs-review` on PRs when a publication match needs an accept/reject call, which is the same sentence. No collision, and `is:issue` / `is:pr` separates the two lanes cleanly.

### Handbook

*Claiming a task* gains what the two labels mean and why they are different, the instruction to read the pinned comment before the issue body where they disagree, and an invitation to report an issue that is already done as a real contribution. The first-week steps lose the weekly call, which #1631 removed from the public page while this file still carried it (rule §11).

The comment beside `helpWantedUrl` in `site.js` said the label sits on PRs rather than issues. True when written, not any more.

### Verification

Build clean at 1431 files, `check-i18n-drift.py` clean, `check-i18n-keys.js` parity at 551 keys. Docs and a code comment only, nothing rendered changes.