### PR TITLE
Anthology: four fixes to the filters and the two long lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 - The archive banner's "Archive" badge failed the AA contrast floor at 4.44:1 against its own background. Now 5.13:1, same colour.
 - Four pages scrolled sideways on a phone, pushed out by an identifier or a web address too long to break: `/licensing` by 153px, `/vocab/themes` by 49px, `/policy` by 21px and `/anthology-atlas` by 16px. Long identifiers now wrap.
 - Sanne Verschuren's website link points at the address her site actually answers on. Her site serves no working HTTPS, so the `https://` form was dead in a browser, and the correction made once by hand had been overwritten by the board-bios sync. The sync now holds a small table of links to pin, so the correction survives every future run.
+- A search on the Anthology now matches each word of the query on its own, so naming a topic and an affiliation together finds the papers carrying both. The filter compared the whole query against one string built from the title, the authors and the affiliations, so anything typed out of order returned nothing at all and read as an absence from the corpus. The by-person search gained the same treatment, which is what lets a name typed surname-first find its entry. Closes [#1637](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1637).
+- A search on the Anthology can now be shared and survives Back. The edition, the theme and the two checkboxes were already carried in the address bar and restored on load, and the search box was not, so copying the address after a search handed the reader the unfiltered list. Closes [#1638](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1638).
 
 ### Removed
 
@@ -119,6 +121,10 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 
 - The SKOS theme vocabulary states its own version and issue date. The concept scheme in `/vocab/themes.ttl` and `/vocab/themes.jsonld` now carries `owl:versionInfo` and `dct:issued`, so a deposited or downloaded copy can be dated and told apart from another copy without the record it came from. The version is the vocabulary's own, moving when a concept is added, retired or relabelled rather than when the site releases, and a build-time guard fails the build if the concepts move and the version does not.
+
+- The Anthology's two lists skip the rendering work for the rows that are off screen. The page holds around 1,000 entries across the by-person and by-paper views, and the browser laid out and painted every one of them on first render and again on each pass of the filters, which is where a phone slowed down. Closes [#1639](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1639).
+
+- The Anthology's two lists carry their count in every state. The line under the filters appeared only once something was filtered, so the unfiltered page gave no total anywhere near the list and clearing a filter confirmed nothing. It now reads "All 511 papers" until a filter narrows it, comes from the server so it is there without scripting, and stays silent for a screen reader while the text is unchanged. Closes [#1640](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1640).
 
 ## [2.28.0] · 2026-08-29 — A usable Atlas, and a citable theme vocabulary
 

--- a/src/_data/i18n.js
+++ b/src/_data/i18n.js
@@ -747,6 +747,7 @@ const locales = {
       note: "Assembled from the published conference programmes. Names are matched conservatively, so a person who appears under noticeably different spellings across years may show more than once. Themes are inferred from the panel each paper sat in (the nine permanent EISS sections plus recurring themes). Names and affiliations stay in their original language. The research themes are our own vocabulary, so they are translated.",
       // Live-region status strings, read by speaker-filter.js. {n}/{q}
       // are substituted client-side.
+      resultsAll: "All {n} speakers",
       resultsOne: "{n} speaker",
       resultsMany: "{n} speakers",
       noMatch: "No speakers match.",
@@ -782,6 +783,7 @@ const locales = {
       note: "Assembled from the published conference programmes. Themes are inferred from the panel each paper sat in (the nine permanent EISS sections plus recurring themes), so a paper may carry more than one or none. Titles, author names and affiliations stay in their original language. The research themes are our own vocabulary, so they are translated.",
       // Live-region status strings, read by paper-filter.js. {n}/{q} are
       // substituted client-side.
+      resultsAll: "All {n} papers",
       resultsOne: "{n} paper",
       resultsMany: "{n} papers",
       noMatch: "No papers match.",
@@ -1439,6 +1441,7 @@ const locales = {
       contributionOne: "communication",
       contributionMany: "communications",
       note: "Constitué à partir des programmes publiés des conférences. Les noms sont rapprochés avec prudence : une personne apparaissant sous des graphies sensiblement différentes selon les années peut figurer plusieurs fois. Les thèmes sont déduits du panel dans lequel chaque communication a été présentée (les neuf sections permanentes de l'EISS et des thèmes récurrents). Les noms et les affiliations restent dans leur langue d'origine. Les thèmes de recherche relèvent de notre propre vocabulaire et sont donc traduits.",
+      resultsAll: "Les {n} intervenants",
       resultsOne: "{n} intervenant",
       resultsMany: "{n} intervenants",
       noMatch: "Aucun intervenant ne correspond.",
@@ -1469,6 +1472,7 @@ const locales = {
       prizeOnly: "European Security Studies Prize",
       clear: "Effacer",
       note: "Constitué à partir des programmes publiés des conférences. Les thèmes sont déduits du panel dans lequel chaque communication a été présentée (les neuf sections permanentes de l'EISS et des thèmes récurrents) : une communication peut en porter plusieurs ou aucun. Les titres, les noms d'auteurs et les affiliations restent dans leur langue d'origine. Les thèmes de recherche relèvent de notre propre vocabulaire et sont donc traduits.",
+      resultsAll: "Les {n} communications",
       resultsOne: "{n} communication",
       resultsMany: "{n} communications",
       noMatch: "Aucune communication ne correspond.",
@@ -2121,6 +2125,7 @@ const locales = {
       contributionOne: "Beitrag",
       contributionMany: "Beiträge",
       note: "Zusammengestellt aus den veröffentlichten Konferenzprogrammen. Namen werden konservativ zusammengeführt: Wer über die Jahre unter deutlich verschiedenen Schreibweisen auftritt, kann mehrfach erscheinen. Themen werden aus dem Panel abgeleitet, in dem der jeweilige Beitrag stand (die neun ständigen EISS-Sektionen sowie wiederkehrende Themen). Namen und Zugehörigkeiten bleiben in ihrer Originalsprache. Die Forschungsthemen sind unser eigenes Vokabular und werden daher übersetzt.",
+      resultsAll: "Alle {n} Vortragenden",
       resultsOne: "{n} Vortragende:r",
       resultsMany: "{n} Vortragende",
       noMatch: "Keine Vortragenden gefunden.",
@@ -2151,6 +2156,7 @@ const locales = {
       prizeOnly: "Best-Paper-Preis",
       clear: "Zurücksetzen",
       note: "Zusammengestellt aus den veröffentlichten Konferenzprogrammen. Themen werden aus dem Panel abgeleitet, in dem der jeweilige Beitrag stand (die neun ständigen EISS-Sektionen sowie wiederkehrende Themen): ein Beitrag kann mehrere oder gar keines tragen. Titel, Autorennamen und Zugehörigkeiten bleiben in ihrer Originalsprache. Die Forschungsthemen sind unser eigenes Vokabular und werden daher übersetzt.",
+      resultsAll: "Alle {n} Beiträge",
       resultsOne: "{n} Beitrag",
       resultsMany: "{n} Beiträge",
       noMatch: "Keine Beiträge gefunden.",

--- a/src/_includes/papers-page.njk
+++ b/src/_includes/papers-page.njk
@@ -54,13 +54,21 @@
 </div>
 
 {# Filter status, announced to assistive tech (role=status → polite live
-   region). Empty when nothing is filtered. The data-msg-* strings are
-   the localised templates paper-filter.js fills in. #}
-<p class="speaker-status" role="status" aria-live="polite" data-paper-status hidden
+   region). The data-msg-* strings are the localised templates
+   paper-filter.js fills in.
+
+   Server-rendered with the unfiltered count rather than starting hidden
+   (#1640): the header stats sit above the Atlas signpost, the coverage bars
+   and the citation panel, so by the time a reader reaches the list the total
+   is off screen, and clearing a filter used to confirm nothing. Rendering it
+   here also gives the no-JS page a count. paper-filter.js only writes when
+   the text actually changes, so this does not announce itself on load. #}
+<p class="speaker-status" role="status" aria-live="polite" data-paper-status
+   data-msg-all="{{ p18n.resultsAll }}"
    data-msg-none="{{ p18n.noMatch }}"
    data-msg-one="{{ p18n.resultsOne }}"
    data-msg-many="{{ p18n.resultsMany }}"
-   data-msg-matching="{{ p18n.matching }}"></p>
+   data-msg-matching="{{ p18n.matching }}">{{ p18n.resultsAll | replace("{n}", paperIndex.stats.paperCount) }}</p>
 
 {# Bulk citation export (#1254). Hidden until the JS enables it: without
    scripting there is no filtering either, so the honest fallback is the

--- a/src/_includes/speakers-index.njk
+++ b/src/_includes/speakers-index.njk
@@ -44,13 +44,15 @@
 </nav>
 
 {# Filter status, announced to assistive tech (role=status → polite live
-   region). Empty when nothing is filtered. The data-msg-* strings are
-   the localised templates speaker-filter.js fills in. #}
-<p class="speaker-status" role="status" aria-live="polite" data-speaker-status hidden
+   region). The data-msg-* strings are the localised templates
+   speaker-filter.js fills in. Server-rendered with the unfiltered count
+   rather than starting hidden (#1640), same treatment as the by-paper view. #}
+<p class="speaker-status" role="status" aria-live="polite" data-speaker-status
+   data-msg-all="{{ s18n.resultsAll }}"
    data-msg-none="{{ s18n.noMatch }}"
    data-msg-one="{{ s18n.resultsOne }}"
    data-msg-many="{{ s18n.resultsMany }}"
-   data-msg-matching="{{ s18n.matching }}"></p>
+   data-msg-matching="{{ s18n.matching }}">{{ s18n.resultsAll | replace("{n}", corpus.stats.speakerCount) }}</p>
 
 <ol class="speaker-index" role="list" data-speaker-list>
   {%- for s in corpus.speakers %}

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -4220,6 +4220,18 @@ a.programme-live-tag:focus-visible {
   align-items: flex-start;
   padding: var(--space-3) 0;
   border-bottom: 1px solid var(--border);
+  /* Skip layout and paint for the rows that are off screen (#1639). The
+     Anthology renders around 1,000 list items in one document, and that cost
+     is paid on first render and again on every filter pass, which is where a
+     phone stalls. The `auto` keyword on contain-intrinsic-size makes the
+     browser remember each row's real height once it has been rendered, so the
+     estimate below only governs rows nobody has scrolled to yet and the
+     scrollbar settles as they are. The number is the measured median row
+     height at 1280px (132px to 260px across the 494 entries), so the starting
+     estimate is close rather than nominal: at 108px the document reported
+     69,871px against a true 100,327px and the A to Z jumps landed short. */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 186px;
 }
 /* `display: flex` above overrides the UA `[hidden] { display: none }`
    rule, so the filter JS (which toggles the hidden attribute) could not
@@ -4636,6 +4648,11 @@ a.speaker-paper-title:hover {
   display: grid;
   gap: var(--space-3);
   max-width: 52rem;
+}
+/* Same off-screen render skipping as .speaker-entry (#1639). */
+.paper-entry {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 158px;
 }
 /* The card uses `display: block`, but toggling the hidden attribute on the
    list item should still hide it. Be explicit (mirrors .speaker-entry). */

--- a/src/assets/js/paper-filter.js
+++ b/src/assets/js/paper-filter.js
@@ -11,13 +11,14 @@
  *     published version (data-published="1");
  *   - a "Prize" checkbox narrows to prize-winning papers;
  *   - a search box narrows by title / author / affiliation (diacritic-
- *     insensitive);
+ *     insensitive, and every whitespace-separated word has to match
+ *     somewhere in the row, so "deterrence sciences po" works);
  *   - all combine (AND);
- *   - a role=status region announces the new count to assistive tech (no
- *     focus move);
+ *   - a role=status region carries the count at all times and announces a
+ *     change to assistive tech (no focus move);
  *   - a Clear button resets them all;
- *   - event + theme + published + prize are mirrored in the URL so a filtered
- *     view is shareable and survives Back. The served page's
+ *   - all five controls are mirrored in the URL so a filtered view is
+ *     shareable and survives Back. The served page's
  *     <link rel=canonical> stays the clean /anthology.html (the params are
  *     added client-side only), so this introduces no duplicate-content URL
  *     for crawlers.
@@ -49,19 +50,35 @@
       .trim();
   };
 
+  // Every word of the query has to appear somewhere in the row, in any order
+  // (#1637). data-search is title + authors + affiliations joined by spaces,
+  // so a single indexOf over the whole string only ever matched one
+  // contiguous run and "deterrence sciences po" found nothing.
+  var tokenise = function (s) {
+    var n = norm(s);
+    return n ? n.split(/\s+/) : [];
+  };
+  var matches = function (hay, tokens) {
+    for (var i = 0; i < tokens.length; i++) {
+      if (hay.indexOf(tokens[i]) === -1) return false;
+    }
+    return true;
+  };
+
   function apply() {
     var event = eventSel ? eventSel.value : "";
     var theme = themeSel ? themeSel.value : "";
     var pub = pubCheck && pubCheck.checked;
     var prize = prizeCheck && prizeCheck.checked;
     var q = norm(findEl && findEl.value);
+    var tokens = tokenise(q);
     var visible = 0;
     entries.forEach(function (el) {
       var okEvent = !event || el.getAttribute("data-event") === event;
       var okTheme = !theme || (el.getAttribute("data-themes") || "").split("|").indexOf(theme) !== -1;
       var okPub = !pub || el.getAttribute("data-published") === "1";
       var okPrize = !prize || el.getAttribute("data-prize") === "1";
-      var okText = !q || norm(el.getAttribute("data-search")).indexOf(q) !== -1;
+      var okText = !q || matches(norm(el.getAttribute("data-search")), tokens);
       var show = okEvent && okTheme && okPub && okPrize && okText;
       el.hidden = !show;
       if (show) visible++;
@@ -73,14 +90,14 @@
       // Give the "nothing matched" message presence (boxed, centred) so the
       // empty list below doesn't read as broken.
       statusEl.classList.toggle("speaker-status--empty", filtering && visible === 0);
+      var d = statusEl.dataset;
       if (!filtering) {
-        statusEl.hidden = true;
-        statusEl.textContent = "";
+        // The unfiltered state keeps a count rather than going blank (#1640),
+        // so clearing a filter confirms the whole list came back.
+        setStatus((d.msgAll || "All {n} papers").replace("{n}", visible));
       } else {
-        statusEl.hidden = false;
-        var d = statusEl.dataset;
         if (visible === 0) {
-          statusEl.textContent = d.msgNone || "No papers match.";
+          setStatus(d.msgNone || "No papers match.");
         } else {
           var tmpl = visible === 1
             ? (d.msgOne || "{n} paper")
@@ -101,17 +118,26 @@
             var matchTmpl = d.msgMatching || 'matching "{q}"';
             bits.push(matchTmpl.replace("{q}", (findEl.value || "").trim()));
           }
-          statusEl.textContent =
+          setStatus(
             tmpl.replace("{n}", visible) +
-            (bits.length ? " · " + bits.join(" · ") : "");
+            (bits.length ? " · " + bits.join(" · ") : "")
+          );
         }
       }
     }
   }
 
-  // Mirror event + theme + published + prize in the URL (shareable /
-  // Back-restorable). Free-text search stays out of the URL — it's an
-  // ephemeral accelerator.
+  // Only touch the live region when the text actually changes. The status is
+  // server-rendered with the unfiltered count, so writing an identical string
+  // during the load-time apply() would announce it for no reason.
+  function setStatus(text) {
+    if (statusEl.textContent.trim() !== text) statusEl.textContent = text;
+  }
+
+  // Mirror all five controls in the URL (shareable / Back-restorable). The
+  // query used to be left out as an ephemeral accelerator, but it is the
+  // control people reach for first and the one result they most want to send
+  // on, so a searched view is now a shareable view like any other (#1638).
   function syncUrl() {
     if (!window.history || !history.replaceState) return;
     var url = new URL(window.location.href);
@@ -123,6 +149,8 @@
     else url.searchParams.delete("published");
     if (prizeCheck && prizeCheck.checked) url.searchParams.set("prize", "1");
     else url.searchParams.delete("prize");
+    if (findEl && findEl.value.trim()) url.searchParams.set("q", findEl.value.trim());
+    else url.searchParams.delete("q");
     history.replaceState(null, "", url.pathname + url.search + url.hash);
   }
 
@@ -130,7 +158,9 @@
   if (themeSel) themeSel.addEventListener("change", function () { syncUrl(); apply(); });
   if (pubCheck) pubCheck.addEventListener("change", function () { syncUrl(); apply(); });
   if (prizeCheck) prizeCheck.addEventListener("change", function () { syncUrl(); apply(); });
-  if (findEl) findEl.addEventListener("input", apply);
+  // replaceState on every keystroke rather than pushState, so typing swaps the
+  // current entry instead of filling the history stack.
+  if (findEl) findEl.addEventListener("input", function () { syncUrl(); apply(); });
   if (clearEl) {
     clearEl.addEventListener("click", function () {
       if (eventSel) eventSel.value = "";
@@ -144,8 +174,7 @@
     });
   }
 
-  // Restore event + theme + published + prize from the URL on load (deep link
-  // / Back).
+  // Restore all five controls from the URL on load (deep link / Back).
   function restore(param, sel) {
     if (!sel) return;
     var v = new URL(window.location.href).searchParams.get(param);
@@ -155,5 +184,7 @@
   restore("theme", themeSel);
   if (pubCheck && new URL(window.location.href).searchParams.get("published") === "1") pubCheck.checked = true;
   if (prizeCheck && new URL(window.location.href).searchParams.get("prize") === "1") prizeCheck.checked = true;
+  var qParam = new URL(window.location.href).searchParams.get("q");
+  if (findEl && qParam) findEl.value = qParam;
   apply();
 })();

--- a/src/assets/js/speaker-filter.js
+++ b/src/assets/js/speaker-filter.js
@@ -3,13 +3,16 @@
  * Progressive enhancement: with JS off the page shows every speaker (the
  * controls simply do nothing). With JS on:
  *   - a theme <select> narrows to speakers carrying that theme;
- *   - a name search box narrows by surname/given (diacritic-insensitive);
+ *   - a name search box narrows by surname/given (diacritic-insensitive, and
+ *     every whitespace-separated word has to match, so a name typed in either
+ *     order finds its entry);
  *   - the two combine (AND);
- *   - empty letter headings are hidden, and a role=status region announces
- *     the new count to assistive tech (no focus move);
+ *   - empty letter headings are hidden, and a role=status region carries the
+ *     count at all times, announcing a change to assistive tech (no focus
+ *     move);
  *   - a Clear button resets both;
- *   - the theme is mirrored in the URL (?theme=…) so a filtered view is
- *     shareable and survives Back. The served page's <link rel=canonical>
+ *   - theme, event and the name query are mirrored in the URL so a filtered
+ *     view is shareable and survives Back. The served page's <link rel=canonical>
  *     stays the clean /speakers.html (the param is added client-side only),
  *     so this introduces no duplicate-content URL for crawlers.
  *
@@ -38,15 +41,30 @@
       .trim();
   };
 
+  // Every word of the query has to appear in the name, in any order (#1637).
+  // A single indexOf matched one contiguous run, so a surname typed before a
+  // given name found nothing.
+  var tokenise = function (s) {
+    var n = norm(s);
+    return n ? n.split(/\s+/) : [];
+  };
+  var matches = function (hay, tokens) {
+    for (var i = 0; i < tokens.length; i++) {
+      if (hay.indexOf(tokens[i]) === -1) return false;
+    }
+    return true;
+  };
+
   function apply() {
     var theme = themeSel.value;
     var ev = eventSel ? eventSel.value : "";
     var q = norm(findEl && findEl.value);
+    var tokens = tokenise(q);
     var visible = 0;
     entries.forEach(function (el) {
       var okTheme = !theme || (el.getAttribute("data-themes") || "").split("|").indexOf(theme) !== -1;
       var okEvent = !ev || (el.getAttribute("data-events") || "").split("|").indexOf(ev) !== -1;
-      var okName = !q || norm(el.getAttribute("data-name")).indexOf(q) !== -1;
+      var okName = !q || matches(norm(el.getAttribute("data-name")), tokens);
       var show = okTheme && okEvent && okName;
       el.hidden = !show;
       if (show) visible++;
@@ -68,14 +86,13 @@
       // Box + centre the "nothing matched" message so the empty list reads as
       // intentional, not broken.
       statusEl.classList.toggle("speaker-status--empty", filtering && visible === 0);
+      var d = statusEl.dataset;
       if (!filtering) {
-        statusEl.hidden = true;
-        statusEl.textContent = "";
+        // The unfiltered state keeps a count rather than going blank (#1640).
+        setStatus((d.msgAll || "All {n} speakers").replace("{n}", visible));
       } else {
-        statusEl.hidden = false;
-        var d = statusEl.dataset;
         if (visible === 0) {
-          statusEl.textContent = d.msgNone || "No speakers match.";
+          setStatus(d.msgNone || "No speakers match.");
         } else {
           var tmpl = visible === 1
             ? (d.msgOne || "{n} speaker")
@@ -93,16 +110,26 @@
             var matchTmpl = d.msgMatching || 'matching "{q}"';
             bits.push(matchTmpl.replace("{q}", (findEl.value || "").trim()));
           }
-          statusEl.textContent =
+          setStatus(
             tmpl.replace("{n}", visible) +
-            (bits.length ? " · " + bits.join(" · ") : "");
+            (bits.length ? " · " + bits.join(" · ") : "")
+          );
         }
       }
     }
   }
 
-  // Mirror the theme in the URL (shareable / Back-restorable). Name search
-  // stays out of the URL — it's an ephemeral accelerator, not a view.
+  // Only touch the live region when the text actually changes. The status is
+  // server-rendered with the unfiltered count, so writing an identical string
+  // during the load-time apply() would announce it for no reason.
+  function setStatus(text) {
+    if (statusEl.textContent.trim() !== text) statusEl.textContent = text;
+  }
+
+  // Mirror theme, event and the name query in the URL (shareable /
+  // Back-restorable). The query used to be left out as an ephemeral
+  // accelerator, but it is the control people reach for first and the one
+  // result they most want to send on (#1638).
   function syncUrl() {
     if (!window.history || !history.replaceState) return;
     var url = new URL(window.location.href);
@@ -110,12 +137,16 @@
     else url.searchParams.delete("theme");
     if (eventSel && eventSel.value) url.searchParams.set("event", eventSel.value);
     else url.searchParams.delete("event");
+    if (findEl && findEl.value.trim()) url.searchParams.set("q", findEl.value.trim());
+    else url.searchParams.delete("q");
     history.replaceState(null, "", url.pathname + url.search + url.hash);
   }
 
   themeSel.addEventListener("change", function () { syncUrl(); apply(); });
   if (eventSel) eventSel.addEventListener("change", function () { syncUrl(); apply(); });
-  if (findEl) findEl.addEventListener("input", apply);
+  // replaceState on every keystroke rather than pushState, so typing swaps the
+  // current entry instead of filling the history stack.
+  if (findEl) findEl.addEventListener("input", function () { syncUrl(); apply(); });
   if (clearEl) {
     clearEl.addEventListener("click", function () {
       themeSel.value = "";
@@ -127,7 +158,8 @@
     });
   }
 
-  // Restore theme + event from the URL on load (deep link / Back).
+  // Restore theme, event and the name query from the URL on load (deep link /
+  // Back).
   function restore(param, sel) {
     if (!sel) return;
     var v = new URL(window.location.href).searchParams.get(param);
@@ -135,6 +167,8 @@
   }
   restore("theme", themeSel);
   restore("event", eventSel);
+  var qParam = new URL(window.location.href).searchParams.get("q");
+  if (findEl && qParam) findEl.value = qParam;
   apply();
 
   // Deep-link to a specific person: ?person=<profile-slug> scrolls to their


### PR DESCRIPTION
The four cheap wins from the Anthology brainstorm, each with its own issue. Closes #1637, #1638, #1639, #1640.

## Search matches every word of the query (#1637)

Both filters compared the whole query against one string with a single `indexOf`, so the query only ever matched as one contiguous run. `data-search` on a paper row is title plus authors plus affiliations joined by spaces, so "deterrence sciences po" returned nothing at all and read as an absence from the corpus. On the by-person side `data-name` is "Surname, Given", so a name typed the other way round missed too.

Each whitespace-separated word now has to appear somewhere in the row, in any order. Verified in the browser: "deterrence sciences po" returns 1 paper, "po deterrence sciences" returns the same 1, "deterrencesciences" returns 0, and "laudrain arthur" finds "Laudrain, Arthur".

## The query joins the other filters in the URL (#1638)

The edition, the theme and the two checkboxes were mirrored with `replaceState` and restored on load. The search box was not, so copying the address after a search handed the reader the unfiltered list. It is now `?q=` alongside the rest, still `replaceState` so typing swaps the current history entry rather than filling the stack. Verified: `/anthology.html?view=people&q=laudrain+arthur` arrives filtered with the box populated, and Clear removes the parameter.

## Off-screen rows skip their render work (#1639)

The page holds around 1,000 entries across the two panels, laid out and painted in full on first render and again on every filter pass. One CSS rule now lets the browser skip the rows nobody is looking at.

The intrinsic-size estimates are measured rather than nominal, which turned out to matter: at a guessed 108px the document reported 69,871px against a true 100,327px, a 30% underestimate that would land the A to Z jumps short. They are now the medians at 1280px, 186px for a speaker entry (real spread 132px to 260px) and 158px for a paper entry (106px to 209px, tightly clustered). The `auto` keyword makes the browser remember each row's real height once it has rendered, so the estimate only governs rows that have never been on screen.

## The count is there in every state (#1640)

The status line under the filters was `hidden` until something was filtered. The header stats sit above the Atlas signpost, the coverage bars and the citation panel, so by the time a reader reaches the list the total is off screen, and clearing a filter confirmed nothing.

It now reads "All 511 papers" until a filter narrows it. Server-rendered, so the count is there without scripting, and `setStatus` only writes when the text actually changes, so the `role="status"` live region does not announce itself during the load-time `apply()`. New `resultsAll` key in all three locales.

## Verification

- `npx eleventy` clean, 1431 files.
- `scripts/check-i18n-keys.js`: EN / FR / DE at 553 keys each.
- `scripts/check-i18n-drift.py`: all translations match their English sources.
- Driven in a browser at 1280px on `/anthology.html` and `/anthology.fr.html`, both panels, with no console errors. The French page reports "Les 511 communications" unfiltered and "39 communications · correspondant à « cyber »" filtered.
- `scripts/check-build-sanity.mjs` was still running locally when this was opened, so CI is the record for it.

## Please eyeball the preview

Per the §2 carve-out: the status line is now visible in the default state on both panels, which is a change a reader sees above the fold. Worth a look before merging. Auto-merge is not armed.

The FR and DE `resultsAll` strings ("Les {n} communications", "Alle {n} Beiträge" and their speaker equivalents) are new copy and want a native reader's eye alongside the rest.
