### PR TITLE
Correct the atlas filters comment: collapsed at every width, not phones

### DIFF
--- a/src/_includes/atlas-body.njk
+++ b/src/_includes/atlas-body.njk
@@ -159,10 +159,11 @@
   </div>
 
   {# Filter rows (#1191). A native <details>, open in the markup so the
-     no-JS and desktop cases simply show everything; anthology-atlas.js
-     collapses it on phones, where 12 edition chips plus 18 theme chips
-     otherwise push the map below the fold. The summary is a visible control
-     at every width since #1508. #}
+     no-JS case simply shows everything. anthology-atlas.js then collapses it
+     at every width (#1430, extending #1191's phones-only behaviour): 12
+     edition chips plus 18 theme chips put the top of the map at y=1074 on a
+     1280x900 desktop too. The summary carries the active-filter count and is
+     a visible control at every width since #1508. #}
   <details class="atlas-filters" id="atlas-filters" open>
     {# The label is its own element so the active-filter count can be rewritten
        independently. Clear itself sits in the view-actions row above, and


### PR DESCRIPTION
`atlas-body.njk` says `anthology-atlas.js` "collapses it on phones, where 12 edition chips plus 18 theme chips otherwise push the map below the fold". That was true of #1191 and stopped being true at **#1430**, which collapses the filter rows at every width for the same reason on desktop.

Verified rather than inferred: the `<details>` reports `open=false` at **both 1280 and 375**. The JS comment at the call site already says "at every width", so only the template was out of step.

Comment only, no behaviour change.

### Why this exists

I went looking for small, verifiable bugs to hand to interns and checked this one because the comment and the behaviour disagreed. They do disagree, but the code is right and the comment is wrong, so there is nothing to delegate. Filing the correction rather than an issue.

Ships alongside the second round of intern triage, summarised in the session: four more issues tagged (#886, #798, #1226, #359), one new one opened (#1635), and #641 re-scoped.