### PR TITLE
Carry the Atlas theme colour onto the Anthology chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,8 @@ At v2.13.0r (formerly v2.21.0) we adopted the NetSec-style versioning rules spel
 
 ### Changed
 
+- Research themes wear their Atlas colour everywhere in the Anthology. The theme doors, the chips on the by-paper and by-person lists and the tags on a paper's own page each carry the hue the map gives that theme, as a small dot beside the label, so a reader who has learned the palette on the Atlas keeps it after clicking through. The wheel moved out of the Atlas script into `site.css` as `--atlas-wheel-*` tokens, which is what stops the map and the pages drifting onto two palettes. Closes [#1660](https://github.com/EISSeuropa/EISSeuropa.github.io/issues/1660).
+
 - The internship page sets out three meetings across the two months rather than a weekly call: onboarding in the first week, a review at the halfway point, and an exit review with a short feedback survey. Updated in all three languages.
 
 

--- a/src/_data/paperIndex.js
+++ b/src/_data/paperIndex.js
@@ -276,6 +276,14 @@ module.exports = {
   themeLabels: Object.fromEntries(
     THEME_ORDER.map((name) => [name, themeLabelByEnglishName.get(name) || { en: name }])
   ),
+  // English name to the theme's colour, as a reference to the wheel token in
+  // site.css (#1660). The index is the theme's position in `themes`, which is
+  // also its Atlas hub index, since anthologyAtlas.js builds `data.themes`
+  // from this same array: a chip that sets --chip-dot from here wears the hue
+  // its hub wears, and the two cannot disagree by construction. A ready CSS
+  // value rather than the bare index, so a template can test it for truth
+  // without index 0 reading as absent.
+  themeDot: Object.fromEntries(themes.map((t, i) => [t.name, `var(--atlas-wheel-${i})`])),
   stats: {
     paperCount: papers.length,
     editions: [...new Set(papers.map((p) => p.programmeUrl))].filter(Boolean).length,

--- a/src/_includes/archive-page.njk
+++ b/src/_includes/archive-page.njk
@@ -97,8 +97,10 @@
       <h2 class="theme-doors__h" id="theme-doors-h">{{ n18n.themeDoorsHeading }}</h2>
       <ul class="theme-doors__list">
         {%- set sfx = "" if (lang or "en") == "en" else "." + lang %}
-        {%- for th in atlasThemePages %}
-        <li><a href="/anthology-atlas/theme/{{ th.slug }}{{ sfx }}.html">{{ th.label[lang or "en"] or th.name }} <span class="theme-doors__n muted">{{ th.count }}</span></a></li>
+        {#- The dot is the theme's Atlas hue (#1660). These doors open the map,
+            so they are where a reader first meets the palette. #}
+        {%- for th in atlasThemePages %}{% set dot = paperIndex.themeDot[th.name] %}
+        <li><a href="/anthology-atlas/theme/{{ th.slug }}{{ sfx }}.html"{% if dot %} style="--chip-dot: {{ dot }}"{% endif %}>{{ th.label[lang or "en"] or th.name }} <span class="theme-doors__n muted">{{ th.count }}</span></a></li>
         {%- endfor %}
       </ul>
     </nav>

--- a/src/_includes/paper-page-body.njk
+++ b/src/_includes/paper-page-body.njk
@@ -49,9 +49,10 @@
     {%- if paper.themes and paper.themes.length %}
     {# Research-theme tags (#1149). Each links to the by-paper view filtered to
        that theme (paper-filter.js restores it from the URL). Reuses the
-       list view's chip styling; the anchor variant is styled alongside it. #}
+       list view's chip styling; the anchor variant is styled alongside it.
+       The dot carries the theme's Atlas hue (#1660). #}
     <p class="paper-themes">
-      {%- for th in paper.themes %}<a class="paper-theme-chip" lang="en" href="/anthology.html?view=papers&theme={{ th | urlencode }}">{{ th }}</a>{% endfor %}
+      {%- for th in paper.themes %}{% set dot = paperIndex.themeDot[th] %}<a class="paper-theme-chip" lang="en"{% if dot %} style="--chip-dot: {{ dot }}"{% endif %} href="/anthology.html?view=papers&theme={{ th | urlencode }}">{{ th }}</a>{% endfor %}
     </p>
     {%- endif %}
   </div>

--- a/src/_includes/papers-page.njk
+++ b/src/_includes/papers-page.njk
@@ -152,7 +152,10 @@
       <p class="paper-themes">
         {#- The chip shows the reader's own language now that the filter above
             does (#1492), so it drops the lang="en" it used to carry. -#}
-        {%- for th in p.theme %}<span class="paper-theme-chip">{{ paperIndex.themeLabels[th][lang or "en"] or th }}</span>{% endfor %}
+        {#- The dot carries the theme's Atlas hue (#1660), so a reader who has
+            learned the map keeps the palette on the page. Decorative: the
+            label is the meaning. #}
+        {%- for th in p.theme %}{% set dot = paperIndex.themeDot[th] %}<span class="paper-theme-chip"{% if dot %} style="--chip-dot: {{ dot }}"{% endif %}>{{ paperIndex.themeLabels[th][lang or "en"] or th }}</span>{% endfor %}
       </p>
       {%- endif %}
     </article>

--- a/src/_includes/speakers-index.njk
+++ b/src/_includes/speakers-index.njk
@@ -103,7 +103,10 @@
       {%- endif %}
       {%- if s.themes.length %}
       <p class="speaker-themes">
-        {%- for th in s.themes %}<span class="speaker-theme-chip">{{ corpus.themeLabels[th][lang or "en"] or corpus.themeLabels[th].en }}</span>{% endfor %}
+        {#- Same Atlas hue as the by-paper chips (#1660). These hold the stable
+            theme key rather than the English name, so they join the wheel
+            through the English label, which is the key everywhere else. #}
+        {%- for th in s.themes %}{% set dot = paperIndex.themeDot[corpus.themeLabels[th].en] %}<span class="speaker-theme-chip"{% if dot %} style="--chip-dot: {{ dot }}"{% endif %}>{{ corpus.themeLabels[th][lang or "en"] or corpus.themeLabels[th].en }}</span>{% endfor %}
       </p>
       {%- endif %}
       {%- if s.count %}

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -129,6 +129,30 @@
      author with no co-author. A blue-grey on the neutral hue, so it reads as
      "nothing here yet" rather than as a category of its own. */
   --atlas-inactive: hsl(220 14% 64%);
+  /* Anthology Atlas theme wheel: one stable hue per research theme, indexed by
+     the theme's position in `paperIndex.themes`. The Atlas colours its hubs and
+     their papers from this, and the theme chips on the Anthology lists and the
+     paper pages carry the same hue as a dot, so orange means Deterrence
+     wherever a reader meets it (#1660). Defined here rather than in
+     anthology-atlas.js so the map and the templates read one palette. Same
+     wheel the NetSec Atlas uses for its theme lens. */
+  --atlas-wheel-0: #0973de; /* Transformations of warfare and conflict */
+  --atlas-wheel-1: #10b981; /* Emerging domains: cyber and technology */
+  --atlas-wheel-2: #8457ea; /* Arms acquisition and transfer */
+  --atlas-wheel-3: #f59e0b; /* Private military actors */
+  --atlas-wheel-4: #e2568c; /* Defence cooperation and military assistance */
+  --atlas-wheel-5: #0aa2c0; /* Military interventions */
+  --atlas-wheel-6: #7a9a01; /* Non-proliferation and arms control */
+  --atlas-wheel-7: #b3562e; /* Terrorism and counter-terrorism */
+  --atlas-wheel-8: #5867dd; /* Theoretical developments in security studies */
+  --atlas-wheel-9: #2e9e6a; /* Deterrence */
+  --atlas-wheel-10: #a855f7; /* Intelligence */
+  --atlas-wheel-11: #d97706; /* European and transatlantic security */
+  --atlas-wheel-12: #3b82f6; /* Regional security and area studies */
+  --atlas-wheel-13: #14b8a6; /* Civil–military relations and the armed forces */
+  --atlas-wheel-14: #ef4444; /* Climate and security */
+  --atlas-wheel-15: #6366f1; /* Gender and security */
+  --atlas-wheel-16: #059669; /* Political economy of security */
   --hero-overlay: linear-gradient(180deg, hsl(220 50% 8% / 0.32) 0%, hsl(220 50% 8% / 0.7) 100%);
 
   --gradient-mesh-1: radial-gradient(800px circle at 12% 8%, hsl(203 88% 70% / 0.22), transparent 55%);
@@ -4580,6 +4604,14 @@ a.speaker-paper-title:hover {
   font-size: var(--fs-sm);
   text-decoration: none;
 }
+/* The theme's Atlas hue, the same `--chip-dot` dot `.atlas-chip` wears
+   (#1660). align-self, because the row aligns on the baseline for the count
+   and a dot has no baseline to sit on. */
+.theme-doors__list a::before {
+  content: ""; flex: none; align-self: center;
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--chip-dot, var(--text-subtle));
+}
 .theme-doors__list a:hover,
 .theme-doors__list a:focus-visible {
   border-color: var(--accent);
@@ -4651,6 +4683,7 @@ a.speaker-paper-title:hover {
   color: var(--text-muted);
 }
 .speaker-theme-chip {
+  display: inline-flex; align-items: center; gap: 0.4em;
   font-size: var(--fs-xs);
   color: var(--text-muted);
   background: var(--bg-tinted);
@@ -4658,6 +4691,14 @@ a.speaker-paper-title:hover {
   border-radius: 999px;
   padding: 0.05rem 0.5rem;
   line-height: 1.5;
+}
+/* The theme's Atlas hue, the same `--chip-dot` treatment `.atlas-chip` wears
+   (#1660). Set per chip from paperIndex.themeDot; a theme the wheel does not
+   know falls back to the subtle ink rather than losing the dot. Decorative:
+   the label carries the meaning, so there is nothing here to announce. */
+.speaker-theme-chip::before {
+  content: ""; flex: none; width: 8px; height: 8px; border-radius: 50%;
+  background: var(--chip-dot, var(--text-subtle));
 }
 @media (max-width: 600px) {
   .speaker-papers li { flex-direction: column; gap: 0.1rem; }
@@ -4788,6 +4829,7 @@ a.speaker-paper-title:hover {
   margin: 0.35rem 0 0;
 }
 .paper-theme-chip {
+  display: inline-flex; align-items: center; gap: 0.4em;
   font-size: var(--fs-xs);
   color: var(--text-muted);
   background: var(--bg-tinted);
@@ -4795,6 +4837,14 @@ a.speaker-paper-title:hover {
   border-radius: 999px;
   padding: 0.05rem 0.5rem;
   line-height: 1.5;
+}
+/* The theme's Atlas hue, the same `--chip-dot` treatment `.atlas-chip` wears
+   (#1660). Set per chip from paperIndex.themeDot; a theme the wheel does not
+   know falls back to the subtle ink rather than losing the dot. Decorative:
+   the label carries the meaning, so there is nothing here to announce. */
+.paper-theme-chip::before {
+  content: ""; flex: none; width: 8px; height: 8px; border-radius: 50%;
+  background: var(--chip-dot, var(--text-subtle));
 }
 /* Anchor variant (#1149): the paper landing page renders the same chips as
    links into the by-paper theme filter. */

--- a/src/assets/js/anthology-atlas.js
+++ b/src/assets/js/anthology-atlas.js
@@ -142,11 +142,23 @@
   const cssVar = (n) => getComputedStyle(document.documentElement).getPropertyValue(n).trim();
 
   // A stable colour per theme hub, drawn from a small brand-adjacent wheel so
-  // the ring of hubs is legible rather than monochrome. Same wheel the NetSec
-  // Atlas uses for its theme lens.
-  const THEME_WHEEL = ['#0973de', '#10b981', '#8457ea', '#f59e0b', '#e2568c',
-    '#0aa2c0', '#7a9a01', '#b3562e', '#5867dd', '#2e9e6a', '#a855f7', '#d97706',
-    '#3b82f6', '#14b8a6', '#ef4444', '#6366f1', '#059669'];
+  // the ring of hubs is legible rather than monochrome. The wheel lives in
+  // site.css as --atlas-wheel-N (#1660), because the theme chips on the
+  // Anthology lists and the paper pages carry the same hue as a dot and a
+  // second copy here would drift. Read once per theme change and cached on
+  // `theme`: hubColour runs per node per frame, so it must not reach for
+  // getComputedStyle itself.
+  function readWheel() {
+    const out = [];
+    for (let i = 0; ; i++) {
+      const c = cssVar('--atlas-wheel-' + i);
+      if (!c) break;
+      out.push(c);
+    }
+    // A stylesheet that failed to load leaves the map monochrome rather than
+    // colourless, which is legible and says something is wrong.
+    return out.length ? out : ['#0973de'];
+  }
 
   // Effective theme: honour the site's manual toggle (data-theme), else the
   // OS preference — mirrors theme.js's currentEffective().
@@ -170,6 +182,7 @@
       // the map and its key cannot drift apart.
       edge: cssVar('--atlas-edge') || '#2f9fe0',
       inactive: cssVar('--atlas-inactive') || '#9aa7bd',
+      wheel: readWheel(),
     };
   }
 
@@ -225,7 +238,7 @@
 
   const items = () => (lens === 'authors' ? authors : papers);
 
-  function hubColour(h) { return THEME_WHEEL[h.wheel % THEME_WHEEL.length]; }
+  function hubColour(h) { return theme.wheel[h.wheel % theme.wheel.length]; }
   function hubFill(h) { return h.type === 'untagged' ? theme.inactive : hubColour(h); }
 
   function nodeVisible(n) {


### PR DESCRIPTION
Closes #1660.

The Atlas gives every research theme a stable hue and shows it on its filter chips as a dot. Everywhere else in the Anthology the same seventeen themes were grey text, so the palette a reader learns on the map was dropped the moment they clicked into a paper.

Four surfaces now carry that hue as the same `--chip-dot` dot `.atlas-chip` already wore:

- the **theme doors** at the top of `/anthology` (`.theme-doors__list a`), which are the on-ramp to the map
- the **by-paper list** chips (`.paper-theme-chip`)
- the **by-person list** chips (`.speaker-theme-chip`)
- the **paper landing pages**, whose chips are the anchor variant of the same class

The dot is decorative (`content: ""`), the label keeps carrying the meaning, so there is nothing new for a screen reader and no new contrast obligation.

## Where the colour comes from

The wheel was a literal array in `anthology-atlas.js`, so a second copy in a template would have drifted. It moved into `site.css` as `--atlas-wheel-0` … `--atlas-wheel-16`, which is where a palette belongs and where `designTokens.js` picks it up for the style guide at no extra cost. The map reads it through the `cssVar()` path it already used for `--atlas-edge` and `--atlas-inactive`, cached in `readTheme()` because `hubColour` runs per node per frame and must not reach for `getComputedStyle` itself.

`paperIndex` exports `themeDot`, keyed on the English theme name. Its index is the Atlas hub index *by construction*: `anthologyAtlas.js` builds `data.themes` from the same `themes` array, so the chip and the hub cannot disagree. Speaker chips hold the stable corpus key rather than the name, so they join through `corpus.themeLabels[key].en`.

## Considered and rejected: icons

The question that started this was whether the themes should get little representative icons. They should not. The vocabulary is abstract (Theoretical developments in security studies, Regional security and area studies, European and transatlantic security, Political economy of security), so the set would collapse into interchangeable globes and shields, seventeen SVGs would each need a brand pass and an alt-text decision, and the reader would still have to read the label. The dot conveys the same grouping at a fraction of the cost.

## Verified

Rendered, not just built (rule §14), with computed reads rather than screenshots (§14 standing habits):

- `/anthology`: 17 doors, 17 distinct `::before` colours. 620 speaker chips, 17 distinct colours.
- `/anthology?view=papers`: 657 paper chips, 17 distinct colours. Deterrence resolves to `#2e9e6a`, which is `--atlas-wheel-9`, the same hue its hub wears.
- `/anthology-atlas`: 18 hub chips, colours byte-identical to the pre-change array, no console errors. The refactor is invisible on the map.
- A paper landing page in light mode, and `/anthology` at 375px: chips stay single-line (23px), no horizontal overflow.
- `check-i18n-drift.py` clean. FR and DE inherit the change through the shared includes, and the localised label keeps its English name's hue.

## Not auto-merged

Visual change, so the §2 carve-out applies. Please eyeball the deploy preview before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)